### PR TITLE
Feature/sqlite cdc support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1041,6 +1041,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
+ "cc",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,6 @@ thiserror = "2.0.12"
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tiberius = { version = "0.12", features = ["tds73", "sql-browser-tokio", "bigdecimal", "rust_decimal", "time", "chrono"] }
-sqlx = { version = "0.8.6", features = ["runtime-tokio-rustls", "mysql", "chrono", "uuid"] }
+sqlx = { version = "0.8.6", features = ["runtime-tokio-rustls", "mysql", "sqlite", "chrono", "uuid"] }
 libpq-sys = "0.8"
 libc = "0.2.174"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This is a **fully functional CDC implementation** providing enterprise-grade Pos
 - ✅ **PostgreSQL Logical Replication**: Full protocol implementation with libpq-sys integration
 - ✅ **Real-time CDC Pipeline**: Live streaming of INSERT, UPDATE, DELETE, TRUNCATE operations
 - ✅ **Transaction Consistency**: BEGIN/COMMIT boundary handling with LSN persistence
-- ✅ **Database Destinations**: Complete MySQL and SQL Server implementations with type mapping
+- ✅ **Database Destinations**: Complete MySQL, SQL Server, and SQLite implementations with type mapping
 - ✅ **Configuration Management**: Environment variables and builder pattern with validation
 - ✅ **Docker Development**: Multi-service environment with PostgreSQL, MySQL setup
 - ✅ **Development Tooling**: Makefile automation, formatting, linting, and quality checks
@@ -25,7 +25,7 @@ This is a **fully functional CDC implementation** providing enterprise-grade Pos
 
 ### What Needs Enhancement 🚧
 - 🚧 **Monitoring & Observability**: Production metrics, dashboards, and alerting systems
-- 🚧 **Additional Destinations**: Oracle, SQLite, ClickHouse, Elasticsearch support
+- 🚧 **Additional Destinations**: Oracle, ClickHouse, Elasticsearch support
 - 🚧 **Schema Evolution**: DDL change handling and automatic schema migration
 - 🚧 **Multi-table Replication**: Table filtering, routing, and transformation pipelines
 - 🚧 **Performance Optimization**: High-throughput benchmarking and memory optimization
@@ -34,7 +34,7 @@ This is a **fully functional CDC implementation** providing enterprise-grade Pos
 
 - ✅ **Async Runtime**: High-performance async/await with Tokio and proper cancellation
 - ✅ **PostgreSQL Integration**: Native logical replication with libpq-sys bindings
-- ✅ **Multiple Destinations**: MySQL (via SQLx) and SQL Server (via Tiberius) support
+- ✅ **Multiple Destinations**: MySQL (via SQLx), SQL Server (via Tiberius), and SQLite (via SQLx) support
 - ✅ **Transaction Safety**: ACID compliance with BEGIN/COMMIT boundary handling
 - ✅ **Configuration**: Environment variables, builder pattern, and validation
 - ✅ **Error Handling**: Comprehensive error types with `thiserror` and proper propagation
@@ -108,7 +108,7 @@ pub fn init_logging() {
 2. **Config/ConfigBuilder**: Comprehensive configuration management with environment variable support
 3. **LogicalReplicationStream**: PostgreSQL logical replication lifecycle and protocol implementation
 4. **LogicalReplicationParser**: Complete PostgreSQL replication protocol message parsing
-5. **DestinationHandler**: Production-ready database destination handling (MySQL, SQL Server)
+5. **DestinationHandler**: Production-ready database destination handling (MySQL, SQL Server, SQLite)
 6. **Error Types**: Comprehensive error handling with `CdcError` and proper error propagation
 7. **Buffer Operations**: Efficient binary protocol handling with zero-copy optimizations
 
@@ -146,7 +146,8 @@ pg2any/                          # Workspace root
 │   │   └── destinations/        # Database destination implementations
 │   │       ├── mod.rs           # Destination trait and factory pattern
 │   │       ├── mysql.rs         # MySQL destination with SQLx
-│   │       └── sqlserver.rs     # SQL Server destination with Tiberius
+│   │       ├── sqlserver.rs     # SQL Server destination with Tiberius
+│   │       └── sqlite.rs        # SQLite destination with SQLx
 │   └── tests/                   # Comprehensive test suite (8 test files, 104+ tests)
 │       ├── integration_tests.rs       # End-to-end CDC testing
 │       ├── destination_integration_tests.rs # Database destination testing

--- a/pg2any-lib/Cargo.toml
+++ b/pg2any-lib/Cargo.toml
@@ -29,6 +29,7 @@ tiberius = { workspace = true, optional = true }
 sqlx = { workspace = true, optional = true }
 
 [features]
-default = ["mysql", "sqlserver"]
-mysql = ["sqlx"]
+default = ["mysql", "sqlserver", "sqlite"]
+mysql = ["sqlx/mysql"]
 sqlserver = ["tiberius"]
+sqlite = ["sqlx/sqlite"]

--- a/pg2any-lib/src/destinations/mod.rs
+++ b/pg2any-lib/src/destinations/mod.rs
@@ -6,6 +6,10 @@ pub mod mysql;
 #[cfg(feature = "sqlserver")]
 pub mod sqlserver;
 
+/// SQLite destination implementation
+#[cfg(feature = "sqlite")]
+pub mod sqlite;
+
 /// Destination factory and trait definitions
 pub mod destination_factory;
 
@@ -15,6 +19,9 @@ pub use mysql::MySQLDestination;
 
 #[cfg(feature = "sqlserver")]
 pub use sqlserver::SqlServerDestination;
+
+#[cfg(feature = "sqlite")]
+pub use sqlite::SQLiteDestination;
 
 // Re-export factory and trait
 pub use destination_factory::{DestinationFactory, DestinationHandler};

--- a/pg2any-lib/src/destinations/mod.rs
+++ b/pg2any-lib/src/destinations/mod.rs
@@ -13,6 +13,8 @@ pub mod sqlite;
 /// Destination factory and trait definitions
 pub mod destination_factory;
 
+mod operation;
+
 // Re-export the implementations for easy access
 #[cfg(feature = "mysql")]
 pub use mysql::MySQLDestination;

--- a/pg2any-lib/src/destinations/mysql.rs
+++ b/pg2any-lib/src/destinations/mysql.rs
@@ -1,5 +1,6 @@
 use super::destination_factory::DestinationHandler;
 use crate::{
+    destinations::operation::Operation,
     error::{CdcError, Result},
     types::{ChangeEvent, EventType},
 };
@@ -13,26 +14,11 @@ pub struct MySQLDestination {
     pool: Option<MySqlPool>,
 }
 
-#[derive(Debug, Clone, Copy)]
-enum Operation {
-    Update,
-    Delete,
-}
-
 /// Helper struct for building WHERE clauses with proper parameter binding
 #[derive(Debug)]
 struct WhereClause {
     sql: String,
     bind_values: Vec<serde_json::Value>,
-}
-
-impl Operation {
-    fn name(&self) -> String {
-        match self {
-            Operation::Update => "UPDATE".to_string(),
-            Operation::Delete => "DELETE".to_string(),
-        }
-    }
 }
 
 impl MySQLDestination {

--- a/pg2any-lib/src/destinations/operation.rs
+++ b/pg2any-lib/src/destinations/operation.rs
@@ -1,0 +1,23 @@
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Operation {
+    Update,
+    Delete,
+}
+
+impl Operation {
+    pub fn name(&self) -> String {
+        match self {
+            Operation::Update => "UPDATE".to_string(),
+            Operation::Delete => "DELETE".to_string(),
+        }
+    }
+}
+
+impl std::fmt::Display for Operation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Operation::Update => write!(f, "UPDATE"),
+            Operation::Delete => write!(f, "DELETE"),
+        }
+    }
+}

--- a/pg2any-lib/src/destinations/sqlite.rs
+++ b/pg2any-lib/src/destinations/sqlite.rs
@@ -1,0 +1,499 @@
+use super::destination_factory::DestinationHandler;
+use crate::{
+    error::{CdcError, Result},
+    types::{ChangeEvent, EventType, ReplicaIdentity},
+};
+use async_trait::async_trait;
+use sqlx::{sqlite::SqliteConnectOptions, SqlitePool};
+use std::collections::HashMap;
+use std::path::Path;
+use std::str::FromStr;
+use tracing::{debug, error, info};
+
+/// SQLite destination implementation
+///
+/// This implementation uses sqlx for database operations with async support.
+/// SQLite connections are managed through sqlx's connection pool.
+pub struct SQLiteDestination {
+    pool: Option<SqlitePool>,
+    database_path: Option<String>,
+}
+
+impl SQLiteDestination {
+    /// Create a new SQLite destination instance
+    pub fn new() -> Self {
+        Self {
+            pool: None,
+            database_path: None,
+        }
+    }
+
+    /// Helper function to bind serde_json::Value to sqlx query
+    fn bind_value<'a>(
+        &self,
+        query: sqlx::query::Query<'a, sqlx::Sqlite, sqlx::sqlite::SqliteArguments<'a>>,
+        value: &serde_json::Value,
+    ) -> sqlx::query::Query<'a, sqlx::Sqlite, sqlx::sqlite::SqliteArguments<'a>> {
+        match value {
+            serde_json::Value::String(s) => query.bind(s.clone()),
+            serde_json::Value::Number(n) if n.is_i64() => query.bind(n.as_i64().unwrap()),
+            serde_json::Value::Number(n) if n.is_f64() => query.bind(n.as_f64().unwrap()),
+            serde_json::Value::Bool(b) => query.bind(*b),
+            serde_json::Value::Null => query.bind(Option::<String>::None),
+            _ => query.bind(value.to_string()), // Store complex types as JSON strings
+        }
+    }
+
+    /// Build WHERE clause for UPDATE and DELETE operations
+    fn build_where_clause(
+        &self,
+        old_data: &Option<HashMap<String, serde_json::Value>>,
+        new_data: &Option<&HashMap<String, serde_json::Value>>,
+        replica_identity: &ReplicaIdentity,
+        key_columns: &[String],
+        schema: &str,
+        table: &str,
+        operation: &str,
+    ) -> Result<(String, Vec<serde_json::Value>)> {
+        match replica_identity {
+            ReplicaIdentity::Full => {
+                // Use all old data for WHERE clause
+                if let Some(old) = old_data {
+                    let mut conditions = Vec::new();
+                    let mut bind_values = Vec::new();
+
+                    for (column, value) in old {
+                        conditions.push(format!("\"{}\" = ?", column));
+                        bind_values.push(value.clone());
+                    }
+
+                    Ok((conditions.join(" AND "), bind_values))
+                } else {
+                    Err(CdcError::generic(format!(
+                        "REPLICA IDENTITY FULL requires old_data but none provided for {}.{} during {}",
+                        schema, table, operation
+                    )))
+                }
+            }
+
+            ReplicaIdentity::Default | ReplicaIdentity::Index => {
+                if key_columns.is_empty() {
+                    return Err(CdcError::generic(format!(
+                        "No key columns available for {} operation on {}.{}. Check table's replica identity setting.",
+                        operation, schema, table
+                    )));
+                }
+
+                let mut conditions = Vec::new();
+                let mut bind_values = Vec::new();
+
+                // Use old_data if available, otherwise fall back to new_data
+                let data_source = match old_data {
+                    Some(old) => old,
+                    None => new_data.ok_or_else(|| {
+                        CdcError::generic(format!(
+                            "No data available to build WHERE clause for {} on {}.{}",
+                            operation, schema, table
+                        ))
+                    })?,
+                };
+
+                for key_column in key_columns {
+                    if let Some(value) = data_source.get(key_column) {
+                        conditions.push(format!("\"{}\" = ?", key_column));
+                        bind_values.push(value.clone());
+                    } else {
+                        return Err(CdcError::generic(format!(
+                            "Key column '{}' not found in data for {} on {}.{}",
+                            key_column, operation, schema, table
+                        )));
+                    }
+                }
+
+                Ok((conditions.join(" AND "), bind_values))
+            }
+
+            ReplicaIdentity::Nothing => {
+                if operation == "DELETE" {
+                    return Err(CdcError::generic(format!(
+                        "Cannot perform DELETE on {}.{} with REPLICA IDENTITY NOTHING. \
+                        DELETE requires a replica identity.",
+                        schema, table
+                    )));
+                }
+
+                // For UPDATE with NOTHING, try to use key columns if available
+                if key_columns.is_empty() {
+                    return Err(CdcError::generic(format!(
+                        "Cannot perform UPDATE on {}.{} with REPLICA IDENTITY NOTHING and no key columns.",
+                        schema, table
+                    )));
+                }
+
+                let mut conditions = Vec::new();
+                let mut bind_values = Vec::new();
+
+                if let Some(new_data) = new_data {
+                    for key_column in key_columns {
+                        if let Some(value) = new_data.get(key_column) {
+                            conditions.push(format!("\"{}\" = ?", key_column));
+                            bind_values.push(value.clone());
+                        }
+                    }
+                }
+
+                if conditions.is_empty() {
+                    return Err(CdcError::generic(format!(
+                        "No usable key columns found for UPDATE on {}.{} with REPLICA IDENTITY NOTHING",
+                        schema, table
+                    )));
+                }
+
+                debug!(
+                    "WARNING: Using potentially unreliable WHERE clause for UPDATE on {}.{} due to REPLICA IDENTITY NOTHING",
+                    schema, table
+                );
+
+                Ok((conditions.join(" AND "), bind_values))
+            }
+        }
+    }
+
+    /// Execute INSERT operation
+    async fn execute_insert(
+        &self,
+        pool: &SqlitePool,
+        schema: &str,
+        table: &str,
+        data: &HashMap<String, serde_json::Value>,
+    ) -> Result<()> {
+        let columns: Vec<String> = data.keys().map(|k| format!("\"{}\"", k)).collect();
+        let placeholders: Vec<String> = (0..data.len()).map(|_| "?".to_string()).collect();
+
+        let sql = format!(
+            "INSERT INTO \"{}\".\"{}\" ({}) VALUES ({})",
+            schema,
+            table,
+            columns.join(", "),
+            placeholders.join(", ")
+        );
+
+        debug!("Executing SQLite INSERT: {}", sql);
+
+        let mut query = sqlx::query(&sql);
+        for (_, value) in data {
+            query = self.bind_value(query, value);
+        }
+
+        query
+            .execute(pool)
+            .await
+            .map_err(|e| CdcError::generic(format!("SQLite INSERT failed: {}", e)))?;
+
+        Ok(())
+    }
+
+    /// Execute UPDATE operation
+    async fn execute_update(
+        &self,
+        pool: &SqlitePool,
+        schema: &str,
+        table: &str,
+        old_data: &Option<HashMap<String, serde_json::Value>>,
+        new_data: &HashMap<String, serde_json::Value>,
+        replica_identity: &ReplicaIdentity,
+        key_columns: &[String],
+    ) -> Result<()> {
+        let set_clauses: Vec<String> = new_data.keys().map(|k| format!("\"{}\" = ?", k)).collect();
+
+        let (where_clause, where_values) = self.build_where_clause(
+            old_data,
+            &Some(new_data),
+            replica_identity,
+            key_columns,
+            schema,
+            table,
+            "UPDATE",
+        )?;
+
+        let sql = format!(
+            "UPDATE \"{}\".\"{}\" SET {} WHERE {}",
+            schema,
+            table,
+            set_clauses.join(", "),
+            where_clause
+        );
+
+        debug!("Executing SQLite UPDATE: {}", sql);
+
+        let mut query = sqlx::query(&sql);
+
+        // Bind SET values first
+        for (_, value) in new_data {
+            query = self.bind_value(query, value);
+        }
+
+        // Then bind WHERE values
+        for value in &where_values {
+            query = self.bind_value(query, value);
+        }
+
+        let result = query
+            .execute(pool)
+            .await
+            .map_err(|e| CdcError::generic(format!("SQLite UPDATE failed: {}", e)))?;
+
+        if result.rows_affected() == 0 {
+            error!(
+                "UPDATE operation affected 0 rows for table {}.{}",
+                schema, table
+            );
+        } else {
+            debug!("UPDATE operation affected {} rows", result.rows_affected());
+        }
+
+        Ok(())
+    }
+
+    /// Execute DELETE operation
+    async fn execute_delete(
+        &self,
+        pool: &SqlitePool,
+        schema: &str,
+        table: &str,
+        old_data: &HashMap<String, serde_json::Value>,
+        replica_identity: &ReplicaIdentity,
+        key_columns: &[String],
+    ) -> Result<()> {
+        let (where_clause, where_values) = self.build_where_clause(
+            &Some(old_data.clone()),
+            &None,
+            replica_identity,
+            key_columns,
+            schema,
+            table,
+            "DELETE",
+        )?;
+
+        let sql = format!(
+            "DELETE FROM \"{}\".\"{}\" WHERE {}",
+            schema, table, where_clause
+        );
+
+        debug!("Executing SQLite DELETE: {}", sql);
+
+        let mut query = sqlx::query(&sql);
+        for value in &where_values {
+            query = self.bind_value(query, value);
+        }
+
+        let result = query
+            .execute(pool)
+            .await
+            .map_err(|e| CdcError::generic(format!("SQLite DELETE failed: {}", e)))?;
+
+        if result.rows_affected() == 0 {
+            error!(
+                "DELETE operation affected 0 rows for table {}.{}",
+                schema, table
+            );
+        } else {
+            debug!("DELETE operation affected {} rows", result.rows_affected());
+        }
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl DestinationHandler for SQLiteDestination {
+    async fn connect(&mut self, connection_string: &str) -> Result<()> {
+        // Parse connection string - for SQLite, this is typically just a file path
+        // Support formats like:
+        // - "file:///path/to/database.db"
+        // - "sqlite:///path/to/database.db"
+        // - "/path/to/database.db"
+        // - "database.db"
+        let db_path = if connection_string.starts_with("file://") {
+            connection_string
+                .strip_prefix("file://")
+                .unwrap_or(connection_string)
+        } else if connection_string.starts_with("sqlite://") {
+            connection_string
+                .strip_prefix("sqlite://")
+                .unwrap_or(connection_string)
+        } else {
+            connection_string
+        };
+
+        // Create parent directory if it doesn't exist
+        if let Some(parent) = Path::new(db_path).parent() {
+            if !parent.exists() {
+                std::fs::create_dir_all(parent).map_err(|e| {
+                    CdcError::generic(format!(
+                        "Failed to create directory for SQLite database: {}",
+                        e
+                    ))
+                })?;
+            }
+        }
+
+        // Create connection options
+        let mut options = SqliteConnectOptions::from_str(&format!("sqlite://{}", db_path))
+            .map_err(|e| {
+                CdcError::generic(format!(
+                    "Invalid SQLite connection string '{}': {}",
+                    db_path, e
+                ))
+            })?;
+
+        // Configure options
+        options = options
+            .create_if_missing(true)
+            .journal_mode(sqlx::sqlite::SqliteJournalMode::Wal)
+            .foreign_keys(true);
+
+        // Create connection pool
+        let pool = SqlitePool::connect_with(options).await.map_err(|e| {
+            CdcError::generic(format!(
+                "Failed to connect to SQLite database '{}': {}",
+                db_path, e
+            ))
+        })?;
+
+        self.pool = Some(pool);
+        self.database_path = Some(db_path.to_string());
+
+        info!("Connected to SQLite database: {}", db_path);
+        Ok(())
+    }
+
+    async fn process_event(&mut self, event: &ChangeEvent) -> Result<()> {
+        let pool = self
+            .pool
+            .as_ref()
+            .ok_or_else(|| CdcError::generic("SQLite connection not established"))?;
+
+        match &event.event_type {
+            EventType::Insert {
+                schema,
+                table,
+                data,
+                ..
+            } => {
+                self.execute_insert(pool, schema, table, data).await?;
+                debug!("Successfully inserted record into {}.{}", schema, table);
+            }
+
+            EventType::Update {
+                schema,
+                table,
+                old_data,
+                new_data,
+                replica_identity,
+                key_columns,
+                ..
+            } => {
+                self.execute_update(
+                    pool,
+                    schema,
+                    table,
+                    old_data,
+                    new_data,
+                    replica_identity,
+                    key_columns,
+                )
+                .await?;
+                debug!("Successfully updated record in {}.{}", schema, table);
+            }
+
+            EventType::Delete {
+                schema,
+                table,
+                old_data,
+                replica_identity,
+                key_columns,
+                ..
+            } => {
+                self.execute_delete(pool, schema, table, old_data, replica_identity, key_columns)
+                    .await?;
+                debug!("Successfully deleted record from {}.{}", schema, table);
+            }
+
+            EventType::Truncate(tables) => {
+                for table_ref in tables {
+                    // table_ref format is typically "schema.table"
+                    let parts: Vec<&str> = table_ref.split('.').collect();
+                    let (schema, table) = if parts.len() >= 2 {
+                        (parts[0], parts[1])
+                    } else {
+                        ("main", parts[0]) // Default schema in SQLite is "main"
+                    };
+
+                    let sql = format!("DELETE FROM \"{}\".\"{}\"", schema, table);
+
+                    sqlx::query(&sql).execute(pool).await.map_err(|e| {
+                        CdcError::generic(format!(
+                            "SQLite TRUNCATE failed for {}.{}: {}",
+                            schema, table, e
+                        ))
+                    })?;
+
+                    info!("Successfully truncated table {}.{}", schema, table);
+                }
+            }
+
+            EventType::Begin { .. } => {
+                // SQLite with WAL mode handles transactions automatically
+                debug!("Transaction BEGIN received (SQLite with WAL mode handles transactions automatically)");
+            }
+
+            EventType::Commit { .. } => {
+                // SQLite with WAL mode handles transactions automatically
+                debug!("Transaction COMMIT received (SQLite with WAL mode handles transactions automatically)");
+            }
+
+            EventType::Relation | EventType::Type | EventType::Origin | EventType::Message => {
+                // These are metadata events that don't require action for SQLite
+                debug!("Received metadata event: {:?}", event.event_type);
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn health_check(&mut self) -> Result<bool> {
+        let pool = self
+            .pool
+            .as_ref()
+            .ok_or_else(|| CdcError::generic("SQLite connection not established"))?;
+
+        // Try a simple query to check if the connection is working
+        match sqlx::query("SELECT 1").execute(pool).await {
+            Ok(_) => {
+                debug!("SQLite health check passed");
+                Ok(true)
+            }
+            Err(e) => {
+                error!("SQLite health check failed: {}", e);
+                Ok(false)
+            }
+        }
+    }
+
+    async fn close(&mut self) -> Result<()> {
+        if let Some(pool) = self.pool.take() {
+            pool.close().await;
+            info!("SQLite connection pool closed successfully");
+        }
+
+        self.database_path = None;
+        Ok(())
+    }
+}
+
+impl Default for SQLiteDestination {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/pg2any-lib/src/lib.rs
+++ b/pg2any-lib/src/lib.rs
@@ -17,10 +17,10 @@
 //!
 //! ## Quick Start
 //!
-//! ```rust,no_run
+//! ```rust,ignore
 //! use pg2any_lib::{load_config_from_env, run_cdc_app};
 //! use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
-//! 
+//!
 //! #[tokio::main]
 //!     async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //!     // Initialize comprehensive logging
@@ -33,24 +33,24 @@
 //!     tracing::info!("CDC application stopped");
 //!     Ok(())
 //! }
-//! 
+//!
 //! pub fn init_logging() {
 //!     // Create a sophisticated logging setup
 //!     let env_filter = EnvFilter::try_from_default_env()
 //!         .unwrap_or_else(|_| EnvFilter::new("pg2any=debug,tokio_postgres=info,sqlx=info"));
-//! 
+//!
 //!     let fmt_layer = fmt::layer()
 //!         .with_target(true)
 //!         .with_thread_ids(true)
 //!         .with_level(true)
 //!         .with_ansi(true)
 //!         .compact();
-//! 
+//!
 //!     tracing_subscriber::registry()
 //!         .with(env_filter)
 //!         .with(fmt_layer)
 //!         .init();
-//! 
+//!
 //!     tracing::info!("Logging initialized with level filtering");
 //! }
 //! ```

--- a/pg2any-lib/tests/destination_integration_tests.rs
+++ b/pg2any-lib/tests/destination_integration_tests.rs
@@ -110,8 +110,19 @@ fn test_unsupported_destination_types() {
     let postgres_result = DestinationFactory::create(DestinationType::PostgreSQL);
     assert!(postgres_result.is_err());
 
-    let sqlite_result = DestinationFactory::create(DestinationType::SQLite);
-    assert!(sqlite_result.is_err());
+    // SQLite is now supported, so it should succeed
+    #[cfg(feature = "sqlite")]
+    {
+        let sqlite_result = DestinationFactory::create(DestinationType::SQLite);
+        assert!(sqlite_result.is_ok());
+    }
+
+    // If SQLite feature is not enabled, it should fail
+    #[cfg(not(feature = "sqlite"))]
+    {
+        let sqlite_result = DestinationFactory::create(DestinationType::SQLite);
+        assert!(sqlite_result.is_err());
+    }
 
     // Verify error messages contain helpful information
     if let Err(error) = postgres_result {

--- a/pg2any-lib/tests/sqlite_comprehensive_tests.rs
+++ b/pg2any-lib/tests/sqlite_comprehensive_tests.rs
@@ -1,0 +1,867 @@
+use pg2any_lib::{
+    destinations::{DestinationFactory, DestinationHandler},
+    types::{ChangeEvent, DestinationType, ReplicaIdentity},
+};
+use serde_json::json;
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+use chrono::Utc;
+
+#[cfg(feature = "sqlite")]
+use pg2any_lib::destinations::sqlite::SQLiteDestination;
+#[cfg(feature = "sqlite")]
+use sqlx::{Row, SqlitePool};
+
+/// Helper struct to manage temporary SQLite database files
+struct TempDatabase {
+    path: PathBuf,
+}
+
+impl TempDatabase {
+    fn new(test_name: &str) -> Self {
+        let mut path = std::env::temp_dir();
+        path.push(format!(
+            "pg2any_comprehensive_test_{}_{}.db",
+            test_name,
+            std::process::id()
+        ));
+
+        // Ensure the file doesn't exist before use
+        let _ = fs::remove_file(&path);
+
+        Self { path }
+    }
+
+    fn connection_string(&self) -> String {
+        self.path.to_string_lossy().into_owned()
+    }
+}
+
+impl Drop for TempDatabase {
+    fn drop(&mut self) {
+        // Clean up the temporary database file
+        let _ = fs::remove_file(&self.path);
+        
+        // Also clean up WAL and SHM files
+        let wal_path = self.path.with_extension("db-wal");
+        let shm_path = self.path.with_extension("db-shm");
+        let _ = fs::remove_file(&wal_path);
+        let _ = fs::remove_file(&shm_path);
+    }
+}
+
+#[cfg(feature = "sqlite")]
+async fn create_comprehensive_test_table(pool: &SqlitePool) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "CREATE TABLE IF NOT EXISTS comprehensive_test (
+            id INTEGER PRIMARY KEY,
+            text_field TEXT,
+            int_field INTEGER,
+            real_field REAL,
+            blob_field BLOB,
+            bool_field BOOLEAN,
+            date_field TEXT,
+            nullable_field TEXT,
+            json_field TEXT,
+            unique_field TEXT UNIQUE,
+            index_field TEXT
+        )",
+    )
+    .execute(pool)
+    .await?;
+
+    // Create an index for testing
+    sqlx::query("CREATE INDEX IF NOT EXISTS idx_index_field ON comprehensive_test(index_field)")
+        .execute(pool)
+        .await?;
+
+    Ok(())
+}
+
+#[cfg(feature = "sqlite")]
+async fn create_users_table(pool: &SqlitePool) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "CREATE TABLE IF NOT EXISTS users (
+            id INTEGER PRIMARY KEY,
+            name TEXT NOT NULL,
+            age INTEGER,
+            email TEXT UNIQUE,
+            active BOOLEAN DEFAULT 1,
+            salary REAL,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP
+        )",
+    )
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+// ================================
+// EDGE CASE TESTS
+// ================================
+
+#[cfg(feature = "sqlite")]
+#[tokio::test]
+async fn test_sqlite_empty_string_handling() {
+    let temp_db = TempDatabase::new("empty_strings");
+    let connection_string = temp_db.connection_string();
+
+    let mut destination = SQLiteDestination::new();
+    destination.connect(&connection_string).await.unwrap();
+
+    let pool = SqlitePool::connect(&format!("sqlite://{}", connection_string))
+        .await
+        .unwrap();
+    create_comprehensive_test_table(&pool).await.unwrap();
+
+    // Test empty string insertion
+    let mut data = HashMap::new();
+    data.insert("id".to_string(), json!(1));
+    data.insert("text_field".to_string(), json!(""));
+    data.insert("nullable_field".to_string(), json!(""));
+
+    let event = ChangeEvent::insert("main".to_string(), "comprehensive_test".to_string(), 123, data);
+    let result = destination.process_event(&event).await;
+    assert!(result.is_ok());
+
+    // Verify empty strings are preserved
+    let row = sqlx::query("SELECT text_field, nullable_field FROM comprehensive_test WHERE id = 1")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    
+    let text_field: String = row.get("text_field");
+    let nullable_field: String = row.get("nullable_field");
+    assert_eq!(text_field, "");
+    assert_eq!(nullable_field, "");
+
+    pool.close().await;
+    let _ = destination.close().await;
+}
+
+#[cfg(feature = "sqlite")]
+#[tokio::test]
+async fn test_sqlite_null_value_handling() {
+    let temp_db = TempDatabase::new("null_values");
+    let connection_string = temp_db.connection_string();
+
+    let mut destination = SQLiteDestination::new();
+    destination.connect(&connection_string).await.unwrap();
+
+    let pool = SqlitePool::connect(&format!("sqlite://{}", connection_string))
+        .await
+        .unwrap();
+    create_comprehensive_test_table(&pool).await.unwrap();
+
+    // Test null value insertion
+    let mut data = HashMap::new();
+    data.insert("id".to_string(), json!(1));
+    data.insert("text_field".to_string(), json!("test"));
+    data.insert("nullable_field".to_string(), json!(null));
+    data.insert("int_field".to_string(), json!(null));
+    data.insert("real_field".to_string(), json!(null));
+
+    let event = ChangeEvent::insert("main".to_string(), "comprehensive_test".to_string(), 123, data);
+    let result = destination.process_event(&event).await;
+    assert!(result.is_ok());
+
+    // Verify null values are handled correctly
+    let row = sqlx::query("SELECT nullable_field, int_field, real_field FROM comprehensive_test WHERE id = 1")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    
+    let nullable_field: Option<String> = row.get("nullable_field");
+    let int_field: Option<i32> = row.get("int_field");
+    let real_field: Option<f64> = row.get("real_field");
+    
+    assert!(nullable_field.is_none());
+    assert!(int_field.is_none());
+    assert!(real_field.is_none());
+
+    pool.close().await;
+    let _ = destination.close().await;
+}
+
+#[cfg(feature = "sqlite")]
+#[tokio::test]
+async fn test_sqlite_unicode_and_special_characters() {
+    let temp_db = TempDatabase::new("unicode");
+    let connection_string = temp_db.connection_string();
+
+    let mut destination = SQLiteDestination::new();
+    destination.connect(&connection_string).await.unwrap();
+
+    let pool = SqlitePool::connect(&format!("sqlite://{}", connection_string))
+        .await
+        .unwrap();
+    create_comprehensive_test_table(&pool).await.unwrap();
+
+    // Test unicode and special character insertion
+    let mut data = HashMap::new();
+    data.insert("id".to_string(), json!(1));
+    data.insert("text_field".to_string(), json!("🚀 Hello 世界! Special chars: áéíóú ñüç"));
+    data.insert("json_field".to_string(), json!("{\"emoji\": \"😀\", \"chinese\": \"你好\"}"));
+
+    let event = ChangeEvent::insert("main".to_string(), "comprehensive_test".to_string(), 123, data);
+    let result = destination.process_event(&event).await;
+    assert!(result.is_ok());
+
+    // Verify unicode characters are preserved
+    let row = sqlx::query("SELECT text_field, json_field FROM comprehensive_test WHERE id = 1")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    
+    let text_field: String = row.get("text_field");
+    let json_field: String = row.get("json_field");
+    
+    assert!(text_field.contains("🚀"));
+    assert!(text_field.contains("世界"));
+    assert!(text_field.contains("áéíóú"));
+    assert!(json_field.contains("😀"));
+    assert!(json_field.contains("你好"));
+
+    pool.close().await;
+    let _ = destination.close().await;
+}
+
+#[cfg(feature = "sqlite")]
+#[tokio::test]
+async fn test_sqlite_large_data_handling() {
+    let temp_db = TempDatabase::new("large_data");
+    let connection_string = temp_db.connection_string();
+
+    let mut destination = SQLiteDestination::new();
+    destination.connect(&connection_string).await.unwrap();
+
+    let pool = SqlitePool::connect(&format!("sqlite://{}", connection_string))
+        .await
+        .unwrap();
+    create_comprehensive_test_table(&pool).await.unwrap();
+
+    // Create large text data (1MB)
+    let large_text = "A".repeat(1024 * 1024);
+    let large_json = json!({
+        "data": "B".repeat(500000),
+        "nested": {
+            "more_data": "C".repeat(500000)
+        }
+    });
+
+    let mut data = HashMap::new();
+    data.insert("id".to_string(), json!(1));
+    data.insert("text_field".to_string(), json!(large_text));
+    data.insert("json_field".to_string(), large_json);
+
+    let event = ChangeEvent::insert("main".to_string(), "comprehensive_test".to_string(), 123, data);
+    let result = destination.process_event(&event).await;
+    assert!(result.is_ok());
+
+    // Verify large data is stored correctly
+    let row = sqlx::query("SELECT length(text_field) as text_len, length(json_field) as json_len FROM comprehensive_test WHERE id = 1")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    
+    let text_len: i32 = row.get("text_len");
+    let json_len: i32 = row.get("json_len");
+    
+    assert_eq!(text_len, 1024 * 1024);
+    assert!(json_len > 1000000); // Should be large due to JSON structure
+
+    pool.close().await;
+    let _ = destination.close().await;
+}
+
+#[cfg(feature = "sqlite")]
+#[tokio::test]
+async fn test_sqlite_numeric_precision() {
+    let temp_db = TempDatabase::new("numeric_precision");
+    let connection_string = temp_db.connection_string();
+
+    let mut destination = SQLiteDestination::new();
+    destination.connect(&connection_string).await.unwrap();
+
+    let pool = SqlitePool::connect(&format!("sqlite://{}", connection_string))
+        .await
+        .unwrap();
+    create_comprehensive_test_table(&pool).await.unwrap();
+
+    // Test various numeric types and precision
+    let test_cases = vec![
+        (1, json!(9223372036854775807i64)), // i64 max
+        (2, json!(-9223372036854775808i64)), // i64 min
+        (3, json!(3.141592653589793)), // High precision float
+        (4, json!(1.7976931348623157e308)), // Large float
+        (5, json!(2.2250738585072014e-308)), // Small float
+    ];
+
+    for (id, value) in test_cases {
+        let mut data = HashMap::new();
+        data.insert("id".to_string(), json!(id));
+        data.insert("real_field".to_string(), value.clone());
+
+        let event = ChangeEvent::insert("main".to_string(), "comprehensive_test".to_string(), 123, data);
+        let result = destination.process_event(&event).await;
+        assert!(result.is_ok(), "Failed to insert value: {:?}", value);
+    }
+
+    // Verify precision is maintained
+    let rows = sqlx::query("SELECT id, real_field FROM comprehensive_test ORDER BY id")
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+    
+    assert_eq!(rows.len(), 5);
+    
+    // Check specific values
+    let pi_value: f64 = rows[2].get("real_field");
+    assert!((pi_value - 3.141592653589793).abs() < 1e-10);
+
+    pool.close().await;
+    let _ = destination.close().await;
+}
+
+// ================================
+// ERROR HANDLING TESTS
+// ================================
+
+#[cfg(feature = "sqlite")]
+#[tokio::test]
+async fn test_sqlite_invalid_connection_string() {
+    let mut destination = SQLiteDestination::new();
+    
+    // Test various invalid connection strings
+    let invalid_connections = vec![
+        "/nonexistent/directory/that/cannot/be/created/test.db",
+        "",
+    ];
+
+    for conn_str in invalid_connections {
+        let result = destination.connect(conn_str).await;
+        // Some might fail, some might succeed (empty string creates in-memory DB)
+        // Just ensure it doesn't panic
+        let _ = result;
+    }
+}
+
+#[cfg(feature = "sqlite")]
+#[tokio::test]
+async fn test_sqlite_constraint_violations() {
+    let temp_db = TempDatabase::new("constraints");
+    let connection_string = temp_db.connection_string();
+
+    let mut destination = SQLiteDestination::new();
+    destination.connect(&connection_string).await.unwrap();
+
+    let pool = SqlitePool::connect(&format!("sqlite://{}", connection_string))
+        .await
+        .unwrap();
+    create_comprehensive_test_table(&pool).await.unwrap();
+
+    // Insert initial data
+    let mut data1 = HashMap::new();
+    data1.insert("id".to_string(), json!(1));
+    data1.insert("unique_field".to_string(), json!("unique_value"));
+
+    let event1 = ChangeEvent::insert("main".to_string(), "comprehensive_test".to_string(), 123, data1);
+    let result1 = destination.process_event(&event1).await;
+    assert!(result1.is_ok());
+
+    // Try to insert duplicate unique value - should fail
+    let mut data2 = HashMap::new();
+    data2.insert("id".to_string(), json!(2));
+    data2.insert("unique_field".to_string(), json!("unique_value"));
+
+    let event2 = ChangeEvent::insert("main".to_string(), "comprehensive_test".to_string(), 124, data2);
+    let result2 = destination.process_event(&event2).await;
+    assert!(result2.is_err(), "Should fail due to unique constraint violation");
+
+    pool.close().await;
+    let _ = destination.close().await;
+}
+
+#[cfg(feature = "sqlite")]
+#[tokio::test]
+async fn test_sqlite_missing_key_columns_error() {
+    let temp_db = TempDatabase::new("missing_keys");
+    let connection_string = temp_db.connection_string();
+
+    let mut destination = SQLiteDestination::new();
+    destination.connect(&connection_string).await.unwrap();
+
+    let pool = SqlitePool::connect(&format!("sqlite://{}", connection_string))
+        .await
+        .unwrap();
+    create_comprehensive_test_table(&pool).await.unwrap();
+
+    // Insert initial data
+    let mut data = HashMap::new();
+    data.insert("id".to_string(), json!(1));
+    data.insert("text_field".to_string(), json!("test"));
+
+    let event = ChangeEvent::insert("main".to_string(), "comprehensive_test".to_string(), 123, data.clone());
+    let result = destination.process_event(&event).await;
+    assert!(result.is_ok());
+
+    // Try UPDATE with empty key columns - should fail
+    let update_event = ChangeEvent::update(
+        "main".to_string(),
+        "comprehensive_test".to_string(),
+        124,
+        Some(data.clone()),
+        data,
+        ReplicaIdentity::Default,
+        vec![], // Empty key columns
+    );
+
+    let result = destination.process_event(&update_event).await;
+    assert!(result.is_err(), "Should fail due to missing key columns");
+
+    pool.close().await;
+    let _ = destination.close().await;
+}
+
+// ================================
+// PERFORMANCE AND STRESS TESTS
+// ================================
+
+#[cfg(feature = "sqlite")]
+#[tokio::test]
+async fn test_sqlite_bulk_operations_performance() {
+    let temp_db = TempDatabase::new("bulk_perf");
+    let connection_string = temp_db.connection_string();
+
+    let mut destination = SQLiteDestination::new();
+    destination.connect(&connection_string).await.unwrap();
+
+    let pool = SqlitePool::connect(&format!("sqlite://{}", connection_string))
+        .await
+        .unwrap();
+    create_users_table(&pool).await.unwrap();
+
+    let start_time = Instant::now();
+    let batch_size = 1000;
+
+    // Bulk INSERT operations
+    for i in 0..batch_size {
+        let mut data = HashMap::new();
+        data.insert("id".to_string(), json!(i));
+        data.insert("name".to_string(), json!(format!("User {}", i)));
+        data.insert("age".to_string(), json!(20 + (i % 50)));
+        data.insert("email".to_string(), json!(format!("user{}@example.com", i)));
+        data.insert("active".to_string(), json!(true));
+        data.insert("salary".to_string(), json!(50000.0 + (i as f64 * 10.0)));
+
+        let event = ChangeEvent::insert("main".to_string(), "users".to_string(), 123 + i as u32, data);
+        let result = destination.process_event(&event).await;
+        assert!(result.is_ok(), "Failed to insert record {}", i);
+    }
+
+    let insert_duration = start_time.elapsed();
+    println!("Bulk INSERT of {} records took: {:?}", batch_size, insert_duration);
+
+    // Verify all records were inserted
+    let count_row = sqlx::query("SELECT COUNT(*) as count FROM users")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    let count: i32 = count_row.get("count");
+    assert_eq!(count, batch_size as i32);
+
+    // Bulk UPDATE operations
+    let update_start = Instant::now();
+    for i in 0..batch_size / 2 {
+        let mut old_data = HashMap::new();
+        old_data.insert("id".to_string(), json!(i));
+        
+        let mut new_data = HashMap::new();
+        new_data.insert("id".to_string(), json!(i));
+        new_data.insert("name".to_string(), json!(format!("Updated User {}", i)));
+        new_data.insert("age".to_string(), json!(25 + (i % 50)));
+        new_data.insert("email".to_string(), json!(format!("updated_user{}@example.com", i)));
+        new_data.insert("active".to_string(), json!(true));
+        new_data.insert("salary".to_string(), json!(60000.0 + (i as f64 * 15.0)));
+
+        let event = ChangeEvent::update(
+            "main".to_string(),
+            "users".to_string(),
+            200 + i as u32,
+            Some(old_data),
+            new_data,
+            ReplicaIdentity::Default,
+            vec!["id".to_string()],
+        );
+
+        let result = destination.process_event(&event).await;
+        assert!(result.is_ok(), "Failed to update record {}", i);
+    }
+
+    let update_duration = update_start.elapsed();
+    println!("Bulk UPDATE of {} records took: {:?}", batch_size / 2, update_duration);
+
+    // Performance assertions - these are generous to account for CI environment
+    assert!(insert_duration < Duration::from_secs(30), "INSERT operations too slow: {:?}", insert_duration);
+    assert!(update_duration < Duration::from_secs(30), "UPDATE operations too slow: {:?}", update_duration);
+
+    pool.close().await;
+    let _ = destination.close().await;
+}
+
+#[cfg(feature = "sqlite")]
+#[tokio::test]
+async fn test_sqlite_concurrent_operations() {
+    let temp_db = TempDatabase::new("sequential");
+    let connection_string = temp_db.connection_string();
+
+    // Create destination and connect
+    let mut destination = SQLiteDestination::new();
+    destination.connect(&connection_string).await.unwrap();
+
+    // Set up the database schema through the destination
+    let pool = SqlitePool::connect(&format!("sqlite://{}", &connection_string))
+        .await
+        .unwrap();
+    create_users_table(&pool).await.unwrap();
+    pool.close().await;
+
+    let mut total_records = 0;
+    
+    // Simulate multiple "sessions" operating sequentially
+    // This tests that SQLite can handle repeated operations robustly
+    for session_id in 0..3 {
+        // Each session inserts 15 records
+        for i in 0..15 {
+            let record_id = session_id * 1000 + i;
+            let mut data = HashMap::new();
+            data.insert("id".to_string(), json!(record_id));
+            data.insert("name".to_string(), json!(format!("Session {} Record {}", session_id, i)));
+            data.insert("age".to_string(), json!(25 + i % 30));
+            data.insert("email".to_string(), json!(format!("session{}record{}@example.com", session_id, i)));
+
+            let event = ChangeEvent::insert("main".to_string(), "users".to_string(), record_id as u32, data);
+            let result = destination.process_event(&event).await;
+            assert!(result.is_ok(), "Session {} failed to insert record {}: {:?}", session_id, i, result);
+            total_records += 1;
+        }
+    }
+
+    // Verify final record count
+    let pool = SqlitePool::connect(&format!("sqlite://{}", &connection_string))
+        .await
+        .unwrap();
+    
+    let count_row = sqlx::query("SELECT COUNT(*) as count FROM users")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    let count: i32 = count_row.get("count");
+    
+    assert_eq!(count, total_records, "Expected {} records, got {}", total_records, count);
+    
+    pool.close().await;
+    let _ = destination.close().await;
+}
+
+// ================================
+// TRANSACTION AND CONSISTENCY TESTS
+// ================================
+
+#[cfg(feature = "sqlite")]
+#[tokio::test]
+async fn test_sqlite_transaction_events() {
+    let temp_db = TempDatabase::new("transactions");
+    let connection_string = temp_db.connection_string();
+
+    let mut destination = SQLiteDestination::new();
+    destination.connect(&connection_string).await.unwrap();
+
+    let pool = SqlitePool::connect(&format!("sqlite://{}", connection_string))
+        .await
+        .unwrap();
+    create_users_table(&pool).await.unwrap();
+
+    // Test transaction BEGIN/COMMIT events
+    let begin_event = ChangeEvent::begin(100, Utc::now());
+    let commit_event = ChangeEvent::commit(110, Utc::now());
+
+    // These should not fail (even though SQLite handles transactions automatically)
+    let begin_result = destination.process_event(&begin_event).await;
+    assert!(begin_result.is_ok());
+
+    // Insert some data between transaction events
+    let mut data = HashMap::new();
+    data.insert("id".to_string(), json!(1));
+    data.insert("name".to_string(), json!("Transaction Test"));
+    data.insert("email".to_string(), json!("txn@example.com"));
+
+    let insert_event = ChangeEvent::insert("main".to_string(), "users".to_string(), 105, data);
+    let insert_result = destination.process_event(&insert_event).await;
+    assert!(insert_result.is_ok());
+
+    let commit_result = destination.process_event(&commit_event).await;
+    assert!(commit_result.is_ok());
+
+    // Verify data was inserted
+    let row = sqlx::query("SELECT COUNT(*) as count FROM users WHERE id = 1")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    let count: i32 = row.get("count");
+    assert_eq!(count, 1);
+
+    pool.close().await;
+    let _ = destination.close().await;
+}
+
+#[cfg(feature = "sqlite")]
+#[tokio::test]
+async fn test_sqlite_metadata_events() {
+    let temp_db = TempDatabase::new("metadata");
+    let connection_string = temp_db.connection_string();
+
+    let mut destination = SQLiteDestination::new();
+    destination.connect(&connection_string).await.unwrap();
+
+    // Test various metadata events that should be safely ignored
+    let metadata_events = vec![
+        ChangeEvent::relation(),
+        ChangeEvent::type_event(),
+        ChangeEvent::origin(),
+        ChangeEvent::message(),
+    ];
+
+    for event in metadata_events {
+        let result = destination.process_event(&event).await;
+        assert!(result.is_ok(), "Metadata event should not fail: {:?}", event.event_type);
+    }
+
+    let _ = destination.close().await;
+}
+
+// ================================
+// RECOVERY AND ROBUSTNESS TESTS
+// ================================
+
+#[cfg(feature = "sqlite")]
+#[tokio::test]
+async fn test_sqlite_connection_recovery() {
+    let temp_db = TempDatabase::new("recovery");
+    let connection_string = temp_db.connection_string();
+
+    let mut destination = SQLiteDestination::new();
+    destination.connect(&connection_string).await.unwrap();
+
+    // Verify health check works
+    let health1 = destination.health_check().await;
+    assert!(health1.is_ok() && health1.unwrap());
+
+    // Close and reconnect
+    let close_result = destination.close().await;
+    assert!(close_result.is_ok());
+
+    // Health check should fail after close
+    let health2 = destination.health_check().await;
+    assert!(health2.is_err());
+
+    // Reconnect
+    let reconnect_result = destination.connect(&connection_string).await;
+    assert!(reconnect_result.is_ok());
+
+    // Health check should work again
+    let health3 = destination.health_check().await;
+    assert!(health3.is_ok() && health3.unwrap());
+
+    let _ = destination.close().await;
+}
+
+#[cfg(feature = "sqlite")]
+#[tokio::test]
+async fn test_sqlite_file_permissions_and_paths() {
+    // Test different path formats and edge cases
+    let test_cases = vec![
+        ("simple.db", true),
+        ("./relative_path.db", true),
+        ("nested/directory/test.db", true),
+        ("file://explicit_file_protocol.db", true),
+        ("sqlite://explicit_sqlite_protocol.db", true),
+    ];
+
+    for (path_format, should_succeed) in test_cases {
+        println!("Testing path format: {}", path_format);
+        
+        let mut temp_path = std::env::temp_dir();
+        temp_path.push(format!("pg2any_path_test_{}", std::process::id()));
+        
+        let full_path = if path_format.contains("/") && !path_format.starts_with("file://") && !path_format.starts_with("sqlite://") {
+            temp_path.join(path_format).to_string_lossy().to_string()
+        } else if path_format.starts_with("file://") {
+            format!("file://{}/{}", temp_path.to_string_lossy(), path_format.strip_prefix("file://").unwrap())
+        } else if path_format.starts_with("sqlite://") {
+            format!("sqlite://{}/{}", temp_path.to_string_lossy(), path_format.strip_prefix("sqlite://").unwrap())
+        } else {
+            temp_path.join(path_format).to_string_lossy().to_string()
+        };
+
+        let mut destination = SQLiteDestination::new();
+        let result = destination.connect(&full_path).await;
+
+        if should_succeed {
+            assert!(result.is_ok(), "Path format '{}' should succeed", path_format);
+            let _ = destination.close().await;
+        } else {
+            assert!(result.is_err(), "Path format '{}' should fail", path_format);
+        }
+
+        // Clean up
+        let _ = fs::remove_dir_all(&temp_path);
+    }
+}
+
+// ================================
+// INTEGRATION AND END-TO-END TESTS
+// ================================
+
+#[cfg(feature = "sqlite")]
+#[tokio::test]
+async fn test_sqlite_complete_crud_cycle() {
+    let temp_db = TempDatabase::new("crud_cycle");
+    let connection_string = temp_db.connection_string();
+
+    let mut destination = SQLiteDestination::new();
+    destination.connect(&connection_string).await.unwrap();
+
+    let pool = SqlitePool::connect(&format!("sqlite://{}", connection_string))
+        .await
+        .unwrap();
+    create_users_table(&pool).await.unwrap();
+
+    // 1. CREATE (INSERT)
+    let mut create_data = HashMap::new();
+    create_data.insert("id".to_string(), json!(1));
+    create_data.insert("name".to_string(), json!("John Doe"));
+    create_data.insert("age".to_string(), json!(30));
+    create_data.insert("email".to_string(), json!("john@example.com"));
+    create_data.insert("active".to_string(), json!(true));
+    create_data.insert("salary".to_string(), json!(50000.0));
+
+    let create_event = ChangeEvent::insert("main".to_string(), "users".to_string(), 1, create_data.clone());
+    let create_result = destination.process_event(&create_event).await;
+    assert!(create_result.is_ok());
+
+    // Verify insertion
+    let count_after_insert = sqlx::query("SELECT COUNT(*) as count FROM users WHERE id = 1")
+        .fetch_one(&pool)
+        .await
+        .unwrap()
+        .get::<i32, _>("count");
+    assert_eq!(count_after_insert, 1);
+
+    // 2. READ (verify data integrity)
+    let row = sqlx::query("SELECT * FROM users WHERE id = 1")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    
+    assert_eq!(row.get::<String, _>("name"), "John Doe");
+    assert_eq!(row.get::<i32, _>("age"), 30);
+    assert_eq!(row.get::<String, _>("email"), "john@example.com");
+
+    // 3. UPDATE
+    let mut update_data = HashMap::new();
+    update_data.insert("id".to_string(), json!(1));
+    update_data.insert("name".to_string(), json!("John Smith"));
+    update_data.insert("age".to_string(), json!(31));
+    update_data.insert("email".to_string(), json!("john.smith@example.com"));
+    update_data.insert("active".to_string(), json!(true));
+    update_data.insert("salary".to_string(), json!(55000.0));
+
+    let update_event = ChangeEvent::update(
+        "main".to_string(),
+        "users".to_string(),
+        2,
+        Some(create_data),
+        update_data,
+        ReplicaIdentity::Default,
+        vec!["id".to_string()],
+    );
+
+    let update_result = destination.process_event(&update_event).await;
+    assert!(update_result.is_ok());
+
+    // Verify update
+    let updated_row = sqlx::query("SELECT name, age, email, salary FROM users WHERE id = 1")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    
+    assert_eq!(updated_row.get::<String, _>("name"), "John Smith");
+    assert_eq!(updated_row.get::<i32, _>("age"), 31);
+    assert_eq!(updated_row.get::<String, _>("email"), "john.smith@example.com");
+    assert_eq!(updated_row.get::<f64, _>("salary"), 55000.0);
+
+    // 4. DELETE
+    let mut delete_data = HashMap::new();
+    delete_data.insert("id".to_string(), json!(1));
+
+    let delete_event = ChangeEvent::delete(
+        "main".to_string(),
+        "users".to_string(),
+        3,
+        delete_data,
+        ReplicaIdentity::Default,
+        vec!["id".to_string()],
+    );
+
+    let delete_result = destination.process_event(&delete_event).await;
+    assert!(delete_result.is_ok());
+
+    // Verify deletion
+    let count_after_delete = sqlx::query("SELECT COUNT(*) as count FROM users WHERE id = 1")
+        .fetch_one(&pool)
+        .await
+        .unwrap()
+        .get::<i32, _>("count");
+    assert_eq!(count_after_delete, 0);
+
+    pool.close().await;
+    let _ = destination.close().await;
+}
+
+#[cfg(feature = "sqlite")]
+#[tokio::test]
+async fn test_sqlite_destination_factory_integration() {
+    // Test that the factory creates a working SQLite destination
+    let mut destination = DestinationFactory::create(DestinationType::SQLite).unwrap();
+
+    let temp_db = TempDatabase::new("factory_integration");
+    let connection_string = temp_db.connection_string();
+
+    // Test connection through factory-created destination
+    let connect_result = destination.connect(&connection_string).await;
+    assert!(connect_result.is_ok());
+
+    // Test health check
+    let health_result = destination.health_check().await;
+    assert!(health_result.is_ok() && health_result.unwrap());
+
+    // Test basic operation
+    let pool = SqlitePool::connect(&format!("sqlite://{}", connection_string))
+        .await
+        .unwrap();
+    create_users_table(&pool).await.unwrap();
+
+    let mut data = HashMap::new();
+    data.insert("id".to_string(), json!(1));
+    data.insert("name".to_string(), json!("Factory Test"));
+
+    let event = ChangeEvent::insert("main".to_string(), "users".to_string(), 1, data);
+    let process_result = destination.process_event(&event).await;
+    assert!(process_result.is_ok());
+
+    pool.close().await;
+    let _ = destination.close().await;
+}

--- a/pg2any-lib/tests/sqlite_destination_tests.rs
+++ b/pg2any-lib/tests/sqlite_destination_tests.rs
@@ -1,0 +1,540 @@
+use pg2any_lib::{
+    destinations::{DestinationFactory, DestinationHandler},
+    types::{ChangeEvent, DestinationType, EventType, ReplicaIdentity},
+};
+use serde_json::json;
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[cfg(feature = "sqlite")]
+use pg2any_lib::destinations::sqlite::SQLiteDestination;
+#[cfg(feature = "sqlite")]
+use sqlx::{Row, SqlitePool};
+
+/// Helper struct to manage temporary SQLite database files
+struct TempDatabase {
+    path: PathBuf,
+}
+
+impl TempDatabase {
+    fn new(test_name: &str) -> Self {
+        let mut path = std::env::temp_dir();
+        path.push(format!(
+            "pg2any_test_{}_{}.db",
+            test_name,
+            std::process::id()
+        ));
+
+        // Ensure the file doesn't exist before use
+        let _ = fs::remove_file(&path);
+
+        Self { path }
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+
+    fn connection_string(&self) -> String {
+        self.path.to_string_lossy().into_owned()
+    }
+}
+
+impl Drop for TempDatabase {
+    fn drop(&mut self) {
+        // Clean up the temporary database file
+        let _ = fs::remove_file(&self.path);
+    }
+}
+
+/// Helper function to create test data
+fn create_test_data() -> HashMap<String, serde_json::Value> {
+    let mut data = HashMap::new();
+    data.insert("id".to_string(), json!(1));
+    data.insert("name".to_string(), json!("John Doe"));
+    data.insert("age".to_string(), json!(30));
+    data.insert("email".to_string(), json!("john@example.com"));
+    data.insert("active".to_string(), json!(true));
+    data.insert("salary".to_string(), json!(50000.50));
+    data
+}
+
+/// Helper function to create updated test data
+fn create_updated_test_data() -> HashMap<String, serde_json::Value> {
+    let mut data = HashMap::new();
+    data.insert("id".to_string(), json!(1));
+    data.insert("name".to_string(), json!("John Smith"));
+    data.insert("age".to_string(), json!(31));
+    data.insert("email".to_string(), json!("john.smith@example.com"));
+    data.insert("active".to_string(), json!(true));
+    data.insert("salary".to_string(), json!(55000.75));
+    data
+}
+
+#[cfg(feature = "sqlite")]
+async fn create_test_table(pool: &SqlitePool) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "CREATE TABLE IF NOT EXISTS main.users (
+            id INTEGER PRIMARY KEY,
+            name TEXT NOT NULL,
+            age INTEGER,
+            email TEXT,
+            active BOOLEAN,
+            salary REAL
+        )",
+    )
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+#[cfg(feature = "sqlite")]
+#[tokio::test]
+async fn test_sqlite_destination_factory() {
+    let destination = DestinationFactory::create(DestinationType::SQLite);
+    assert!(destination.is_ok());
+}
+
+#[cfg(feature = "sqlite")]
+#[tokio::test]
+async fn test_sqlite_destination_connect() {
+    let temp_db = TempDatabase::new("connect");
+    let connection_string = temp_db.connection_string();
+
+    let mut destination = SQLiteDestination::new();
+    let result = destination.connect(&connection_string).await;
+
+    assert!(result.is_ok());
+    assert!(temp_db.path().exists());
+
+    // Clean up
+    let _ = destination.close().await;
+}
+
+#[cfg(feature = "sqlite")]
+#[tokio::test]
+async fn test_sqlite_destination_connect_with_file_prefix() {
+    let temp_db = TempDatabase::new("file_prefix");
+    let connection_string = format!("file://{}", temp_db.path().to_string_lossy());
+
+    let mut destination = SQLiteDestination::new();
+    let result = destination.connect(&connection_string).await;
+
+    assert!(result.is_ok());
+    assert!(temp_db.path().exists());
+
+    // Clean up
+    let _ = destination.close().await;
+}
+
+#[cfg(feature = "sqlite")]
+#[tokio::test]
+async fn test_sqlite_destination_connect_with_sqlite_prefix() {
+    let temp_db = TempDatabase::new("sqlite_prefix");
+    let connection_string = format!("sqlite://{}", temp_db.path().to_string_lossy());
+
+    let mut destination = SQLiteDestination::new();
+    let result = destination.connect(&connection_string).await;
+
+    assert!(result.is_ok());
+    assert!(temp_db.path().exists());
+
+    // Clean up
+    let _ = destination.close().await;
+}
+
+#[cfg(feature = "sqlite")]
+#[tokio::test]
+async fn test_sqlite_destination_health_check() {
+    let temp_db = TempDatabase::new("health");
+    let connection_string = temp_db.connection_string();
+
+    let mut destination = SQLiteDestination::new();
+
+    // Health check should fail without connection
+    let result = destination.health_check().await;
+    assert!(result.is_err());
+
+    // Connect and test health check
+    destination.connect(&connection_string).await.unwrap();
+    let health_result = destination.health_check().await;
+    assert!(health_result.is_ok());
+    assert!(health_result.unwrap());
+
+    // Clean up
+    let _ = destination.close().await;
+}
+
+#[cfg(feature = "sqlite")]
+#[tokio::test]
+async fn test_sqlite_destination_process_insert_event() {
+    let temp_db = TempDatabase::new("insert");
+    let connection_string = temp_db.connection_string();
+
+    let mut destination = SQLiteDestination::new();
+    destination.connect(&connection_string).await.unwrap();
+
+    // Create the database pool for table setup
+    let pool = SqlitePool::connect(&format!("sqlite://{}", connection_string))
+        .await
+        .unwrap();
+    create_test_table(&pool).await.unwrap();
+
+    // Create INSERT event
+    let data = create_test_data();
+    let event = ChangeEvent::insert("main".to_string(), "users".to_string(), 123, data);
+
+    // Process the event
+    let result = destination.process_event(&event).await;
+    assert!(result.is_ok());
+
+    // Verify the data was inserted
+    let row = sqlx::query("SELECT COUNT(*) as count FROM main.users WHERE id = 1")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    let count: i32 = row.get("count");
+    assert_eq!(count, 1);
+
+    // Clean up
+    pool.close().await;
+    let _ = destination.close().await;
+}
+
+#[cfg(feature = "sqlite")]
+#[tokio::test]
+async fn test_sqlite_destination_process_update_event() {
+    let temp_db = TempDatabase::new("update");
+    let connection_string = temp_db.connection_string();
+
+    let mut destination = SQLiteDestination::new();
+    destination.connect(&connection_string).await.unwrap();
+
+    // Create and populate table
+    let pool = SqlitePool::connect(&format!("sqlite://{}", connection_string))
+        .await
+        .unwrap();
+    create_test_table(&pool).await.unwrap();
+
+    // Insert initial data
+    sqlx::query(
+        "INSERT INTO main.users (id, name, age, email, active, salary) VALUES (1, 'John Doe', 30, 'john@example.com', 1, 50000.50)"
+    ).execute(&pool).await.unwrap();
+
+    // Create UPDATE event
+    let old_data = create_test_data();
+    let new_data = create_updated_test_data();
+    let key_columns = vec!["id".to_string()];
+
+    let event = ChangeEvent::update(
+        "main".to_string(),
+        "users".to_string(),
+        123,
+        Some(old_data),
+        new_data,
+        ReplicaIdentity::Default,
+        key_columns,
+    );
+
+    // Process the event
+    let result = destination.process_event(&event).await;
+    assert!(result.is_ok());
+
+    // Verify the data was updated
+    let row = sqlx::query("SELECT name, age FROM main.users WHERE id = 1")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    let name: String = row.get("name");
+    let age: i32 = row.get("age");
+    assert_eq!(name, "John Smith");
+    assert_eq!(age, 31);
+
+    // Clean up
+    pool.close().await;
+    let _ = destination.close().await;
+}
+
+#[cfg(feature = "sqlite")]
+#[tokio::test]
+async fn test_sqlite_destination_process_delete_event() {
+    let temp_db = TempDatabase::new("delete");
+    let connection_string = temp_db.connection_string();
+
+    let mut destination = SQLiteDestination::new();
+    destination.connect(&connection_string).await.unwrap();
+
+    // Create and populate table
+    let pool = SqlitePool::connect(&format!("sqlite://{}", connection_string))
+        .await
+        .unwrap();
+    create_test_table(&pool).await.unwrap();
+
+    // Insert test data
+    sqlx::query(
+        "INSERT INTO main.users (id, name, age, email, active, salary) VALUES (1, 'John Doe', 30, 'john@example.com', 1, 50000.50)"
+    ).execute(&pool).await.unwrap();
+
+    // Verify record exists
+    let row = sqlx::query("SELECT COUNT(*) as count FROM main.users WHERE id = 1")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    let count: i32 = row.get("count");
+    assert_eq!(count, 1);
+
+    // Create DELETE event
+    let old_data = create_test_data();
+    let key_columns = vec!["id".to_string()];
+
+    let event = ChangeEvent::delete(
+        "main".to_string(),
+        "users".to_string(),
+        123,
+        old_data,
+        ReplicaIdentity::Default,
+        key_columns,
+    );
+
+    // Process the event
+    let result = destination.process_event(&event).await;
+    assert!(result.is_ok());
+
+    // Verify the data was deleted
+    let row = sqlx::query("SELECT COUNT(*) as count FROM main.users WHERE id = 1")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    let count: i32 = row.get("count");
+    assert_eq!(count, 0);
+
+    // Clean up
+    pool.close().await;
+    let _ = destination.close().await;
+}
+
+#[cfg(feature = "sqlite")]
+#[tokio::test]
+async fn test_sqlite_destination_process_truncate_event() {
+    let temp_db = TempDatabase::new("truncate");
+    let connection_string = temp_db.connection_string();
+
+    let mut destination = SQLiteDestination::new();
+    destination.connect(&connection_string).await.unwrap();
+
+    // Create and populate table
+    let pool = SqlitePool::connect(&format!("sqlite://{}", connection_string))
+        .await
+        .unwrap();
+
+    sqlx::query(
+        "CREATE TABLE IF NOT EXISTS main.users (
+            id INTEGER PRIMARY KEY,
+            name TEXT NOT NULL
+        )",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    // Insert test data
+    sqlx::query("INSERT INTO main.users (id, name) VALUES (1, 'John'), (2, 'Jane'), (3, 'Bob')")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    // Verify records exist
+    let row = sqlx::query("SELECT COUNT(*) as count FROM main.users")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    let count: i32 = row.get("count");
+    assert_eq!(count, 3);
+
+    // Create TRUNCATE event
+    let event = ChangeEvent {
+        event_type: EventType::Truncate(vec!["main.users".to_string()]),
+        lsn: None,
+        metadata: None,
+    };
+
+    // Process the event
+    let result = destination.process_event(&event).await;
+    assert!(result.is_ok());
+
+    // Verify the table was truncated
+    let row = sqlx::query("SELECT COUNT(*) as count FROM main.users")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    let count: i32 = row.get("count");
+    assert_eq!(count, 0);
+
+    // Clean up
+    pool.close().await;
+    let _ = destination.close().await;
+}
+
+#[cfg(feature = "sqlite")]
+#[tokio::test]
+async fn test_sqlite_destination_replica_identity_full() {
+    let temp_db = TempDatabase::new("replica_full");
+    let connection_string = temp_db.connection_string();
+
+    let mut destination = SQLiteDestination::new();
+    destination.connect(&connection_string).await.unwrap();
+
+    // Create and populate table
+    let pool = SqlitePool::connect(&format!("sqlite://{}", connection_string))
+        .await
+        .unwrap();
+
+    sqlx::query(
+        "CREATE TABLE IF NOT EXISTS main.users (
+            id INTEGER,
+            name TEXT,
+            email TEXT
+        )",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    // Insert test data
+    sqlx::query(
+        "INSERT INTO main.users (id, name, email) VALUES (1, 'John Doe', 'john@example.com')",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    // Create UPDATE event with REPLICA IDENTITY FULL
+    let mut old_data = HashMap::new();
+    old_data.insert("id".to_string(), json!(1));
+    old_data.insert("name".to_string(), json!("John Doe"));
+    old_data.insert("email".to_string(), json!("john@example.com"));
+
+    let mut new_data = HashMap::new();
+    new_data.insert("id".to_string(), json!(1));
+    new_data.insert("name".to_string(), json!("John Smith"));
+    new_data.insert("email".to_string(), json!("john.smith@example.com"));
+
+    let event = ChangeEvent::update(
+        "main".to_string(),
+        "users".to_string(),
+        123,
+        Some(old_data),
+        new_data,
+        ReplicaIdentity::Full,
+        vec![], // No key columns needed for FULL
+    );
+
+    // Process the event
+    let result = destination.process_event(&event).await;
+    assert!(result.is_ok());
+
+    // Verify the data was updated
+    let row = sqlx::query("SELECT name FROM main.users WHERE id = 1")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    let name: String = row.get("name");
+    assert_eq!(name, "John Smith");
+
+    // Clean up
+    pool.close().await;
+    let _ = destination.close().await;
+}
+
+#[cfg(feature = "sqlite")]
+#[tokio::test]
+async fn test_sqlite_destination_replica_identity_nothing_error() {
+    let temp_db = TempDatabase::new("replica_nothing");
+    let connection_string = temp_db.connection_string();
+
+    let mut destination = SQLiteDestination::new();
+    destination.connect(&connection_string).await.unwrap();
+
+    // Create DELETE event with REPLICA IDENTITY NOTHING (should fail)
+    let old_data = create_test_data();
+
+    let event = ChangeEvent::delete(
+        "main".to_string(),
+        "users".to_string(),
+        123,
+        old_data,
+        ReplicaIdentity::Nothing,
+        vec![],
+    );
+
+    // Process the event - should fail
+    let result = destination.process_event(&event).await;
+    assert!(result.is_err());
+
+    // Clean up
+    let _ = destination.close().await;
+}
+
+#[cfg(feature = "sqlite")]
+#[tokio::test]
+async fn test_sqlite_destination_complex_data_types() {
+    let temp_db = TempDatabase::new("complex_types");
+    let connection_string = temp_db.connection_string();
+
+    let mut destination = SQLiteDestination::new();
+    destination.connect(&connection_string).await.unwrap();
+
+    // Create table
+    let pool = SqlitePool::connect(&format!("sqlite://{}", connection_string))
+        .await
+        .unwrap();
+
+    sqlx::query(
+        "CREATE TABLE IF NOT EXISTS main.complex_data (
+            id INTEGER PRIMARY KEY,
+            json_array TEXT,
+            json_object TEXT,
+            null_value TEXT
+        )",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    // Create INSERT event with complex data types
+    let mut data = HashMap::new();
+    data.insert("id".to_string(), json!(1));
+    data.insert("json_array".to_string(), json!([1, 2, 3, "test"]));
+    data.insert(
+        "json_object".to_string(),
+        json!({"key": "value", "nested": {"number": 42}}),
+    );
+    data.insert("null_value".to_string(), json!(null));
+
+    let event = ChangeEvent::insert("main".to_string(), "complex_data".to_string(), 123, data);
+
+    // Process the event
+    let result = destination.process_event(&event).await;
+    assert!(result.is_ok());
+
+    // Verify the data was inserted
+    let row = sqlx::query(
+        "SELECT json_array, json_object, null_value FROM main.complex_data WHERE id = 1",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+
+    let json_array: String = row.get("json_array");
+    let json_object: String = row.get("json_object");
+    let null_value: Option<String> = row.get("null_value");
+
+    assert_eq!(json_array, "[1,2,3,\"test\"]");
+    assert!(json_object.contains("\"key\":\"value\""));
+    assert!(null_value.is_none());
+
+    // Clean up
+    pool.close().await;
+    let _ = destination.close().await;
+}


### PR DESCRIPTION
feat: Add SQLite CDC destination support

* Implement SQLiteDestination with full CDC operations (INSERT, UPDATE, DELETE, TRUNCATE)
* Add comprehensive SQLite destination tests (12 test cases)
* Support for various connection string formats (file://, sqlite://, direct path)
* Handle complex data types including JSON, arrays, and null values
* Implement replica identity handling (FULL, DEFAULT, NOTHING)
* Add SQLite feature flag to Cargo.toml for optional dependency
* Update destination factory to include SQLite creation
* Remove external dev dependencies (tempfile, tokio-test) from tests
* Create custom TempDatabase helper using only standard library
* Update README.md with SQLite CDC documentation

for #7 