### PR TITLE
Refactor: Implement async LSN tracker with background persistence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,9 +108,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
+checksum = "0e050f626429857a27ddccb31e0aca21356bfa709c04041aefddac081a8f068a"
 
 [[package]]
 name = "bigdecimal"
@@ -206,9 +206,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.0"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "bytecheck"
@@ -246,9 +246,9 @@ checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
 name = "cc"
-version = "1.2.48"
+version = "1.2.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c481bdbf0ed3b892f6f806287d72acd515b352a4ec27a208489b8c1bc839633a"
+checksum = "9f50d563227a1c37cc0a263f64eca3334388c01c5e4c4861a9def205c614383c"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -873,9 +873,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52e9a2a24dc5c6821e71a7030e1e14b7b632acac55c40e9d2e082c621261bb56"
+checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
 dependencies = [
  "base64",
  "bytes",
@@ -892,6 +892,7 @@ dependencies = [
  "socket2",
  "system-configuration",
  "tokio",
+ "tower-layer",
  "tower-service",
  "tracing",
  "windows-registry",
@@ -969,9 +970,9 @@ checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e93fcd3157766c0c8da2f8cff6ce651a31f0810eaa1c51ec363ef790bbb5fb99"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -983,9 +984,9 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02845b3647bb045f1100ecd6480ff52f34c35f82d9880e029d329c21d1054899"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
 
 [[package]]
 name = "icu_provider"
@@ -1041,9 +1042,9 @@ checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "7ee5b5339afb4c41626dde77b7a611bd4f2c202b897852b4bcf5d03eddc61010"
 
 [[package]]
 name = "js-sys"
@@ -1072,9 +1073,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.178"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
 
 [[package]]
 name = "libloading"
@@ -1105,13 +1106,13 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
+checksum = "df15f6eac291ed1cf25865b1ee60399f57e7c227e7f51bdbd4c5270396a9ed50"
 dependencies = [
  "bitflags 2.10.0",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.6.0",
 ]
 
 [[package]]
@@ -1154,9 +1155,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "matchers"
@@ -1197,9 +1198,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
@@ -1378,7 +1379,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -1416,7 +1417,7 @@ dependencies = [
 
 [[package]]
 name = "pg2any_lib"
-version = "0.3.5"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1425,7 +1426,6 @@ dependencies = [
  "hyper",
  "hyper-util",
  "lazy_static",
- "libc",
  "libpq-sys",
  "prometheus",
  "serde",
@@ -1706,6 +1706,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec96166dafa0886eb81fe1c0a388bece180fbef2135f97c1e2cf8302e74b43b5"
+dependencies = [
+ "bitflags 2.10.0",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1870,9 +1879,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.13.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "708c0f9d5f54ba0272468c1d306a52c495b31fa155e91bc25371e6df7996908c"
+checksum = "21e6f2ab2928ca4291b86736a8bd920a277a399bba1589409d72154ff87c1282"
 dependencies = [
  "zeroize",
 ]
@@ -1896,9 +1905,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+checksum = "62049b2877bf12821e8f9ad256ee38fdc31db7387ec2d3b3f403024de2034aea"
 
 [[package]]
 name = "schannel"
@@ -2578,18 +2587,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.3"
+version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2cdb639ebbc97961c51720f858597f7f24c4fc295327923af55b74c3c724533"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.23.7"
+version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6485ef6d0d9b5d0ec17244ff7eb05310113c3f316f2d14200d4de56b3cb98f8d"
+checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -2599,12 +2608,18 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.4"
+version = "1.0.6+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e"
+checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
 dependencies = [
  "winnow",
 ]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-service"
@@ -2614,9 +2629,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d15d90a0b5c19378952d479dc858407149d7bb45a14de0142f6c534b16fc647"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "log",
  "pin-project-lite",
@@ -2637,9 +2652,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.35"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a04e24fab5c89c6a36eb8558c9656f30d81de51dfa4d3b45f26b21d61fa0a6c"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
 tiberius = { version = "0.12", features = ["tds73", "sql-browser-tokio", "bigdecimal", "rust_decimal", "time", "chrono"] }
 sqlx = { version = "0.8.6", features = ["runtime-tokio-rustls", "mysql", "sqlite", "chrono", "uuid"] }
 libpq-sys = "0.8"
-libc = "0.2.174"
 # Monitoring and metrics dependencies
 prometheus = { version = "0.14.0", features = ["process"] }
 lazy_static = "1.5"

--- a/README.md
+++ b/README.md
@@ -665,7 +665,6 @@ When you run the application, you'll see structured logging output like this:
 - **tracing-subscriber** (0.3.20): Log filtering and formatting
 - **prometheus** (0.13): Metrics collection library
 - **lazy_static** (1.4): Global metrics registry initialization
-- **libc** (0.2.174): C library bindings for system operations
 
 ### Running Tests
 ```bash

--- a/pg2any-lib/Cargo.toml
+++ b/pg2any-lib/Cargo.toml
@@ -23,7 +23,6 @@ async-trait = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 libpq-sys = { workspace = true }
-libc = { workspace = true }
 lazy_static = { workspace = true }
 tiberius = { workspace = true, optional = true }
 sqlx = { workspace = true, optional = true }

--- a/pg2any-lib/src/app.rs
+++ b/pg2any-lib/src/app.rs
@@ -10,7 +10,7 @@ use tracing::info;
 #[cfg(feature = "metrics")]
 use crate::MetricsServer;
 use crate::{
-    client::CdcClient, config::Config, lsn_tracker::create_lsn_tracker_with_load, types::Lsn,
+    client::CdcClient, config::Config, lsn_tracker::create_lsn_tracker_with_load_async, types::Lsn,
     CdcResult,
 };
 
@@ -131,7 +131,7 @@ impl CdcApp {
         self.client.init_build_info(&self.config.version);
 
         // Create LSN tracker and load last known LSN
-        let (lsn_tracker, start_lsn) = create_lsn_tracker_with_load(lsn_file_path);
+        let (lsn_tracker, start_lsn) = create_lsn_tracker_with_load_async(lsn_file_path).await;
 
         // Set the LSN tracker on the client for tracking committed LSN
         self.client.set_lsn_tracker(lsn_tracker);

--- a/pg2any-lib/src/client.rs
+++ b/pg2any-lib/src/client.rs
@@ -63,7 +63,7 @@ impl CdcClient {
         info!("Creating CDC client");
 
         // Create destination handler
-        let destination_handler = DestinationFactory::create(config.destination_type.clone())?;
+        let destination_handler = DestinationFactory::create(&config.destination_type)?;
 
         let replication_manager = ReplicationManager::new(config.clone());
 
@@ -174,7 +174,7 @@ impl CdcClient {
         info!("Starting consumer for transaction processing");
 
         // Create destination handler for the consumer
-        let mut consumer_destination = DestinationFactory::create(dest_type.clone())?;
+        let mut consumer_destination = DestinationFactory::create(&dest_type)?;
 
         // Connect the consumer's destination handler
         consumer_destination.connect(dest_connection_string).await?;
@@ -441,7 +441,7 @@ impl CdcClient {
                                         if let Some(batch_tx) = tx_manager.take_batch(xid) {
                                             let batch_count = batch_tx.event_count();
 
-                                            info!(
+                                            debug!(
                                                 "Producer: Sending mid-stream batch with {} events for transaction {}",
                                                 batch_count, xid
                                             );
@@ -637,7 +637,7 @@ impl CdcClient {
                     // Final persist of LSN on shutdown
                     if let Some(ref tracker) = lsn_tracker {
                         info!("Consumer: Final LSN persistence on shutdown");
-                        tracker.persist_async();
+                        tracker.shutdown_async().await;
                     }
 
                     // Log final LSN state
@@ -665,6 +665,7 @@ impl CdcClient {
                                 &destination_type,
                                 &lsn_tracker,
                                 &shared_lsn_feedback,
+                                false, // shutdown_mode
                             ).await;
 
                             info!("Consumer completed transaction {}", tx_id);
@@ -716,6 +717,7 @@ impl CdcClient {
                         "Consumer: Processing remaining transaction {} during shutdown",
                         transaction.transaction_id
                     );
+                    // Pass shutdown_mode=true to force LSN persistence for all batches
                     Self::process_transaction(
                         transaction,
                         destination_handler,
@@ -723,6 +725,7 @@ impl CdcClient {
                         destination_type,
                         lsn_tracker,
                         shared_lsn_feedback,
+                        true, // shutdown_mode
                     )
                     .await;
                     count += 1;
@@ -753,6 +756,7 @@ impl CdcClient {
         destination_type: &str,
         lsn_tracker: &Option<Arc<LsnTracker>>,
         shared_lsn_feedback: &Arc<SharedLsnFeedback>,
+        shutdown_mode: bool,
     ) {
         let start_time = std::time::Instant::now();
         let event_count = transaction.event_count();
@@ -766,42 +770,21 @@ impl CdcClient {
             Ok(_) => {
                 let duration = start_time.elapsed();
 
-                // Update and persist LSN after successful commit
-                if let Some(lsn) = commit_lsn {
-                    // Update shared LSN feedback for replication protocol
-                    // This is crucial for proper PostgreSQL feedback
-                    if is_final {
-                        // Final batch - transaction is fully committed
-                        shared_lsn_feedback.update_applied_lsn(lsn.0);
-                        debug!(
-                            "Updated applied LSN to {} for transaction {} (committed)",
-                            lsn, tx_id
-                        );
-                    } else {
-                        // Non-final batch - data is flushed but not committed
-                        shared_lsn_feedback.update_flushed_lsn(lsn.0);
-                        debug!(
-                            "Updated flushed LSN to {} for transaction {} (batch written)",
-                            lsn, tx_id
-                        );
-                    }
-
-                    // Persist to file for restart recovery
-                    if let Some(ref tracker) = lsn_tracker {
-                        tracker.commit_lsn(lsn.0);
-                        debug!(
-                            "Persisted LSN {} for transaction {} (final={})",
-                            lsn, tx_id, is_final
-                        );
-                    }
-                }
+                handle_lsn_update(
+                    lsn_tracker,
+                    shared_lsn_feedback,
+                    shutdown_mode,
+                    tx_id,
+                    is_final,
+                    commit_lsn,
+                );
 
                 // Only record metrics when transaction is complete (final batch)
                 if is_final {
                     metrics_collector.record_transaction_processed(&transaction, destination_type);
                 }
 
-                debug!(
+                info!(
                     "Successfully processed transaction {} batch ({} events, final={}) in {:?}",
                     tx_id, event_count, is_final, duration
                 );
@@ -902,6 +885,54 @@ impl CdcClient {
             events_processed: 0, // In a real implementation, you'd track this
             last_processed_lsn: None,
             lag_seconds: None,
+        }
+    }
+}
+
+fn handle_lsn_update(
+    lsn_tracker: &Option<Arc<LsnTracker>>,
+    shared_lsn_feedback: &Arc<SharedLsnFeedback>,
+    shutdown_mode: bool,
+    tx_id: u32,
+    is_final: bool,
+    commit_lsn: Option<Lsn>,
+) {
+    let Some(lsn) = commit_lsn else {
+        return;
+    };
+
+    if is_final {
+        // Final batch - transaction is fully committed
+        shared_lsn_feedback.update_applied_lsn(lsn.0);
+        debug!(
+            "Updated applied LSN to {} for transaction {} (committed)",
+            lsn, tx_id
+        );
+
+        // Persist LSN for final batches (actual commits)
+        if let Some(ref tracker) = lsn_tracker {
+            tracker.commit_lsn(lsn.0);
+            debug!(
+                "Persisted commit LSN {} for transaction {} (final commit)",
+                lsn, tx_id
+            );
+        }
+    } else {
+        // Non-final batch - data is flushed but not committed
+        shared_lsn_feedback.update_flushed_lsn(lsn.0);
+        debug!(
+            "Updated flushed LSN to {} for transaction {} (batch written, not persisted)",
+            lsn, tx_id
+        );
+
+        if shutdown_mode {
+            if let Some(ref tracker) = lsn_tracker {
+                tracker.commit_lsn(lsn.0);
+                info!(
+                    "[SHUTDOWN] Persisted LSN {} for transaction {} (non-final batch, shutdown mode)",
+                    lsn, tx_id
+                );
+            }
         }
     }
 }
@@ -1446,6 +1477,7 @@ mod tests {
             "test",
             &None,
             &shared_lsn_feedback,
+            false, // shutdown_mode
         )
         .await;
 

--- a/pg2any-lib/src/destinations/destination_factory.rs
+++ b/pg2any-lib/src/destinations/destination_factory.rs
@@ -77,8 +77,8 @@ pub struct DestinationFactory;
 
 impl DestinationFactory {
     /// Create a new destination handler for the specified type
-    pub fn create(destination_type: DestinationType) -> Result<Box<dyn DestinationHandler>> {
-        match destination_type {
+    pub fn create(destination_type: &DestinationType) -> Result<Box<dyn DestinationHandler>> {
+        match *destination_type {
             #[cfg(feature = "mysql")]
             DestinationType::MySQL => Ok(Box::new(MySQLDestination::new())),
 
@@ -105,25 +105,21 @@ mod tests {
         // Test factory creation for different destination types
         #[cfg(feature = "mysql")]
         {
-            let result = DestinationFactory::create(DestinationType::MySQL);
+            let result = DestinationFactory::create(&DestinationType::MySQL);
             assert!(result.is_ok());
         }
 
         #[cfg(feature = "sqlserver")]
         {
-            let result = DestinationFactory::create(DestinationType::SqlServer);
+            let result = DestinationFactory::create(&DestinationType::SqlServer);
             assert!(result.is_ok());
         }
 
         #[cfg(feature = "sqlite")]
         {
-            let result = DestinationFactory::create(DestinationType::SQLite);
+            let result = DestinationFactory::create(&DestinationType::SQLite);
             assert!(result.is_ok());
         }
-
-        // Test unsupported destination type
-        let result = DestinationFactory::create(DestinationType::PostgreSQL);
-        assert!(result.is_err());
     }
 
     #[test]

--- a/pg2any-lib/src/destinations/sqlite.rs
+++ b/pg2any-lib/src/destinations/sqlite.rs
@@ -448,7 +448,7 @@ impl DestinationHandler for SQLiteDestination {
         // Create parent directory if it doesn't exist
         if let Some(parent) = Path::new(db_path).parent() {
             if !parent.exists() {
-                std::fs::create_dir_all(parent).map_err(|e| {
+                tokio::fs::create_dir_all(parent).await.map_err(|e| {
                     CdcError::generic(format!(
                         "Failed to create directory for SQLite database: {}",
                         e

--- a/pg2any-lib/src/lib.rs
+++ b/pg2any-lib/src/lib.rs
@@ -89,7 +89,7 @@ pub use client::CdcClient;
 pub use config::{Config, ConfigBuilder};
 pub use env::load_config_from_env;
 pub use error::CdcError;
-pub use lsn_tracker::{create_lsn_tracker_with_load, LsnTracker};
+pub use lsn_tracker::{create_lsn_tracker_with_load_async, LsnTracker};
 
 /// Result type for CDC operations
 pub type CdcResult<T> = Result<T, CdcError>;

--- a/pg2any-lib/src/lsn_tracker.rs
+++ b/pg2any-lib/src/lsn_tracker.rs
@@ -16,12 +16,24 @@
 //! Since the producer reads from PostgreSQL and the consumer writes to the destination,
 //! we need a thread-safe way to share the committed LSN from consumer back to producer
 //! for accurate feedback to PostgreSQL.
+//!
+//! ## Optimization Strategy
+//!
+//! Instead of persisting on every commit (which causes excessive I/O), the LsnTracker:
+//! - Batches multiple commits and persists periodically (default: every 1 second)
+//! - Uses a background tokio task for non-blocking persistence
+//! - Tracks a "dirty" flag to skip unnecessary writes
+//! - Ensures graceful shutdown with final persistence
 
 use crate::pg_replication::XLogRecPtr;
 use crate::types::Lsn;
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Arc;
-use tracing::{debug, info, warn};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tokio::sync::Notify;
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, error, info, warn};
 
 /// Thread-safe tracker for LSN positions used in replication feedback
 ///
@@ -171,7 +183,15 @@ impl Clone for SharedLsnFeedback {
 /// Thread-safe tracker for the last committed LSN with file persistence
 ///
 /// This tracker maintains the LSN of the last successfully committed transaction
-/// and provides atomic persistence to ensure no data loss on graceful shutdown.
+/// and provides optimized batched persistence to reduce I/O overhead.
+///
+/// ## Optimization Strategy
+///
+/// Instead of persisting on every commit (which causes excessive I/O), this tracker:
+/// - Batches multiple commits and persists periodically (default: every 1 second)
+/// - Uses a background tokio task for non-blocking persistence
+/// - Tracks a "dirty" flag to skip unnecessary writes
+/// - Ensures graceful shutdown with final persistence
 ///
 /// ## Key Design Principle
 ///
@@ -186,46 +206,213 @@ impl Clone for SharedLsnFeedback {
 pub struct LsnTracker {
     /// The last committed LSN (atomic for thread-safety)
     last_committed_lsn: AtomicU64,
+    /// Last persisted LSN (to avoid unnecessary writes)
+    last_persisted_lsn: AtomicU64,
+    /// Flag indicating if LSN needs to be persisted
+    dirty: AtomicBool,
     /// Path to the LSN persistence file
     lsn_file_path: String,
+    /// Persistence interval in milliseconds
+    interval_ms: u64,
+    /// Cancellation token for background task
+    shutdown_token: CancellationToken,
+    /// Notify for immediate persistence request
+    persist_notify: Arc<Notify>,
+    /// Handle to the background persistence task
+    background_task: Arc<Mutex<JoinHandle<()>>>,
 }
 
 impl LsnTracker {
+    /// Default persistence interval in milliseconds (1 second)
+    pub const DEFAULT_PERSIST_INTERVAL_MS: u64 = 1000;
+
     /// Create a new LSN tracker with the specified file path
-    pub fn new(lsn_file_path: Option<&str>) -> Self {
+    pub fn new(lsn_file_path: Option<&str>) -> Arc<Self> {
+        Self::new_with_interval(lsn_file_path, Self::DEFAULT_PERSIST_INTERVAL_MS)
+    }
+
+    /// Create a new LSN tracker with custom persistence interval
+    /// The background persistence task is started automatically and will run
+    /// until shutdown_async() is called or the tracker is dropped.
+    pub fn new_with_interval(lsn_file_path: Option<&str>, interval_ms: u64) -> Arc<Self> {
         let path = lsn_file_path
             .map(String::from)
             .or_else(|| std::env::var("CDC_LAST_LSN_FILE").ok())
             .unwrap_or_else(|| "./pg2any_last_lsn".to_string());
 
-        Self {
-            last_committed_lsn: AtomicU64::new(0),
-            lsn_file_path: path,
-        }
+        let shutdown_token = CancellationToken::new();
+        let persist_notify = Arc::new(Notify::new());
+        let interval = Duration::from_millis(interval_ms);
+
+        // Use Arc::new_cyclic to create the tracker and spawn the background task
+        // with a reference to the tracker in a single step
+        let tracker = Arc::new_cyclic(|weak_tracker: &std::sync::Weak<Self>| {
+            let shutdown_token_clone = shutdown_token.clone();
+            let persist_notify_clone = persist_notify.clone();
+
+            // Spawn the background task with a weak reference
+            let weak_tracker_clone = weak_tracker.clone();
+            let handle = tokio::spawn(async move {
+                debug!(
+                    "Background LSN persistence task started (interval: {:?})",
+                    interval
+                );
+
+                loop {
+                    tokio::select! {
+                        biased;
+
+                        // Shutdown signal
+                        _ = shutdown_token_clone.cancelled() => {
+                            debug!("Background persistence task received shutdown signal");
+                            break;
+                        }
+
+                        // Immediate persist request
+                        _ = persist_notify_clone.notified() => {
+                            if let Some(tracker) = weak_tracker_clone.upgrade() {
+                                if let Err(e) = tracker.persist_internal().await {
+                                    warn!("Immediate persistence failed: {}", e);
+                                }
+                            }
+                        }
+
+                        // Periodic persistence
+                        _ = tokio::time::sleep(interval) => {
+                            if let Some(tracker) = weak_tracker_clone.upgrade() {
+                                if tracker.dirty.load(Ordering::Acquire) {
+                                    if let Err(e) = tracker.persist_internal().await {
+                                        warn!("Background persistence failed: {}", e);
+                                    }
+                                }
+                            } else {
+                                // Tracker was dropped, exit the loop
+                                debug!("Tracker dropped, stopping background persistence");
+                                break;
+                            }
+                        }
+                    }
+                }
+
+                // Final persist on shutdown
+                if let Some(tracker) = weak_tracker_clone.upgrade() {
+                    if let Err(e) = tracker.persist_internal().await {
+                        warn!("Final persistence on shutdown failed: {}", e);
+                    } else {
+                        let final_lsn = tracker.last_committed_lsn.load(Ordering::Acquire);
+                        if final_lsn > 0 {
+                            info!(
+                                "Final LSN persisted on shutdown: {}",
+                                crate::pg_replication::format_lsn(final_lsn)
+                            );
+                        }
+                    }
+                }
+
+                debug!("Background LSN persistence task stopped");
+            });
+
+            // Create the tracker with the actual handle
+            Self {
+                last_committed_lsn: AtomicU64::new(0),
+                last_persisted_lsn: AtomicU64::new(0),
+                dirty: AtomicBool::new(false),
+                lsn_file_path: path,
+                interval_ms,
+                shutdown_token,
+                persist_notify,
+                background_task: Arc::new(Mutex::new(handle)),
+            }
+        });
+
+        info!(
+            "Started background LSN persistence (interval: {}ms)",
+            interval_ms
+        );
+
+        tracker
     }
 
     /// Create a new LSN tracker and load the initial value from file
     ///
     /// This is the preferred way to create a tracker that should resume
     /// from a previously persisted LSN.
-    pub fn new_with_load(lsn_file_path: Option<&str>) -> (Self, Option<Lsn>) {
-        let tracker = Self::new(lsn_file_path);
-        let loaded_lsn = tracker.load_from_file();
+    pub async fn new_with_load(lsn_file_path: Option<&str>) -> (Arc<Self>, Option<Lsn>) {
+        Self::new_with_load_and_interval(lsn_file_path, Self::DEFAULT_PERSIST_INTERVAL_MS).await
+    }
 
-        // Initialize the atomic with the loaded value
+    /// Create a new LSN tracker with custom interval and load the initial value from file
+    ///
+    /// The background persistence task is started automatically.
+    pub async fn new_with_load_and_interval(
+        lsn_file_path: Option<&str>,
+        interval_ms: u64,
+    ) -> (Arc<Self>, Option<Lsn>) {
+        let tracker = Self::new_with_interval(lsn_file_path, interval_ms);
+        let loaded_lsn = tracker.load_from_file().await;
+
+        // Initialize the atomics with the loaded value
         if let Some(lsn) = loaded_lsn {
             tracker.last_committed_lsn.store(lsn.0, Ordering::Release);
+            tracker.last_persisted_lsn.store(lsn.0, Ordering::Release);
         }
 
         (tracker, loaded_lsn)
+    }
+
+    /// Shutdown the background persistence task gracefully
+    /// This ensures the final LSN is persisted before the task exits.
+    /// Should be called before dropping the tracker.
+    /// **CRITICAL**: This method waits for the background task to complete its, final persistence, ensuring no LSN data loss during shutdown.
+    pub async fn shutdown_async(&self) {
+        if self.shutdown_token.is_cancelled() {
+            debug!("LSN tracker already shutting down");
+            return;
+        }
+
+        info!("Shutting down LSN persistence task");
+
+        // Signal the background task to shutdown
+        self.shutdown_token.cancel();
+
+        let handle = {
+            let mut task_guard = self.background_task.lock().unwrap();
+            std::mem::replace(&mut *task_guard, tokio::spawn(async {}))
+        };
+
+        debug!("Waiting for background persistence task to complete...");
+        match handle.await {
+            Ok(_) => info!("Background persistence task completed successfully"),
+            Err(e) => {
+                error!("Shutdown Async persist failed: {}", e);
+            }
+        }
+
+        info!("LSN persistence task stopped gracefully");
+    }
+
+    /// Synchronous shutdown for use in Drop or non-async contexts
+    /// Note: This cannot wait for async operations to complete.
+    pub fn shutdown_sync(&self) {
+        if self.shutdown_token.is_cancelled() {
+            return;
+        }
+
+        info!("Initiating sync shutdown of LSN persistence");
+        self.shutdown_token.cancel();
+
+        // Perform synchronous final persist
+        if let Err(e) = self.persist_sync() {
+            warn!("Failed to persist LSN on sync shutdown: {}", e);
+        }
     }
 
     /// Load LSN from the persistence file
     ///
     /// Returns `Some(Lsn)` if a valid LSN was found and parsed, `None` otherwise.
     /// Logs warnings for parsing errors but doesn't fail.
-    pub fn load_from_file(&self) -> Option<Lsn> {
-        match std::fs::read_to_string(&self.lsn_file_path) {
+    pub async fn load_from_file(&self) -> Option<Lsn> {
+        match tokio::fs::read_to_string(&self.lsn_file_path).await {
             Ok(contents) => {
                 let s = contents.trim();
                 if s.is_empty() {
@@ -282,6 +469,7 @@ impl LsnTracker {
             ) {
                 Ok(_) => {
                     debug!("Updated last committed LSN from {} to {}", current, lsn);
+                    self.dirty.store(true, Ordering::Release);
                     return;
                 }
                 Err(_) => continue, // Retry if another thread updated concurrently
@@ -289,13 +477,14 @@ impl LsnTracker {
         }
     }
 
-    /// Update and persist the LSN atomically
-    ///
+    /// Update and mark LSN for persistence
     /// This should be called after each successful transaction commit to the destination.
-    /// It updates the in-memory LSN and persists it to disk.
+    /// It updates the in-memory LSN and marks it as dirty for background persistence.
+    /// Note: With background persistence enabled, this does NOT immediately persist to disk.
+    /// The background task handles periodic persistence to reduce I/O overhead.
+    #[inline]
     pub fn commit_lsn(&self, lsn: u64) {
         self.update_if_greater(lsn);
-        self.persist_async();
     }
 
     /// Get the current last committed LSN
@@ -314,14 +503,56 @@ impl LsnTracker {
         }
     }
 
-    /// Persist the current LSN to file
-    ///
+    /// Request immediate persistence (non-blocking)
+    /// This notifies the background task to persist immediately.
+    /// Useful for critical checkpoints where waiting for the next interval is not acceptable.
+    pub fn request_persist(&self) {
+        self.persist_notify.notify_one();
+    }
+
+    /// Persist the current LSN to file asynchronously
     /// This method writes the LSN atomically by first writing to a temp file
-    /// and then renaming to ensure crash safety.
-    pub fn persist(&self) -> std::io::Result<()> {
-        let lsn = self.get();
-        if lsn == 0 {
-            tracing::debug!("Skipping LSN persistence: no committed LSN yet");
+    /// and then renaming to ensure crash safety. Returns early if the LSN
+    /// is already persisted.
+    pub async fn persist_async(&self) -> std::io::Result<()> {
+        self.persist_internal().await
+    }
+
+    /// Internal persist implementation that updates the persisted LSN tracker
+    async fn persist_internal(&self) -> std::io::Result<()> {
+        let lsn = self.last_committed_lsn.load(Ordering::Acquire);
+        let persisted = self.last_persisted_lsn.load(Ordering::Acquire);
+
+        // Skip if already persisted or no LSN yet
+        if lsn == 0 || lsn <= persisted {
+            return Ok(());
+        }
+
+        let lsn_str = crate::pg_replication::format_lsn(lsn);
+
+        // Write to temp file first for atomic write
+        let temp_path = format!("{}.tmp", self.lsn_file_path);
+        tokio::fs::write(&temp_path, &lsn_str).await?;
+        tokio::fs::rename(&temp_path, &self.lsn_file_path).await?;
+
+        // Update persisted LSN and clear dirty flag
+        self.last_persisted_lsn.store(lsn, Ordering::Release);
+        self.dirty.store(false, Ordering::Release);
+
+        info!(
+            "Persisted committed LSN {} to {}",
+            lsn_str, self.lsn_file_path
+        );
+        Ok(())
+    }
+
+    /// Synchronous persist for use in Drop or non-async contexts
+    fn persist_sync(&self) -> std::io::Result<()> {
+        let lsn = self.last_committed_lsn.load(Ordering::Acquire);
+        let persisted = self.last_persisted_lsn.load(Ordering::Acquire);
+
+        // Skip if already persisted or no LSN yet
+        if lsn == 0 || lsn <= persisted {
             return Ok(());
         }
 
@@ -332,58 +563,88 @@ impl LsnTracker {
         std::fs::write(&temp_path, &lsn_str)?;
         std::fs::rename(&temp_path, &self.lsn_file_path)?;
 
+        // Update persisted LSN and clear dirty flag
+        self.last_persisted_lsn.store(lsn, Ordering::Release);
+        self.dirty.store(false, Ordering::Release);
+
         info!(
-            "Persisted committed LSN {} to {}",
+            "Persisted committed LSN {} to {} (sync)",
             lsn_str, self.lsn_file_path
         );
         Ok(())
-    }
-
-    /// Persist the current LSN to file (non-blocking, logs errors)
-    pub fn persist_async(&self) {
-        if let Err(e) = self.persist() {
-            warn!("Failed to persist LSN: {}", e);
-        }
     }
 
     /// Get the file path for LSN persistence
     pub fn file_path(&self) -> &str {
         &self.lsn_file_path
     }
+
+    /// Get the persistence interval in milliseconds
+    pub fn interval_ms(&self) -> u64 {
+        self.interval_ms
+    }
+
+    /// Check if there are pending changes to persist
+    pub fn is_dirty(&self) -> bool {
+        self.dirty.load(Ordering::Acquire)
+    }
 }
 
-impl Clone for LsnTracker {
-    fn clone(&self) -> Self {
-        Self {
-            last_committed_lsn: AtomicU64::new(self.last_committed_lsn.load(Ordering::Acquire)),
-            lsn_file_path: self.lsn_file_path.clone(),
-        }
+impl Drop for LsnTracker {
+    fn drop(&mut self) {
+        // Ensure graceful shutdown on drop
+        self.shutdown_sync();
     }
 }
 
 /// Create a shared LSN tracker with initial load from file
-pub fn create_lsn_tracker_with_load(lsn_file_path: Option<&str>) -> (Arc<LsnTracker>, Option<Lsn>) {
-    let (tracker, lsn) = LsnTracker::new_with_load(lsn_file_path);
-    (Arc::new(tracker), lsn)
+///
+/// The background persistence task is started automatically.
+/// The returned `Arc<LsnTracker>` should be used throughout the application lifecycle.
+/// Background persistence will be stopped when the tracker is dropped.
+pub async fn create_lsn_tracker_with_load_async(
+    lsn_file_path: Option<&str>,
+) -> (Arc<LsnTracker>, Option<Lsn>) {
+    LsnTracker::new_with_load(lsn_file_path).await
+}
+
+/// Create a shared LSN tracker with custom persistence interval
+///
+/// This is useful for tuning I/O performance based on workload characteristics:
+/// - High-frequency, low-latency: Use shorter intervals (100-500ms)
+/// - Batch processing: Use longer intervals (2000-5000ms)
+/// - Default: 1000ms provides good balance
+///
+/// # Arguments
+///
+/// * `lsn_file_path` - Optional path to the LSN persistence file
+/// * `interval_ms` - Persistence interval in milliseconds
+pub async fn create_lsn_tracker_with_interval_async(
+    lsn_file_path: Option<&str>,
+    interval_ms: u64,
+) -> (Arc<LsnTracker>, Option<Lsn>) {
+    LsnTracker::new_with_load_and_interval(lsn_file_path, interval_ms).await
 }
 
 #[cfg(test)]
 mod lsn_tracker_tests {
     use super::*;
 
-    #[test]
-    fn test_lsn_tracker_new() {
-        let tracker = LsnTracker::new(Some("/tmp/test_lsn"));
+    #[tokio::test]
+    async fn test_lsn_tracker_new() {
+        let tracker = LsnTracker::new_with_interval(Some("/tmp/test_lsn_new"), 60000);
         assert_eq!(tracker.get(), 0);
-        assert_eq!(tracker.file_path(), "/tmp/test_lsn");
+        assert_eq!(tracker.file_path(), "/tmp/test_lsn_new");
+        assert_eq!(tracker.interval_ms(), 60000);
     }
 
-    #[test]
-    fn test_lsn_tracker_update_if_greater() {
-        let tracker = LsnTracker::new(Some("/tmp/test_lsn"));
+    #[tokio::test]
+    async fn test_lsn_tracker_update_if_greater() {
+        let tracker = LsnTracker::new_with_interval(Some("/tmp/test_lsn_update"), 60000);
 
         tracker.update_if_greater(100);
         assert_eq!(tracker.get(), 100);
+        assert!(tracker.is_dirty());
 
         // Should not update with smaller value
         tracker.update_if_greater(50);
@@ -398,9 +659,9 @@ mod lsn_tracker_tests {
         assert_eq!(tracker.get(), 150);
     }
 
-    #[test]
-    fn test_lsn_tracker_get_lsn() {
-        let tracker = LsnTracker::new(Some("/tmp/test_lsn"));
+    #[tokio::test]
+    async fn test_lsn_tracker_get_lsn() {
+        let tracker = LsnTracker::new_with_interval(Some("/tmp/test_lsn_get"), 60000);
 
         assert_eq!(tracker.get_lsn(), None);
 
@@ -408,14 +669,154 @@ mod lsn_tracker_tests {
         assert_eq!(tracker.get_lsn(), Some(Lsn(100)));
     }
 
-    #[test]
-    fn test_lsn_tracker_clone() {
-        let tracker = LsnTracker::new(Some("/tmp/test_lsn"));
-        tracker.update_if_greater(42);
+    #[tokio::test]
+    async fn test_commit_lsn_marks_dirty() {
+        let tracker = LsnTracker::new_with_interval(Some("/tmp/test_lsn_commit"), 60000);
+        assert!(!tracker.is_dirty());
 
-        let cloned = tracker.clone();
-        assert_eq!(cloned.get(), 42);
-        assert_eq!(cloned.file_path(), "/tmp/test_lsn");
+        tracker.commit_lsn(100);
+        assert_eq!(tracker.get(), 100);
+        assert!(tracker.is_dirty());
+    }
+
+    #[tokio::test]
+    async fn test_persist_async() {
+        let path = "/tmp/test_lsn_persist_async";
+        let tracker = LsnTracker::new_with_interval(Some(path), 60000);
+
+        tracker.commit_lsn(12345678);
+        assert!(tracker.is_dirty());
+
+        tracker.persist_async().await.unwrap();
+
+        // After persist, dirty flag should be cleared
+        assert!(!tracker.is_dirty());
+
+        // Verify file contents
+        let contents = tokio::fs::read_to_string(path).await.unwrap();
+        assert!(!contents.is_empty());
+
+        // Cleanup
+        let _ = tokio::fs::remove_file(path).await;
+    }
+
+    #[tokio::test]
+    async fn test_persist_skips_when_not_dirty() {
+        let path = "/tmp/test_lsn_skip_persist";
+        let tracker = LsnTracker::new_with_interval(Some(path), 60000);
+
+        tracker.commit_lsn(100);
+        tracker.persist_async().await.unwrap();
+
+        // Persist again without changes - should skip
+        let result = tracker.persist_async().await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_load_from_file() {
+        let path = "/tmp/test_lsn_load";
+
+        // Write a test LSN
+        tokio::fs::write(path, "0/ABCDEF").await.unwrap();
+
+        let tracker = LsnTracker::new_with_interval(Some(path), 60000);
+        let loaded = tracker.load_from_file().await;
+
+        assert!(loaded.is_some());
+
+        // Cleanup
+        let _ = tokio::fs::remove_file(path).await;
+    }
+
+    #[tokio::test]
+    async fn test_new_with_load() {
+        let path = "/tmp/test_lsn_with_load";
+
+        // Write a test LSN
+        tokio::fs::write(path, "0/123456").await.unwrap();
+
+        let (tracker, lsn) = LsnTracker::new_with_load(Some(path)).await;
+
+        assert!(lsn.is_some());
+        assert!(tracker.get() > 0);
+
+        // Cleanup
+        let _ = tokio::fs::remove_file(path).await;
+    }
+
+    #[tokio::test]
+    async fn test_background_persistence_with_shutdown() {
+        let path = "/tmp/test_lsn_bg_shutdown";
+
+        // Create tracker with short interval for testing
+        let arc_tracker = LsnTracker::new_with_interval(Some(path), 100);
+
+        // Commit some LSNs
+        arc_tracker.commit_lsn(100);
+        arc_tracker.commit_lsn(200);
+        arc_tracker.commit_lsn(300);
+
+        // Wait a bit for background task to persist
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        // Commit final LSN
+        arc_tracker.commit_lsn(400);
+
+        // Shutdown gracefully - this should persist the final LSN
+        arc_tracker.shutdown_async().await;
+
+        // Verify final LSN was persisted
+        let contents = tokio::fs::read_to_string(path).await.unwrap();
+        assert!(!contents.is_empty());
+
+        // Load from file to verify
+        let (new_tracker, loaded_lsn) = LsnTracker::new_with_load(Some(path)).await;
+        assert!(loaded_lsn.is_some());
+        assert_eq!(new_tracker.get(), 400);
+
+        // Cleanup
+        let _ = tokio::fs::remove_file(path).await;
+    }
+
+    #[tokio::test]
+    async fn test_shutdown_without_background_task() {
+        let path = "/tmp/test_lsn_no_bg_shutdown";
+        let tracker = LsnTracker::new_with_interval(Some(path), 60000);
+
+        // Commit LSN (background task is already running from new_with_interval)
+        tracker.commit_lsn(999);
+
+        // Shutdown should still persist
+        tracker.shutdown_async().await;
+
+        // Verify LSN was persisted
+        let contents = tokio::fs::read_to_string(path).await.unwrap();
+        assert!(!contents.is_empty());
+
+        let (new_tracker, loaded_lsn) = LsnTracker::new_with_load(Some(path)).await;
+        assert!(loaded_lsn.is_some());
+        assert_eq!(new_tracker.get(), 999);
+
+        // Cleanup
+        let _ = tokio::fs::remove_file(path).await;
+    }
+
+    #[tokio::test]
+    async fn test_double_shutdown_is_safe() {
+        let path = "/tmp/test_lsn_double_shutdown";
+        let (arc_tracker, _) = LsnTracker::new_with_load(Some(path)).await;
+
+        arc_tracker.commit_lsn(555);
+
+        // First shutdown
+        arc_tracker.shutdown_async().await;
+
+        // Second shutdown should be safe (no-op)
+        arc_tracker.shutdown_async().await;
+
+        // Cleanup
+        let _ = tokio::fs::remove_file(path).await;
     }
 
     #[test]

--- a/pg2any-lib/src/pg_replication.rs
+++ b/pg2any-lib/src/pg_replication.rs
@@ -128,7 +128,7 @@ impl PgReplicationConnection {
         // Check for errors
         let status = pg_result.status();
         info!(
-            "query : {}, pg_result.status() : {:?}",
+            "query : {} pg_result.status() : {:?}",
             query,
             pg_result.status()
         );
@@ -182,7 +182,6 @@ impl PgReplicationConnection {
             slot_name, output_plugin
         );
 
-        debug!("Creating replication slot: {}", slot_name);
         let result = self.exec(&create_slot_sql)?;
 
         if result.ntuples() > 0 {

--- a/pg2any-lib/src/transaction_manager.rs
+++ b/pg2any-lib/src/transaction_manager.rs
@@ -264,7 +264,9 @@ impl TransactionManager {
             }
 
             let events = std::mem::take(&mut state.pending_events);
-            let mut tx = Transaction::new_batch(transaction_id, state.commit_timestamp, true);
+
+            // This ensures LSN is not persisted until the actual commit
+            let mut tx = Transaction::new_batch(transaction_id, state.commit_timestamp, false);
             tx.events = events;
 
             if let Some(lsn) = state.last_lsn {

--- a/pg2any-lib/src/types.rs
+++ b/pg2any-lib/src/types.rs
@@ -64,8 +64,6 @@ pub enum EventType {
 pub enum DestinationType {
     MySQL,
     SqlServer,
-    // Future support for other databases
-    PostgreSQL,
     SQLite,
 }
 
@@ -74,7 +72,6 @@ impl std::fmt::Display for DestinationType {
         match self {
             DestinationType::MySQL => write!(f, "mysql"),
             DestinationType::SqlServer => write!(f, "sqlserver"),
-            DestinationType::PostgreSQL => write!(f, "postgresql"),
             DestinationType::SQLite => write!(f, "sqlite"),
         }
     }

--- a/pg2any-lib/tests/destination_integration_tests.rs
+++ b/pg2any-lib/tests/destination_integration_tests.rs
@@ -24,7 +24,7 @@ async fn test_destination_handler_interface() {
 
     #[cfg(feature = "mysql")]
     {
-        let mut destination = DestinationFactory::create(DestinationType::MySQL).unwrap();
+        let mut destination = DestinationFactory::create(&DestinationType::MySQL).unwrap();
 
         // Test single event processing interface
         for event in &events {
@@ -42,7 +42,7 @@ async fn test_destination_handler_interface() {
 
     #[cfg(feature = "sqlserver")]
     {
-        let mut destination = DestinationFactory::create(DestinationType::SqlServer).unwrap();
+        let mut destination = DestinationFactory::create(&DestinationType::SqlServer).unwrap();
 
         // Test single event processing interface
         for event in &events {
@@ -66,18 +66,15 @@ fn test_destination_type_serialization() {
 
     let mysql_type = DestinationType::MySQL;
     let sqlserver_type = DestinationType::SqlServer;
-    let postgres_type = DestinationType::PostgreSQL;
     let sqlite_type = DestinationType::SQLite;
 
     // Test serialization
     let mysql_json = serde_json::to_string(&mysql_type).unwrap();
     let sqlserver_json = serde_json::to_string(&sqlserver_type).unwrap();
-    let postgres_json = serde_json::to_string(&postgres_type).unwrap();
     let sqlite_json = serde_json::to_string(&sqlite_type).unwrap();
 
     assert_eq!(mysql_json, "\"MySQL\"");
     assert_eq!(sqlserver_json, "\"SqlServer\"");
-    assert_eq!(postgres_json, "\"PostgreSQL\"");
     assert_eq!(sqlite_json, "\"SQLite\"");
 
     // Test deserialization
@@ -91,28 +88,18 @@ fn test_destination_type_serialization() {
 /// Test that unsupported destination types return proper errors
 #[test]
 fn test_unsupported_destination_types() {
-    let postgres_result = DestinationFactory::create(DestinationType::PostgreSQL);
-    assert!(postgres_result.is_err());
-
     // SQLite is now supported, so it should succeed
     #[cfg(feature = "sqlite")]
     {
-        let sqlite_result = DestinationFactory::create(DestinationType::SQLite);
+        let sqlite_result = DestinationFactory::create(&DestinationType::SQLite);
         assert!(sqlite_result.is_ok());
     }
 
     // If SQLite feature is not enabled, it should fail
     #[cfg(not(feature = "sqlite"))]
     {
-        let sqlite_result = DestinationFactory::create(DestinationType::SQLite);
+        let sqlite_result = DestinationFactory::create(&DestinationType::SQLite);
         assert!(sqlite_result.is_err());
-    }
-
-    // Verify error messages contain helpful information
-    if let Err(error) = postgres_result {
-        let error_msg = error.to_string();
-        assert!(error_msg.contains("PostgreSQL"));
-        assert!(error_msg.contains("not supported") || error_msg.contains("not enabled"));
     }
 }
 

--- a/pg2any-lib/tests/sqlite_comprehensive_tests.rs
+++ b/pg2any-lib/tests/sqlite_comprehensive_tests.rs
@@ -6,9 +6,9 @@ use pg2any_lib::{
 };
 use serde_json::json;
 use std::collections::HashMap;
-use std::fs;
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
+use tokio::fs;
 
 /// Helper function to wrap a single event in a transaction for testing
 fn wrap_in_transaction(event: ChangeEvent) -> Transaction {
@@ -1011,7 +1011,7 @@ async fn test_sqlite_complete_crud_cycle() {
 #[tokio::test]
 async fn test_sqlite_destination_factory_integration() {
     // Test that the factory creates a working SQLite destination
-    let mut destination = DestinationFactory::create(DestinationType::SQLite).unwrap();
+    let mut destination = DestinationFactory::create(&DestinationType::SQLite).unwrap();
 
     let temp_db = TempDatabase::new("factory_integration");
     let connection_string = temp_db.connection_string();

--- a/pg2any-lib/tests/sqlite_destination_tests.rs
+++ b/pg2any-lib/tests/sqlite_destination_tests.rs
@@ -6,8 +6,8 @@ use pg2any_lib::{
 };
 use serde_json::json;
 use std::collections::HashMap;
-use std::fs;
 use std::path::{Path, PathBuf};
+use tokio::fs;
 
 /// Helper function to wrap a single event in a transaction for testing
 fn wrap_in_transaction(event: ChangeEvent) -> Transaction {
@@ -101,7 +101,7 @@ async fn create_test_table(pool: &SqlitePool) -> Result<(), sqlx::Error> {
 #[cfg(feature = "sqlite")]
 #[tokio::test]
 async fn test_sqlite_destination_factory() {
-    let destination = DestinationFactory::create(DestinationType::SQLite);
+    let destination = DestinationFactory::create(&DestinationType::SQLite);
     assert!(destination.is_ok());
 }
 

--- a/pg2any-lib/tests/streaming_transaction_tests.rs
+++ b/pg2any-lib/tests/streaming_transaction_tests.rs
@@ -16,7 +16,7 @@ mod streaming_transaction_tests {
         // Test MySQL
         #[cfg(feature = "mysql")]
         {
-            let mut mysql_dest = DestinationFactory::create(DestinationType::MySQL).unwrap();
+            let mut mysql_dest = DestinationFactory::create(&DestinationType::MySQL).unwrap();
 
             // Should have no active streaming transaction initially
             assert_eq!(mysql_dest.get_active_streaming_transaction_id(), None);
@@ -28,7 +28,7 @@ mod streaming_transaction_tests {
         // Test SQLite
         #[cfg(feature = "sqlite")]
         {
-            let mut sqlite_dest = DestinationFactory::create(DestinationType::SQLite).unwrap();
+            let mut sqlite_dest = DestinationFactory::create(&DestinationType::SQLite).unwrap();
 
             // Should have no active streaming transaction initially
             assert_eq!(sqlite_dest.get_active_streaming_transaction_id(), None);
@@ -41,7 +41,7 @@ mod streaming_transaction_tests {
         #[cfg(feature = "sqlserver")]
         {
             let mut sqlserver_dest =
-                DestinationFactory::create(DestinationType::SqlServer).unwrap();
+                DestinationFactory::create(&DestinationType::SqlServer).unwrap();
 
             // Should have no active streaming transaction initially
             assert_eq!(sqlserver_dest.get_active_streaming_transaction_id(), None);
@@ -59,7 +59,7 @@ mod streaming_transaction_tests {
     async fn test_non_streaming_transaction_processing() {
         #[cfg(feature = "sqlite")]
         {
-            let sqlite_dest = DestinationFactory::create(DestinationType::SQLite).unwrap();
+            let sqlite_dest = DestinationFactory::create(&DestinationType::SQLite).unwrap();
 
             // Create a non-final batch transaction
             let mut transaction = Transaction::new(1, chrono::Utc::now());
@@ -78,7 +78,7 @@ mod streaming_transaction_tests {
     async fn test_empty_streaming_batch_handling() {
         #[cfg(feature = "sqlite")]
         {
-            let sqlite_dest = DestinationFactory::create(DestinationType::SQLite).unwrap();
+            let sqlite_dest = DestinationFactory::create(&DestinationType::SQLite).unwrap();
 
             // Create an empty non-final batch transaction
             let mut transaction = Transaction::new(1, chrono::Utc::now());
@@ -97,7 +97,7 @@ mod streaming_transaction_tests {
 
         #[cfg(feature = "mysql")]
         {
-            let result = DestinationFactory::create(DestinationType::MySQL);
+            let result = DestinationFactory::create(&DestinationType::MySQL);
             assert!(
                 result.is_ok(),
                 "MySQL destination should be created successfully"
@@ -106,7 +106,7 @@ mod streaming_transaction_tests {
 
         #[cfg(feature = "sqlite")]
         {
-            let result = DestinationFactory::create(DestinationType::SQLite);
+            let result = DestinationFactory::create(&DestinationType::SQLite);
             assert!(
                 result.is_ok(),
                 "SQLite destination should be created successfully"
@@ -115,7 +115,7 @@ mod streaming_transaction_tests {
 
         #[cfg(feature = "sqlserver")]
         {
-            let result = DestinationFactory::create(DestinationType::SqlServer);
+            let result = DestinationFactory::create(&DestinationType::SqlServer);
             assert!(
                 result.is_ok(),
                 "SQL Server destination should be created successfully"
@@ -128,7 +128,7 @@ mod streaming_transaction_tests {
     async fn test_graceful_shutdown_with_streaming_transaction() {
         #[cfg(feature = "sqlite")]
         {
-            let mut sqlite_dest = DestinationFactory::create(DestinationType::SQLite).unwrap();
+            let mut sqlite_dest = DestinationFactory::create(&DestinationType::SQLite).unwrap();
 
             // Closing without active transactions should succeed
             assert!(sqlite_dest.close().await.is_ok());
@@ -137,7 +137,7 @@ mod streaming_transaction_tests {
         #[cfg(feature = "sqlserver")]
         {
             let mut sqlserver_dest =
-                DestinationFactory::create(DestinationType::SqlServer).unwrap();
+                DestinationFactory::create(&DestinationType::SqlServer).unwrap();
 
             // Closing without active transactions should succeed
             assert!(sqlserver_dest.close().await.is_ok());
@@ -149,7 +149,7 @@ mod streaming_transaction_tests {
     async fn test_streaming_transaction_state_management() {
         #[cfg(feature = "sqlite")]
         {
-            let mut sqlite_dest = DestinationFactory::create(DestinationType::SQLite).unwrap();
+            let mut sqlite_dest = DestinationFactory::create(&DestinationType::SQLite).unwrap();
 
             // Initial state should be no active transaction
             assert_eq!(sqlite_dest.get_active_streaming_transaction_id(), None);
@@ -165,7 +165,7 @@ mod streaming_transaction_tests {
         #[cfg(feature = "sqlserver")]
         {
             let mut sqlserver_dest =
-                DestinationFactory::create(DestinationType::SqlServer).unwrap();
+                DestinationFactory::create(&DestinationType::SqlServer).unwrap();
 
             // Initial state should be no active transaction
             assert_eq!(sqlserver_dest.get_active_streaming_transaction_id(), None);
@@ -187,7 +187,7 @@ mod streaming_transaction_tests {
     async fn test_schema_mappings_with_streaming_transactions() {
         #[cfg(feature = "sqlite")]
         {
-            let mut sqlite_dest = DestinationFactory::create(DestinationType::SQLite).unwrap();
+            let mut sqlite_dest = DestinationFactory::create(&DestinationType::SQLite).unwrap();
 
             let mut mappings = HashMap::new();
             mappings.insert("public".to_string(), "cdc_db".to_string());
@@ -202,7 +202,7 @@ mod streaming_transaction_tests {
         #[cfg(feature = "sqlserver")]
         {
             let mut sqlserver_dest =
-                DestinationFactory::create(DestinationType::SqlServer).unwrap();
+                DestinationFactory::create(&DestinationType::SqlServer).unwrap();
 
             let mut mappings = HashMap::new();
             mappings.insert("public".to_string(), "cdc_db".to_string());
@@ -222,21 +222,21 @@ mod streaming_transaction_tests {
 
         #[cfg(feature = "mysql")]
         {
-            let mysql_dest = DestinationFactory::create(DestinationType::MySQL).unwrap();
+            let mysql_dest = DestinationFactory::create(&DestinationType::MySQL).unwrap();
             // If this compiles and runs, the interface is compatible
             drop(mysql_dest);
         }
 
         #[cfg(feature = "sqlite")]
         {
-            let sqlite_dest = DestinationFactory::create(DestinationType::SQLite).unwrap();
+            let sqlite_dest = DestinationFactory::create(&DestinationType::SQLite).unwrap();
             // If this compiles and runs, the interface is compatible
             drop(sqlite_dest);
         }
 
         #[cfg(feature = "sqlserver")]
         {
-            let sqlserver_dest = DestinationFactory::create(DestinationType::SqlServer).unwrap();
+            let sqlserver_dest = DestinationFactory::create(&DestinationType::SqlServer).unwrap();
             // If this compiles and runs, the interface is compatible
             drop(sqlserver_dest);
         }


### PR DESCRIPTION
Major improvements:
- Convert LsnTracker to fully async with background persistence task
- Use tokio::spawn with Arc::new_cyclic for proper lifetime management
- Add shutdown_async() method for graceful background task termination
- Implement batched persistence (default: 1 second interval) to reduce I/O
- Add dirty flag tracking to skip unnecessary writes
- Support both async and sync persistence for compatibility
- Update all call sites to use async methods
- fix graceful shutdown bug & remove libc which didn't use in lib.
- DestinationFactory::create now takes reference instead of owned value
- Remove PostgreSQL from DestinationType enum (not yet supported)
- Convert std::fs to tokio::fs for async file operations in SQLite
- Fix all test references to use new async API

This change significantly improves performance by batching LSN persistence while maintaining data durability through graceful shutdown handling.