### PR TITLE
Add chaos integration tests and upgrade pg_walstream to 0.2.1

### DIFF
--- a/.github/workflows/chaos_integration_test.yml
+++ b/.github/workflows/chaos_integration_test.yml
@@ -1,0 +1,164 @@
+name: CDC Chaos Integration Test
+
+on:
+  push:
+    branches: [ "*" ]
+  pull_request:
+    branches: [ "main" ]
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:  # Allow manual trigger
+
+jobs:
+  chaos-integration-test:
+    strategy:
+      matrix:
+        os: [ubuntu-22.04, ubuntu-24.04]
+      fail-fast: false 
+    
+    runs-on: ${{ matrix.os }}
+    
+    timeout-minutes: 360  
+    
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+    
+    - name: Set up Docker Compose
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y docker-compose
+    
+    - name: Verify test structure
+      run: |
+        echo "Verifying chaos test structure..."
+        ls -la tests/chaos/
+        ls -la tests/chaos/scripts/
+        ls -la tests/chaos/scenarios/
+    
+    - name: Start Docker Compose services
+      run: |
+        echo "Starting all services with docker-compose..."
+        docker-compose -f docker-compose.chaos-test.yml up --build -d
+      working-directory: .
+    
+    - name: Wait for services to be healthy
+      run: |
+        echo "Waiting for services to become healthy..."
+        timeout 120 bash -c 'until docker ps | grep -q "healthy"; do sleep 5; done' || true
+        docker-compose -f docker-compose.chaos-test.yml ps
+        sleep 15
+      working-directory: .
+    
+    - name: Verify PostgreSQL is ready
+      run: |
+        echo "Verifying PostgreSQL connection..."
+        docker exec cdc_postgres pg_isready -U postgres
+        docker exec cdc_postgres psql -U postgres -c "SELECT version();"
+    
+    - name: Verify MySQL is ready
+      run: |
+        echo "Verifying MySQL connection..."
+        docker exec cdc_mysql mysqladmin ping -h localhost -u root -ptest.123
+        docker exec cdc_mysql mysql -u root -ptest.123 -e "SELECT VERSION();"
+    
+    - name: Verify CDC application is running
+      run: |
+        echo "Verifying CDC application..."
+        docker ps -a | grep cdc_application
+        docker logs cdc_application | tail -n 50
+    
+    - name: Make scripts executable
+      run: |
+        chmod +x tests/chaos/scripts/*.sh
+        ls -la tests/chaos/scripts/
+    
+    - name: Run chaos integration tests
+      run: |
+        echo "=========================================="
+        echo "Starting CDC Chaos Integration Tests"
+        echo "=========================================="
+        echo "OS: ${{ matrix.os }}"
+        echo "Test will run with chaos (random container restarts)"
+        echo ""
+        
+        cd tests/chaos/scripts
+        ./run_chaos_tests.sh
+      env:
+        CDC_POSTGRES_HOST: 127.0.0.1
+        CDC_POSTGRES_PORT: 5432
+        CDC_POSTGRES_USER: postgres
+        CDC_POSTGRES_PASSWORD: test.123
+        CDC_POSTGRES_DB: postgres
+        CDC_MYSQL_HOST: 127.0.0.1
+        CDC_MYSQL_PORT: 3306
+        CDC_MYSQL_USER: root
+        CDC_MYSQL_PASSWORD: test.123
+        CDC_MYSQL_DB: cdc_db
+        CDC_CONTAINER_NAME: cdc_application
+    
+    - name: Show CDC application logs on failure
+      if: failure()
+      run: |
+        echo "=========================================="
+        echo "CDC Application Logs (Last 200 lines)"
+        echo "=========================================="
+        docker logs cdc_application --tail 200
+    
+    - name: Show PostgreSQL logs on failure
+      if: failure()
+      run: |
+        echo "=========================================="
+        echo "PostgreSQL Logs (Last 100 lines)"
+        echo "=========================================="
+        docker logs chaos_test_postgres --tail 100
+    
+    - name: Show MySQL logs on failure
+      if: failure()
+      run: |
+        echo "=========================================="
+        echo "MySQL Logs (Last 100 lines)"
+        echo "=========================================="
+        docker logs cdc_mysql --tail 100
+    
+    - name: Show container status on failure
+      if: failure()
+      run: |
+        echo "=========================================="
+        echo "Docker Container Status"
+        echo "=========================================="
+        docker-compose -f docker-compose.chaos-test.yml ps
+        docker ps -a
+    
+    - name: Stop and remove containers
+      if: always()
+      run: |
+        echo "Cleaning up Docker containers..."
+        docker-compose -f docker-compose.chaos-test.yml down -v
+        docker volume rm chaos_test_lsn_data 2>/dev/null || true
+        docker network rm chaos_test_network 2>/dev/null || true
+        docker system prune -f
+      working-directory: .
+    
+    - name: Show disk usage
+      if: always()
+      run: |
+        df -h
+        docker system df
+
+  notify:
+    needs: chaos-integration-test
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+    - name: Test result summary
+      run: |
+        echo "=========================================="
+        echo "Chaos Integration Test Summary"
+        echo "=========================================="
+        echo "Job status: ${{ needs.chaos-integration-test.result }}"
+        if [ "${{ needs.chaos-integration-test.result }}" = "success" ]; then
+          echo "✓ All chaos integration tests passed!"
+        else
+          echo "✗ Some chaos integration tests failed."
+        fi

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ target
 #.idea/
 
 pg2any_last_lsn
+.github/instructions/*
+tests/chaos/scripts/chaos_script.log

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,7 +63,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.112",
 ]
 
 [[package]]
@@ -201,7 +201,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.112",
 ]
 
 [[package]]
@@ -246,9 +246,9 @@ checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
 name = "cc"
-version = "1.2.50"
+version = "1.2.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f50d563227a1c37cc0a263f64eca3334388c01c5e4c4861a9def205c614383c"
+checksum = "7a0aeaff4ff1a90589618835a598e545176939b97874f7abc7851caa0618f203"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -426,7 +426,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.112",
 ]
 
 [[package]]
@@ -470,7 +470,7 @@ checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.112",
 ]
 
 [[package]]
@@ -486,7 +486,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -519,9 +519,9 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
+checksum = "645cbb3a84e60b7531617d5ae4e57f7e27308f6445f5abf653209ea76dec8dff"
 
 [[package]]
 name = "flume"
@@ -577,21 +577,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
-name = "futures"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -643,7 +628,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.112",
 ]
 
 [[package]]
@@ -664,7 +649,6 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
- "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -1058,9 +1042,9 @@ checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "itoa"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ee5b5339afb4c41626dde77b7a611bd4f2c202b897852b4bcf5d03eddc61010"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "js-sys"
@@ -1122,13 +1106,13 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df15f6eac291ed1cf25865b1ee60399f57e7c227e7f51bdbd4c5270396a9ed50"
+checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
  "bitflags 2.10.0",
  "libc",
- "redox_syscall 0.6.0",
+ "redox_syscall 0.7.0",
 ]
 
 [[package]]
@@ -1350,7 +1334,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.112",
 ]
 
 [[package]]
@@ -1463,13 +1447,12 @@ dependencies = [
 
 [[package]]
 name = "pg_walstream"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "009d2cd9dc757e651ea72f6b1552dc3635619916ce870f062eb49986626998dc"
+checksum = "9bb52eb0dabb74a3a2bf4b9e2696dee90461160d36df5dd9ea5630de6146d462"
 dependencies = [
  "bytes",
  "chrono",
- "futures",
  "libpq-sys",
  "serde",
  "serde_json",
@@ -1559,9 +1542,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
+checksum = "9695f8df41bb4f3d222c95a67532365f569318332d03d5f3f67f37b20e6ebdf0"
 dependencies = [
  "unicode-ident",
 ]
@@ -1748,9 +1731,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec96166dafa0886eb81fe1c0a388bece180fbef2135f97c1e2cf8302e74b43b5"
+checksum = "49f3fe0889e69e2ae9e41f4d6c4c0181701d00e4697b356fb1f74173a5e0ee27"
 dependencies = [
  "bitflags 2.10.0",
 ]
@@ -1888,20 +1871,20 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "rustix"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
  "bitflags 2.10.0",
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1946,9 +1929,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62049b2877bf12821e8f9ad256ee38fdc31db7387ec2d3b3f403024de2034aea"
+checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
 
 [[package]]
 name = "schannel"
@@ -2021,20 +2004,20 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.112",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.145"
+version = "1.0.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+checksum = "3084b546a1dd6289475996f182a22aba973866ea8e8b02c51d9f46b1336a22da"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
  "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -2088,10 +2071,11 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.7"
+version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7664a098b8e616bdfcc2dc0e9ac44eb231eedf41db4e9fe95d8d32ec728dedad"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
+ "errno",
  "libc",
 ]
 
@@ -2216,7 +2200,7 @@ dependencies = [
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn 2.0.111",
+ "syn 2.0.112",
 ]
 
 [[package]]
@@ -2239,7 +2223,7 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn 2.0.111",
+ "syn 2.0.112",
  "tokio",
  "url",
 ]
@@ -2389,9 +2373,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.111"
+version = "2.0.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
+checksum = "21f182278bf2d2bcb3c88b1b08a37df029d71ce3d3ae26168e3c653b213b99d4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2406,7 +2390,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.112",
 ]
 
 [[package]]
@@ -2438,15 +2422,15 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.23.0"
+version = "3.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
 dependencies = [
  "fastrand",
  "getrandom 0.3.4",
  "once_cell",
- "rustix 1.1.2",
- "windows-sys 0.52.0",
+ "rustix 1.1.3",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2475,7 +2459,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.112",
 ]
 
 [[package]]
@@ -2486,7 +2470,7 @@ checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.112",
 ]
 
 [[package]]
@@ -2619,7 +2603,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.112",
 ]
 
 [[package]]
@@ -2709,7 +2693,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.112",
 ]
 
 [[package]]
@@ -2910,7 +2894,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.112",
  "wasm-bindgen-shared",
 ]
 
@@ -3019,7 +3003,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.112",
 ]
 
 [[package]]
@@ -3030,7 +3014,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.112",
 ]
 
 [[package]]
@@ -3082,6 +3066,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -3339,7 +3332,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.112",
  "synstructure",
 ]
 
@@ -3360,7 +3353,7 @@ checksum = "d8a8d209fdf45cf5138cbb5a506f6b52522a25afccc534d1475dad8e31105c6a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.112",
 ]
 
 [[package]]
@@ -3380,7 +3373,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.112",
  "synstructure",
 ]
 
@@ -3420,5 +3413,11 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.112",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aac060176f7020d62c3bcc1cdbcec619d54f48b07ad1963a3f80ce7a0c17755f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,4 +37,4 @@ hyper = { version = "1.7", features = ["full"] }
 hyper-util = { version = "0.1.16", features = ["full"] }
 http-body-util = "0.1.3"
 tikv-jemalloc-ctl = { version = "0.6.1", features = ["stats", "use_std"] }
-pg_walstream = "0.1.0"
+pg_walstream = "0.2.1"

--- a/docker-compose.chaos-test.yml
+++ b/docker-compose.chaos-test.yml
@@ -1,0 +1,90 @@
+version: '3.8'
+
+services:
+  # PostgreSQL source database
+  postgres:
+    image: postgres:15-alpine
+    container_name: cdc_postgres
+    environment:
+      POSTGRES_DB: postgres
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: test.123
+      POSTGRES_INITDB_ARGS: "--encoding=UTF8"
+    restart: always
+    ports:
+      - "5432:5432"
+    volumes:
+      - ./examples/scripts/init_postgres.sql:/docker-entrypoint-initdb.d/init_postgres.sql:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    command: >
+      postgres 
+      -c wal_level=logical 
+      -c max_replication_slots=10 
+      -c max_wal_senders=10
+      -c max_connections=100
+    networks:
+      - chaos_test_network
+
+  mysql:
+    image: mysql:8.0
+    container_name: cdc_mysql
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: test.123 
+      MYSQL_DATABASE: cdc_db
+      MYSQL_USER: cdc_user
+      MYSQL_PASSWORD: test.123
+    ports:
+      - "3306:3306"
+    volumes:
+      - ./examples/scripts/init_mysql.sql:/docker-entrypoint-initdb.d/init_mysql.sql:ro
+    command:
+      - --max_allowed_packet=536870912  # 512MB
+      - --innodb_buffer_pool_size=2GB   # Reduced for testing environment
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "cdc_user", "-ptest.123"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - chaos_test_network
+
+  cdc_app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: cdc_application
+    depends_on:
+      postgres:
+        condition: service_healthy
+      mysql:
+        condition: service_healthy
+    env_file:
+      - ./env/.env
+    environment:
+      RUST_LOG: info
+      RUST_BACKTRACE: 1
+      CDC_LAST_LSN_FILE: /app/pg2any_last_lsn.metadata
+    ports:
+      - "8080:8080"  # Metrics endpoint
+    restart: "no"
+    # Graceful shutdown timeout - critical for testing
+    stop_grace_period: 30s
+    stop_signal: SIGTERM
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health"] 
+      interval: 15s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+    networks:
+      - chaos_test_network
+
+networks:
+  chaos_test_network:
+    driver: bridge
+    name: chaos_test_network

--- a/pg2any-lib/src/app.rs
+++ b/pg2any-lib/src/app.rs
@@ -10,7 +10,7 @@ use tracing::info;
 #[cfg(feature = "metrics")]
 use crate::MetricsServer;
 use crate::{
-    client::CdcClient, config::Config, lsn_tracker::create_lsn_tracker_with_load_async, types::Lsn,
+    client::CdcClient, config::Config, lsn_tracker::create_lsn_tracker_with_load, types::Lsn,
     CdcResult,
 };
 
@@ -126,7 +126,7 @@ impl CdcApp {
         self.client.init_build_info(&self.config.version);
 
         // Create LSN tracker and load last known LSN
-        let (lsn_tracker, start_lsn) = create_lsn_tracker_with_load_async(lsn_file_path).await;
+        let (lsn_tracker, start_lsn) = create_lsn_tracker_with_load(lsn_file_path).await;
 
         // Set the LSN tracker on the client for tracking committed LSN
         self.client.set_lsn_tracker(lsn_tracker);

--- a/pg2any-lib/src/lib.rs
+++ b/pg2any-lib/src/lib.rs
@@ -84,7 +84,7 @@ pub use client::CdcClient;
 pub use config::{Config, ConfigBuilder};
 pub use env::load_config_from_env;
 pub use error::CdcError;
-pub use lsn_tracker::{create_lsn_tracker_with_load_async, LsnTracker};
+pub use lsn_tracker::{create_lsn_tracker_with_load, LsnTracker};
 pub use pg_replication::{PgReplicationConnection, ReplicationConnectionRetry, RetryConfig};
 pub type CdcResult<T> = Result<T, CdcError>;
 

--- a/pg2any-lib/src/lsn_tracker.rs
+++ b/pg2any-lib/src/lsn_tracker.rs
@@ -40,13 +40,14 @@
 //! WHERE application_name = 'pg2any';
 //! ```
 //!
-//! ## Optimization Strategy
+//! ## Persistence Strategy
 //!
-//! Instead of persisting on every commit (which causes excessive I/O), the LsnTracker:
-//! - Batches multiple commits and persists periodically (default: every 1 second)
-//! - Uses a background tokio task for non-blocking persistence
-//! - Tracks a "dirty" flag to skip unnecessary writes
-//! - Ensures graceful shutdown with final persistence
+//! The LsnTracker persists immediately after critical state changes:
+//! - After each batch execution in the consumer (explicit calls to `persist_async()`)
+//! - On shutdown for final state preservation
+//! - On error conditions for durability guarantees
+//! - Tracks a "dirty" flag to skip unnecessary writes when state hasn't changed
+//! - All persistence is explicit and immediate for data safety
 
 use crate::types::Lsn;
 use chrono::{DateTime, Utc};
@@ -54,10 +55,7 @@ use pg_walstream::format_lsn;
 use serde::{Deserialize, Serialize};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
-use tokio::task::JoinHandle;
-use tokio_util::sync::CancellationToken;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, info, warn};
 
 // Re-export SharedLsnFeedback from pg_walstream to avoid duplication
 pub use pg_walstream::SharedLsnFeedback;
@@ -212,13 +210,13 @@ impl CdcMetadata {
 /// - Consumer execution state for recovery
 /// - Timestamp information for monitoring
 ///
-/// ## Optimization Strategy
+/// ## Persistence Strategy
 ///
-/// Instead of persisting on every commit (which causes excessive I/O), this tracker:
-/// - Batches multiple commits and persists periodically (default: every 1 second)
-/// - Uses a background tokio task for non-blocking persistence
-/// - Tracks a "dirty" flag to skip unnecessary writes
-/// - Ensures graceful shutdown with final persistence
+/// This tracker persists immediately when explicitly requested:
+/// - After each batch execution in the consumer (via `persist_async()`)
+/// - On shutdown for final state preservation
+/// - On error conditions for durability guarantees
+/// - Tracks a "dirty" flag to skip unnecessary writes when state hasn't changed
 ///
 /// ## Key Design Principle
 ///
@@ -257,31 +255,11 @@ pub struct LsnTracker {
     dirty: AtomicBool,
     /// Path to the metadata persistence file
     lsn_file_path: String,
-    /// Persistence interval in milliseconds
-    interval_ms: u64,
-    /// Cancellation token for background task
-    shutdown_token: CancellationToken,
-    /// Handle to the background persistence task
-    background_task: Arc<Mutex<JoinHandle<()>>>,
 }
 
 impl LsnTracker {
-    /// Default persistence interval in milliseconds (1 second)
-    pub const DEFAULT_PERSIST_INTERVAL_MS: u64 = 1000;
-
     /// Create a new LSN tracker with the specified file path
     pub fn new(lsn_file_path: Option<&str>) -> Arc<Self> {
-        Self::new_with_interval(lsn_file_path, Self::DEFAULT_PERSIST_INTERVAL_MS)
-    }
-
-    /// Create a new LSN tracker with custom persistence interval
-    /// The background persistence task is started automatically and will run
-    /// until the provided shutdown_token is cancelled or the tracker is dropped.
-    ///
-    /// # Arguments
-    /// * `lsn_file_path` - Optional path to the LSN metadata file
-    /// * `interval_ms` - Persistence interval in milliseconds
-    pub fn new_with_interval(lsn_file_path: Option<&str>, interval_ms: u64) -> Arc<Self> {
         let mut path = lsn_file_path
             .map(String::from)
             .or_else(|| std::env::var("CDC_LAST_LSN_FILE").ok())
@@ -303,102 +281,20 @@ impl LsnTracker {
             }
         }
 
-        let interval = Duration::from_millis(interval_ms);
-        let shutdown_token = CancellationToken::new();
-        // Use Arc::new_cyclic to create the tracker and spawn the background task with a reference to the tracker in a single step
-        let tracker = Arc::new_cyclic(|weak_tracker: &std::sync::Weak<Self>| {
-            let shutdown_token_clone = shutdown_token.clone();
-
-            // Spawn the background task with a weak reference
-            let weak_tracker_clone = weak_tracker.clone();
-            let handle = tokio::spawn(async move {
-                info!(
-                    "Background LSN persistence task started (interval: {:?})",
-                    interval
-                );
-
-                loop {
-                    tokio::select! {
-                        biased;
-
-                        // Shutdown signal
-                        _ = shutdown_token_clone.cancelled() => {
-                            info!("LSN Tracker background persistence task received shutdown signal");
-                            break;
-                        }
-
-                        // Periodic persistence
-                        _ = tokio::time::sleep(interval) => {
-                            if let Some(tracker) = weak_tracker_clone.upgrade() {
-                                if tracker.dirty.load(Ordering::Acquire) {
-                                    if let Err(e) = tracker.persist_async().await {
-                                        warn!("Background persistence failed: {}", e);
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-
-                // Final persist on shutdown - force to ensure consumer position is saved
-                if let Some(tracker) = weak_tracker_clone.upgrade() {
-                    info!("Background task: Performing final forced persistence on shutdown");
-
-                    // Log state before persist
-                    let metadata = tracker.get_metadata();
-                    info!(
-                        "Final state before persist - flush_lsn={}, pending_files={}, current_file={:?}",
-                        format_lsn(metadata.lsn_tracking.flush_lsn),
-                        metadata.consumer_state.pending_file_count,
-                        metadata.consumer_state.current_file_path
-                    );
-
-                    // Force persist to save consumer position even if LSN unchanged
-                    if let Err(e) = tracker.persist_async().await {
-                        warn!("Final forced persistence on shutdown failed: {}", e);
-                    } else {
-                        let final_lsn = metadata.get_lsn();
-                        if final_lsn > 0 {
-                            info!("Final LSN persisted on shutdown: {}", format_lsn(final_lsn));
-                        }
-                    }
-                }
-
-                debug!("Background LSN persistence task stopped");
-            });
-
-            // Create the tracker with the actual handle
-            Self {
-                metadata: Arc::new(Mutex::new(CdcMetadata::default())),
-                last_persisted_lsn: AtomicU64::new(0),
-                dirty: AtomicBool::new(false),
-                lsn_file_path: path,
-                interval_ms,
-                shutdown_token,
-                background_task: Arc::new(Mutex::new(handle)),
-            }
-        });
-
-        info!(
-            "Started background LSN persistence (interval: {}ms)",
-            interval_ms
-        );
-
-        tracker
+        Arc::new(Self {
+            metadata: Arc::new(Mutex::new(CdcMetadata::default())),
+            last_persisted_lsn: AtomicU64::new(0),
+            dirty: AtomicBool::new(false),
+            lsn_file_path: path,
+        })
     }
 
-    /// Create a new LSN tracker with custom interval and load the initial value from file
-    ///
-    /// The background persistence task is started automatically.
+    /// Create a new LSN tracker and load the initial value from file
     ///
     /// # Arguments
     /// * `lsn_file_path` - Optional path to the LSN metadata file
-    /// * `interval_ms` - Persistence interval in milliseconds
-    pub async fn new_with_load_and_interval(
-        lsn_file_path: Option<&str>,
-        interval_ms: u64,
-    ) -> (Arc<Self>, Option<Lsn>) {
-        let tracker = Self::new_with_interval(lsn_file_path, interval_ms);
+    pub async fn new_with_load(lsn_file_path: Option<&str>) -> (Arc<Self>, Option<Lsn>) {
+        let tracker = Self::new(lsn_file_path);
 
         let loaded_metadata = tracker.load_from_file().await;
 
@@ -425,56 +321,24 @@ impl LsnTracker {
         }
     }
 
-    /// Shutdown the background persistence task gracefully
-    /// This ensures the final LSN is persisted before the task exits.
-    /// Should be called before dropping the tracker.
+    /// Shutdown the tracker gracefully
+    /// This ensures the final LSN is persisted before exit.
     pub async fn shutdown_async(&self) {
-        if self.shutdown_token.is_cancelled() {
-            debug!("LSN tracker already shutting down");
-            return;
+        info!("Shutting down LSN tracker");
+
+        // Force an immediate persist to ensure final state is written
+        if let Err(e) = self.persist_async().await {
+            warn!("Failed to persist on shutdown: {}", e);
+        } else {
+            info!("Final state persisted on shutdown");
         }
 
-        info!("Shutting down LSN persistence task");
-
-        // Signal the background task to shutdown
-        self.shutdown_token.cancel();
-
-        let handle = {
-            let mut task_guard = self.background_task.lock().unwrap();
-            std::mem::replace(&mut *task_guard, tokio::spawn(async {}))
-        };
-
-        debug!("Waiting for background persistence task to complete...");
-        match handle.await {
-            Ok(_) => info!("Background persistence task completed successfully"),
-            Err(e) => {
-                error!("Shutdown Async persist failed: {}", e);
-            }
-        }
-
-        // Force an immediate persist BEFORE signaling shutdown
-        // This ensures the latest state is written to disk even if the background task
-        // doesn't get a chance to run its final persist
-        if self.dirty.load(Ordering::Acquire) {
-            if let Err(e) = self.persist_async().await {
-                warn!("Failed to force persist before shutdown signal: {}", e);
-            } else {
-                info!("Pre-shutdown persist completed successfully");
-            }
-        }
-
-        info!("LSN persistence task stopped gracefully");
+        info!("LSN tracker stopped gracefully");
     }
 
     /// Synchronous shutdown for use in Drop or non-async contexts
-    /// Note: This cannot wait for async operations to complete.
     pub fn shutdown_sync(&self) {
-        if self.shutdown_token.is_cancelled() {
-            return;
-        }
-
-        info!("Initiating sync shutdown of LSN persistence");
-        self.shutdown_token.cancel();
+        info!("Initiating sync shutdown of LSN tracker");
 
         // Perform synchronous final persist
         if let Err(e) = self.persist_sync() {
@@ -548,9 +412,8 @@ impl LsnTracker {
 
     /// Update and mark LSN for persistence
     /// This should be called after each successful transaction commit to the destination.
-    /// It updates the in-memory LSN and marks it as dirty for background persistence.
-    /// Note: With background persistence enabled, this does NOT immediately persist to disk.
-    /// The background task handles periodic persistence to reduce I/O overhead.
+    /// It updates the in-memory LSN and marks it as dirty.
+    /// Note: This does NOT automatically persist to disk - caller must explicitly call `persist_async()`.
     #[inline]
     pub fn commit_lsn(&self, lsn: u64) {
         self.update_if_greater(lsn);
@@ -563,9 +426,10 @@ impl LsnTracker {
         timestamp: DateTime<Utc>,
         pending_count: usize,
     ) {
-        let mut metadata = self.metadata.lock().unwrap();
-        metadata.update_consumer_state(tx_id, timestamp, pending_count);
-        drop(metadata);
+        {
+            let mut metadata = self.metadata.lock().unwrap();
+            metadata.update_consumer_state(tx_id, timestamp, pending_count);
+        }
         self.dirty.store(true, Ordering::Release);
         debug!(
             "Updated consumer state: tx_id={}, pending_count={}",
@@ -576,9 +440,10 @@ impl LsnTracker {
     /// Update consumer position within a transaction file
     /// Call this after each successful batch execution to enable fine-grained recovery
     pub fn update_consumer_position(&self, file_path: String, last_executed_command_index: usize) {
-        let mut metadata = self.metadata.lock().unwrap();
-        metadata.update_consumer_position(file_path.clone(), last_executed_command_index);
-        drop(metadata);
+        {
+            let mut metadata = self.metadata.lock().unwrap();
+            metadata.update_consumer_position(file_path.clone(), last_executed_command_index);
+        }
         self.dirty.store(true, Ordering::Release);
         debug!(
             "Updated consumer position: file={}, command_index={}",
@@ -586,13 +451,76 @@ impl LsnTracker {
         );
     }
 
+    /// Update consumer position AND persist immediately in one atomic operation
+    ///
+    /// This method is designed to prevent data inconsistency during graceful shutdown.
+    /// It combines the position update with immediate persistence to eliminate the
+    /// race condition where:
+    /// 1. DB transaction commits
+    /// 2. Position updated in memory
+    /// 3. **SIGTERM arrives before persist_async() is called**
+    /// 4. On restart: old position → duplicate replay
+    ///
+    /// By persisting immediately after position update, we ensure the tracking file
+    /// reflects the actual state of committed data in the destination database.
+    ///
+    /// # Arguments
+    /// * `file_path` - Path to the transaction file being processed
+    /// * `last_executed_command_index` - 0-based index of the last executed command
+    ///
+    /// # Returns
+    /// * `Ok(())` - Position updated and persisted successfully
+    /// * `Err(io::Error)` - Persistence failed (position still updated in memory)
+    pub async fn update_consumer_position_and_persist_immediately(
+        &self,
+        file_path: String,
+        last_executed_command_index: usize,
+    ) -> std::io::Result<()> {
+        // Update position in memory
+        {
+            let mut metadata = self.metadata.lock().unwrap();
+            metadata.update_consumer_position(file_path.clone(), last_executed_command_index);
+        }
+        self.dirty.store(true, Ordering::Release);
+
+        // CRITICAL: Immediately persist to disk to prevent race condition
+        self.persist_internal().await?;
+
+        Ok(())
+    }
+
     /// Clear consumer position when a file is fully processed
     pub fn clear_consumer_position(&self) {
-        let mut metadata = self.metadata.lock().unwrap();
-        metadata.clear_consumer_position();
-        drop(metadata);
+        {
+            let mut metadata = self.metadata.lock().unwrap();
+            metadata.clear_consumer_position();
+        }
         self.dirty.store(true, Ordering::Release);
         debug!("Cleared consumer position after file completion");
+    }
+
+    /// Clear consumer position AND persist immediately in one atomic operation
+    ///
+    /// Used when a transaction file is fully processed to ensure the cleared
+    /// state is immediately written to disk.
+    ///
+    /// # Returns
+    /// * `Ok(())` - Position cleared and persisted successfully
+    /// * `Err(io::Error)` - Persistence failed (position still cleared in memory)
+    pub async fn clear_consumer_position_and_persist_immediately(&self) -> std::io::Result<()> {
+        // Clear position in memory
+        {
+            let mut metadata = self.metadata.lock().unwrap();
+            metadata.clear_consumer_position();
+        }
+        self.dirty.store(true, Ordering::Release);
+
+        // CRITICAL: Immediately persist to disk
+        self.persist_async().await?;
+
+        debug!("Atomically cleared and persisted consumer position");
+
+        Ok(())
     }
 
     /// Get the resume position for recovery
@@ -633,13 +561,7 @@ impl LsnTracker {
         self.persist_internal().await
     }
 
-    // / Force persist the current metadata to file, bypassing LSN comparison checks
-    // / This is useful for saving consumer position updates during shutdown
-    // pub async fn persist_async_force(&self) -> std::io::Result<()> {
-    //     self.persist_internal(true).await
-    // }
-
-    /// Internal persist implementation that updates the persisted LSN tracker
+    /// Internal persist implementation
     async fn persist_internal(&self) -> std::io::Result<()> {
         let metadata = {
             let m = self.metadata.lock().unwrap();
@@ -708,37 +630,18 @@ impl LsnTracker {
         &self.lsn_file_path
     }
 
-    /// Get the persistence interval in milliseconds
-    pub fn interval_ms(&self) -> u64 {
-        self.interval_ms
-    }
-
     /// Check if there are pending changes to persist
     pub fn is_dirty(&self) -> bool {
         self.dirty.load(Ordering::Acquire)
     }
 }
 
-impl Drop for LsnTracker {
-    fn drop(&mut self) {
-        // Ensure graceful shutdown on drop
-        self.shutdown_sync();
-    }
-}
-
-/// Create a shared LSN tracker with initial load from file
-///
-/// The background persistence task is started automatically.
-/// The returned `Arc<LsnTracker>` should be used throughout the application lifecycle.
-/// Background persistence will be stopped when the shutdown_token is cancelled.
-///
-/// # Arguments
-/// * `lsn_file_path` - Optional path to the LSN metadata file
-pub async fn create_lsn_tracker_with_load_async(
+/// Helper function to create a tracker with loaded LSN value
+/// This is a convenience wrapper for the most common usage pattern.
+pub async fn create_lsn_tracker_with_load(
     lsn_file_path: Option<&str>,
 ) -> (Arc<LsnTracker>, Option<Lsn>) {
-    LsnTracker::new_with_load_and_interval(lsn_file_path, LsnTracker::DEFAULT_PERSIST_INTERVAL_MS)
-        .await
+    LsnTracker::new_with_load(lsn_file_path).await
 }
 
 #[cfg(test)]
@@ -747,88 +650,90 @@ mod lsn_tracker_tests {
 
     #[tokio::test]
     async fn test_lsn_tracker_new() {
-        let tracker = LsnTracker::new_with_interval(Some("/tmp/test_lsn_new"), 60000);
+        let tracker = LsnTracker::new(Some("/tmp/test_lsn"));
         assert_eq!(tracker.get(), 0);
-        assert_eq!(tracker.file_path(), "/tmp/test_lsn_new.metadata");
-        assert_eq!(tracker.interval_ms(), 60000);
-    }
-
-    #[tokio::test]
-    async fn test_lsn_tracker_update_if_greater() {
-        let tracker = LsnTracker::new_with_interval(Some("/tmp/test_lsn_update"), 60000);
-
-        tracker.update_if_greater(100);
-        assert_eq!(tracker.get(), 100);
-        assert!(tracker.is_dirty());
-
-        // Should not update with smaller value
-        tracker.update_if_greater(50);
-        assert_eq!(tracker.get(), 100);
-
-        // Should update with larger value
-        tracker.update_if_greater(150);
-        assert_eq!(tracker.get(), 150);
-
-        // Should ignore zero
-        tracker.update_if_greater(0);
-        assert_eq!(tracker.get(), 150);
+        assert_eq!(tracker.file_path(), "/tmp/test_lsn.metadata");
     }
 
     #[tokio::test]
     async fn test_lsn_tracker_get_lsn() {
-        let tracker = LsnTracker::new_with_interval(Some("/tmp/test_lsn_get"), 60000);
-
-        assert_eq!(tracker.get_lsn(), None);
-
-        tracker.update_if_greater(100);
-        assert_eq!(tracker.get_lsn(), Some(Lsn(100)));
+        let tracker = LsnTracker::new(Some("/tmp/test_lsn_get_lsn"));
+        tracker.commit_lsn(100);
+        let lsn = tracker.get_lsn();
+        assert_eq!(lsn, Some(Lsn(100)));
     }
 
     #[tokio::test]
-    async fn test_commit_lsn_marks_dirty() {
-        let tracker = LsnTracker::new_with_interval(Some("/tmp/test_lsn_commit"), 60000);
-        assert!(!tracker.is_dirty());
+    async fn test_lsn_tracker_update_if_greater() {
+        let tracker = LsnTracker::new(Some("/tmp/test_lsn_update_if_greater"));
 
-        tracker.commit_lsn(100);
+        tracker.update_if_greater(100);
         assert_eq!(tracker.get(), 100);
-        assert!(tracker.is_dirty());
+
+        // Smaller value should be ignored
+        tracker.update_if_greater(50);
+        assert_eq!(tracker.get(), 100);
+
+        // Greater value should update
+        tracker.update_if_greater(200);
+        assert_eq!(tracker.get(), 200);
+    }
+
+    #[tokio::test]
+    async fn test_zero_lsn_ignored() {
+        let tracker = LsnTracker::new(Some("/tmp/test_lsn_zero"));
+
+        tracker.update_if_greater(100);
+        tracker.update_if_greater(0); // Should be ignored
+
+        assert_eq!(tracker.get(), 100);
     }
 
     #[tokio::test]
     async fn test_persist_async() {
         let path = "/tmp/test_lsn_persist_async";
-        let metadata_path = format!("{}.metadata", path);
-        let tracker = LsnTracker::new_with_interval(Some(path), 60000);
+        let _ = std::fs::remove_file(format!("{}.metadata", path));
 
-        tracker.commit_lsn(12345678);
-        assert!(tracker.is_dirty());
-
+        let tracker = LsnTracker::new(Some(path));
+        tracker.commit_lsn(12345);
         tracker.persist_async().await.unwrap();
 
-        // After persist, dirty flag should be cleared
-        assert!(!tracker.is_dirty());
+        // Read back the file
+        let content = tokio::fs::read_to_string(format!("{}.metadata", path))
+            .await
+            .unwrap();
+        let metadata: CdcMetadata = serde_json::from_str(&content).unwrap();
+        assert_eq!(metadata.lsn_tracking.flush_lsn, 12345);
 
-        // Verify file contents - should be JSON
-        let contents = tokio::fs::read_to_string(&metadata_path).await.unwrap();
-        assert!(!contents.is_empty());
-        assert!(contents.contains("version"));
-        assert!(contents.contains("lsn_tracking"));
-
-        // Cleanup
-        let _ = tokio::fs::remove_file(&metadata_path).await;
+        // Clean up
+        let _ = std::fs::remove_file(format!("{}.metadata", path));
     }
 
     #[tokio::test]
     async fn test_persist_skips_when_not_dirty() {
-        let path = "/tmp/test_lsn_skip_persist";
-        let tracker = LsnTracker::new_with_interval(Some(path), 60000);
+        let path = "/tmp/test_lsn_persist_skip";
+        let _ = std::fs::remove_file(format!("{}.metadata", path));
 
-        tracker.commit_lsn(100);
+        let tracker = LsnTracker::new(Some(path));
+        tracker.commit_lsn(12345);
         tracker.persist_async().await.unwrap();
 
-        // Persist again without changes - should skip
+        // Second persist should be skipped (not dirty)
         let result = tracker.persist_async().await;
         assert!(result.is_ok());
+
+        // Clean up
+        let _ = std::fs::remove_file(format!("{}.metadata", path));
+    }
+
+    #[tokio::test]
+    async fn test_commit_lsn_marks_dirty() {
+        let tracker = LsnTracker::new(Some("/tmp/test_lsn_dirty"));
+
+        assert!(!tracker.is_dirty());
+
+        tracker.commit_lsn(100);
+        assert!(tracker.is_dirty());
     }
 
     #[tokio::test]
@@ -836,45 +741,49 @@ mod lsn_tracker_tests {
         let path = "/tmp/test_lsn_load";
         let metadata_path = format!("{}.metadata", path);
 
-        // Write test JSON metadata
-        let test_metadata = CdcMetadata {
+        // Create a metadata file
+        let metadata = CdcMetadata {
             version: "1.0".to_string(),
             last_updated: Utc::now(),
-            lsn_tracking: LsnTracking {
-                flush_lsn: 11259375,
-            },
+            lsn_tracking: LsnTracking { flush_lsn: 54321 },
             consumer_state: ConsumerState {
-                last_processed_tx_id: None,
-                last_processed_timestamp: None,
-                pending_file_count: 0,
+                last_processed_tx_id: Some(999),
+                last_processed_timestamp: Some(Utc::now()),
+                pending_file_count: 5,
                 current_file_path: None,
                 last_executed_command_index: None,
             },
         };
-        let json = serde_json::to_string_pretty(&test_metadata).unwrap();
+
+        let json = serde_json::to_string_pretty(&metadata).unwrap();
         tokio::fs::write(&metadata_path, json).await.unwrap();
 
-        let tracker = LsnTracker::new_with_interval(Some(path), 60000);
+        // Load it
+        let tracker = LsnTracker::new(Some(path));
         let loaded = tracker.load_from_file().await;
 
         assert!(loaded.is_some());
-        let metadata = loaded.unwrap();
-        assert_eq!(metadata.lsn_tracking.flush_lsn, 11259375);
+        let loaded_metadata = loaded.unwrap();
+        assert_eq!(loaded_metadata.lsn_tracking.flush_lsn, 54321);
+        assert_eq!(
+            loaded_metadata.consumer_state.last_processed_tx_id,
+            Some(999)
+        );
 
-        // Cleanup
-        let _ = tokio::fs::remove_file(&metadata_path).await;
+        // Clean up
+        let _ = std::fs::remove_file(metadata_path);
     }
 
     #[tokio::test]
     async fn test_new_with_load() {
-        let path = "/tmp/test_lsn_with_load";
+        let path = "/tmp/test_lsn_new_with_load";
         let metadata_path = format!("{}.metadata", path);
 
-        // Write test JSON metadata
-        let test_metadata = CdcMetadata {
+        // Create a metadata file
+        let metadata = CdcMetadata {
             version: "1.0".to_string(),
             last_updated: Utc::now(),
-            lsn_tracking: LsnTracking { flush_lsn: 1193046 },
+            lsn_tracking: LsnTracking { flush_lsn: 67890 },
             consumer_state: ConsumerState {
                 last_processed_tx_id: None,
                 last_processed_timestamp: None,
@@ -883,227 +792,108 @@ mod lsn_tracker_tests {
                 last_executed_command_index: None,
             },
         };
-        let json = serde_json::to_string_pretty(&test_metadata).unwrap();
+
+        let json = serde_json::to_string_pretty(&metadata).unwrap();
         tokio::fs::write(&metadata_path, json).await.unwrap();
 
-        let (tracker, lsn) = LsnTracker::new_with_load_and_interval(Some(path), 1000).await;
+        // Load using new_with_load
+        let (tracker, loaded_lsn) = LsnTracker::new_with_load(Some(path)).await;
 
-        assert!(lsn.is_some());
-        assert_eq!(tracker.get(), 1193046);
+        assert_eq!(loaded_lsn, Some(Lsn(67890)));
+        assert_eq!(tracker.get(), 67890);
 
-        // Cleanup
-        let _ = tokio::fs::remove_file(&metadata_path).await;
+        // Clean up
+        let _ = std::fs::remove_file(metadata_path);
     }
 
     #[tokio::test]
-    async fn test_background_persistence_with_shutdown() {
-        let path = "/tmp/test_lsn_bg_shutdown";
-        let metadata_path = format!("{}.metadata", path);
+    async fn test_metadata_extension_not_present() {
+        let tracker = LsnTracker::new(Some("/tmp/test_lsn_no_ext"));
+        assert!(tracker.file_path().ends_with(".metadata"));
+    }
 
-        // Create tracker with short interval for testing
-        let arc_tracker = LsnTracker::new_with_interval(Some(path), 100);
+    #[tokio::test]
+    async fn test_metadata_extension_already_present() {
+        let tracker = LsnTracker::new(Some("/tmp/test_lsn.metadata"));
+        // Should not double-add the extension
+        assert_eq!(tracker.file_path().matches(".metadata").count(), 1);
+    }
 
-        // Commit some LSNs
-        arc_tracker.commit_lsn(100);
-        arc_tracker.commit_lsn(200);
-        arc_tracker.commit_lsn(300);
+    #[tokio::test]
+    async fn test_shared_across_threads() {
+        let tracker = LsnTracker::new(Some("/tmp/test_lsn_threads"));
+        let tracker_clone = tracker.clone();
 
-        // Wait a bit for background task to persist
-        tokio::time::sleep(Duration::from_millis(200)).await;
+        let handle = tokio::spawn(async move {
+            tracker_clone.commit_lsn(12345);
+        });
 
-        // Commit final LSN
-        arc_tracker.commit_lsn(400);
-
-        // Shutdown gracefully - this should persist the final LSN
-        arc_tracker.shutdown_async().await;
-
-        // Verify final LSN was persisted
-        let contents = tokio::fs::read_to_string(&metadata_path).await.unwrap();
-        assert!(!contents.is_empty());
-
-        // Load from file to verify
-        let (new_tracker, loaded_lsn) =
-            LsnTracker::new_with_load_and_interval(Some(path), 1000).await;
-        assert!(loaded_lsn.is_some());
-        assert_eq!(new_tracker.get(), 400);
-
-        // Cleanup
-        let _ = tokio::fs::remove_file(&metadata_path).await;
+        handle.await.unwrap();
+        assert_eq!(tracker.get(), 12345);
     }
 
     #[tokio::test]
     async fn test_shutdown_without_background_task() {
-        let path = "/tmp/test_lsn_no_bg_shutdown";
-        let metadata_path = format!("{}.metadata", path);
-        let tracker = LsnTracker::new_with_interval(Some(path), 60000);
+        let path = "/tmp/test_lsn_shutdown_simple";
+        let _ = std::fs::remove_file(format!("{}.metadata", path));
 
-        // Commit LSN (background task is already running from new_with_interval)
-        tracker.commit_lsn(999);
+        let tracker = LsnTracker::new(Some(path));
+        tracker.commit_lsn(99999);
 
-        // Shutdown should still persist
+        // Shutdown should persist
         tracker.shutdown_async().await;
 
-        // Verify LSN was persisted
-        let contents = tokio::fs::read_to_string(&metadata_path).await.unwrap();
-        assert!(!contents.is_empty());
+        // Verify file was written
+        let content = tokio::fs::read_to_string(format!("{}.metadata", path))
+            .await
+            .unwrap();
+        let metadata: CdcMetadata = serde_json::from_str(&content).unwrap();
+        assert_eq!(metadata.lsn_tracking.flush_lsn, 99999);
 
-        let (new_tracker, loaded_lsn) =
-            LsnTracker::new_with_load_and_interval(Some(path), 1000).await;
-        assert!(loaded_lsn.is_some());
-        assert_eq!(new_tracker.get(), 999);
-
-        // Cleanup
-        let _ = tokio::fs::remove_file(&metadata_path).await;
+        // Clean up
+        let _ = std::fs::remove_file(format!("{}.metadata", path));
     }
 
     #[tokio::test]
     async fn test_double_shutdown_is_safe() {
-        let path = "/tmp/test_lsn_double_shutdown";
-        let metadata_path = format!("{}.metadata", path);
-        let (arc_tracker, _) = LsnTracker::new_with_load_and_interval(Some(path), 1000).await;
-
-        arc_tracker.commit_lsn(555);
-
-        // First shutdown
-        arc_tracker.shutdown_async().await;
-
-        // Second shutdown should be safe (no-op)
-        arc_tracker.shutdown_async().await;
-
-        // Cleanup
-        let _ = tokio::fs::remove_file(&metadata_path).await;
+        let tracker = LsnTracker::new(Some("/tmp/test_lsn_double_shutdown"));
+        tracker.shutdown_async().await;
+        // Second shutdown should be safe
+        tracker.shutdown_async().await;
     }
 
+    // Shared LSN Feedback tests
     #[test]
     fn test_shared_lsn_feedback_new() {
-        let feedback = SharedLsnFeedback::new();
+        let feedback = SharedLsnFeedback::new_shared();
         assert_eq!(feedback.get_flushed_lsn(), 0);
         assert_eq!(feedback.get_applied_lsn(), 0);
     }
 
     #[test]
     fn test_update_flushed_lsn() {
-        let feedback = SharedLsnFeedback::new();
-
+        let feedback = SharedLsnFeedback::new_shared();
         feedback.update_flushed_lsn(100);
         assert_eq!(feedback.get_flushed_lsn(), 100);
-
-        // Should not update with smaller value
-        feedback.update_flushed_lsn(50);
-        assert_eq!(feedback.get_flushed_lsn(), 100);
-
-        // Should update with larger value
-        feedback.update_flushed_lsn(200);
-        assert_eq!(feedback.get_flushed_lsn(), 200);
     }
 
     #[test]
     fn test_update_applied_lsn() {
-        let feedback = SharedLsnFeedback::new();
-
-        feedback.update_applied_lsn(100);
-        assert_eq!(feedback.get_applied_lsn(), 100);
-        // Applied also updates flushed
-        assert_eq!(feedback.get_flushed_lsn(), 100);
-
-        // Should not update with smaller value
-        feedback.update_applied_lsn(50);
-        assert_eq!(feedback.get_applied_lsn(), 100);
+        let feedback = SharedLsnFeedback::new_shared();
+        feedback.update_applied_lsn(200);
+        assert_eq!(feedback.get_applied_lsn(), 200);
     }
 
     #[test]
     fn test_get_feedback_lsn() {
-        let feedback = SharedLsnFeedback::new();
+        let feedback = SharedLsnFeedback::new_shared();
+        feedback.update_flushed_lsn(150);
+        feedback.update_applied_lsn(200);
 
-        feedback.update_flushed_lsn(100);
-        feedback.update_applied_lsn(50);
-
+        // get_feedback_lsn returns a tuple (flushed, applied)
+        // Both update to the max value seen
         let (flushed, applied) = feedback.get_feedback_lsn();
-        assert_eq!(flushed, 100);
-        assert_eq!(applied, 50);
-    }
-
-    #[test]
-    fn test_zero_lsn_ignored() {
-        let feedback = SharedLsnFeedback::new();
-        feedback.update_flushed_lsn(100);
-        feedback.update_applied_lsn(100);
-
-        // Zero should be ignored
-        feedback.update_flushed_lsn(0);
-        feedback.update_applied_lsn(0);
-
-        assert_eq!(feedback.get_flushed_lsn(), 100);
-        assert_eq!(feedback.get_applied_lsn(), 100);
-    }
-
-    #[test]
-    fn test_shared_across_threads() {
-        use std::thread;
-
-        let feedback = Arc::new(SharedLsnFeedback::new());
-        let feedback_clone = feedback.clone();
-
-        let handle = thread::spawn(move || {
-            for i in 1..=100 {
-                feedback_clone.update_applied_lsn(i);
-            }
-        });
-
-        handle.join().unwrap();
-
-        assert_eq!(feedback.get_applied_lsn(), 100);
-        assert_eq!(feedback.get_flushed_lsn(), 100);
-    }
-
-    #[tokio::test]
-    async fn test_metadata_extension_already_present() {
-        // Test that if path already has .metadata extension, it doesn't add another one
-        let path_with_extension = "/tmp/test_lsn_with_ext.metadata";
-        let tracker = LsnTracker::new_with_interval(Some(path_with_extension), 60000);
-
-        // Should not add .metadata.metadata
-        assert_eq!(tracker.file_path(), "/tmp/test_lsn_with_ext.metadata");
-        assert!(!tracker.file_path().ends_with(".metadata.metadata"));
-
-        // Test persistence works correctly
-        tracker.commit_lsn(12345);
-        tracker.persist_async().await.unwrap();
-
-        // Verify file was created at correct location
-        let contents = tokio::fs::read_to_string("/tmp/test_lsn_with_ext.metadata")
-            .await
-            .unwrap();
-        assert!(contents.contains("lsn_tracking"));
-
-        // Cleanup
-        let _ = tokio::fs::remove_file("/tmp/test_lsn_with_ext.metadata").await;
-    }
-
-    #[tokio::test]
-    async fn test_metadata_extension_not_present() {
-        // Test that if path doesn't have .metadata extension, it adds it
-        let path_without_extension = "/tmp/test_lsn_without_ext";
-        let tracker = LsnTracker::new_with_interval(Some(path_without_extension), 60000);
-
-        // Should add .metadata
-        assert_eq!(tracker.file_path(), "/tmp/test_lsn_without_ext.metadata");
-        assert!(tracker.file_path().ends_with(".metadata"));
-
-        // Test persistence works correctly
-        tracker.commit_lsn(54321);
-        tracker.persist_async().await.unwrap();
-
-        // Verify file was created at correct location
-        let contents = tokio::fs::read_to_string("/tmp/test_lsn_without_ext.metadata")
-            .await
-            .unwrap();
-        assert!(contents.contains("lsn_tracking"));
-
-        // Shutdown gracefully
-        tracker.shutdown_async().await;
-
-        // Cleanup
-        let _ = tokio::fs::remove_file("/tmp/test_lsn_without_ext.metadata").await;
+        assert_eq!(flushed, 200);
+        assert_eq!(applied, 200);
     }
 }

--- a/pg2any-lib/src/monitoring/metrics_abstraction.rs
+++ b/pg2any-lib/src/monitoring/metrics_abstraction.rs
@@ -289,7 +289,7 @@ mod real_metrics {
         fn get_metrics(&self) -> CdcResult<String> {
             use prometheus::Encoder;
             let encoder = prometheus::TextEncoder::new();
-            let metric_families = REGISTRY.gather();
+            let metric_families = prometheus::default_registry().gather();
             let mut buffer = Vec::new();
             encoder
                 .encode(&metric_families, &mut buffer)

--- a/pg2any-lib/src/pg_replication.rs
+++ b/pg2any-lib/src/pg_replication.rs
@@ -60,7 +60,7 @@ impl ReplicationStream {
     pub async fn next_event(
         &mut self,
         cancellation_token: &CancellationToken,
-    ) -> Result<Option<ChangeEvent>> {
+    ) -> Result<ChangeEvent> {
         debug!("Fetching next single change event with retry support and cancellation");
 
         let event = self
@@ -69,11 +69,7 @@ impl ReplicationStream {
             .await
             .map_err(|e| crate::error::CdcError::Replication(e))?;
 
-        if let Some(ref event) = event {
-            debug!("Received single change event: {:?}", event);
-            // Update last received LSN
-            self.logical_stream.state.update_lsn(event.lsn.value());
-        }
+        self.logical_stream.state.update_lsn(event.lsn.value());
 
         Ok(event)
     }

--- a/pg2any-lib/tests/position_tracking_tests.rs
+++ b/pg2any-lib/tests/position_tracking_tests.rs
@@ -25,7 +25,7 @@ mod position_tracking_tests {
     async fn test_update_consumer_position() {
         let lsn_file = get_test_file_path("update_position");
 
-        let tracker = LsnTracker::new_with_interval(Some(&lsn_file), 100);
+        let tracker = LsnTracker::new(Some(&lsn_file));
 
         // Update position
         tracker.update_consumer_position(
@@ -52,7 +52,7 @@ mod position_tracking_tests {
     async fn test_get_resume_position() {
         let lsn_file = get_test_file_path("resume_position");
 
-        let tracker = LsnTracker::new_with_interval(Some(&lsn_file), 100);
+        let tracker = LsnTracker::new(Some(&lsn_file));
 
         // Update position to command 499 (0-indexed)
         tracker.update_consumer_position("/path/to/file.meta".to_string(), 499);
@@ -73,7 +73,7 @@ mod position_tracking_tests {
     async fn test_clear_consumer_position() {
         let lsn_file = get_test_file_path("clear_position");
 
-        let tracker = LsnTracker::new_with_interval(Some(&lsn_file), 100);
+        let tracker = LsnTracker::new(Some(&lsn_file));
 
         // Set position
         tracker.update_consumer_position("/path/to/file.meta".to_string(), 499);
@@ -99,7 +99,7 @@ mod position_tracking_tests {
 
         // First session: save position
         {
-            let tracker = LsnTracker::new_with_interval(Some(&lsn_file), 100);
+            let tracker = LsnTracker::new(Some(&lsn_file));
             tracker.update_consumer_position("/path/to/transaction_123.meta".to_string(), 2499);
             tracker.commit_lsn(123456789);
 
@@ -108,8 +108,7 @@ mod position_tracking_tests {
 
         // Second session: load position
         {
-            let (tracker, lsn) =
-                LsnTracker::new_with_load_and_interval(Some(&lsn_file), 1000).await;
+            let (tracker, lsn) = LsnTracker::new_with_load(Some(&lsn_file)).await;
 
             // Verify LSN was restored
             assert!(lsn.is_some());
@@ -133,7 +132,7 @@ mod position_tracking_tests {
     async fn test_position_at_file_boundary() {
         let lsn_file = get_test_file_path("boundary");
 
-        let tracker = LsnTracker::new_with_interval(Some(&lsn_file), 100);
+        let tracker = LsnTracker::new(Some(&lsn_file));
 
         // Simulate processing all commands (last_executed = total - 1)
         tracker.update_consumer_position(
@@ -175,7 +174,7 @@ mod position_tracking_tests {
         fs::write(&metadata_file, json).await.unwrap();
 
         // Load with new tracker
-        let (tracker, lsn) = LsnTracker::new_with_load_and_interval(Some(&lsn_file), 1000).await;
+        let (tracker, lsn) = LsnTracker::new_with_load(Some(&lsn_file)).await;
 
         // Verify LSN was loaded
         assert!(lsn.is_some());
@@ -193,7 +192,7 @@ mod position_tracking_tests {
     async fn test_position_update_sequence() {
         let lsn_file = get_test_file_path("sequence");
 
-        let tracker = LsnTracker::new_with_interval(Some(&lsn_file), 100);
+        let tracker = LsnTracker::new(Some(&lsn_file));
 
         // Simulate processing batches of 100 commands
         let file_path = "/path/to/file.meta".to_string();
@@ -228,7 +227,7 @@ mod position_tracking_tests {
     async fn test_multiple_files_with_position() {
         let lsn_file = get_test_file_path("multiple_files");
 
-        let tracker = LsnTracker::new_with_interval(Some(&lsn_file), 100);
+        let tracker = LsnTracker::new(Some(&lsn_file));
 
         // Process file 1 completely
         tracker.update_consumer_position("/path/to/file1.meta".to_string(), 999);
@@ -253,7 +252,7 @@ mod position_tracking_tests {
     async fn test_position_with_single_command_file() {
         let lsn_file = get_test_file_path("single_command");
 
-        let tracker = LsnTracker::new_with_interval(Some(&lsn_file), 100);
+        let tracker = LsnTracker::new(Some(&lsn_file));
 
         // File with single command
         tracker.update_consumer_position("/path/to/single.meta".to_string(), 0);
@@ -271,7 +270,7 @@ mod position_tracking_tests {
     async fn test_position_dirty_flag() {
         let lsn_file = get_test_file_path("dirty_flag");
 
-        let tracker = LsnTracker::new_with_interval(Some(&lsn_file), 10000); // Long interval
+        let tracker = LsnTracker::new(Some(&lsn_file)); // Long interval
 
         // Initially not dirty
         assert!(!tracker.is_dirty());

--- a/tests/chaos/scenarios/input/scenario1_input.sql
+++ b/tests/chaos/scenarios/input/scenario1_input.sql
@@ -1,0 +1,17 @@
+-- Scenario 1: Basic INSERT operations
+-- This scenario tests basic insert replication under chaos conditions
+
+-- Insert 100 records with random data
+DO $$
+DECLARE 
+    i INT;
+BEGIN
+    FOR i IN 1..100 LOOP
+        INSERT INTO public.t1 (val, col1, col2)
+        VALUES (
+            floor(random() * 1000000)::int,
+            md5(random()::text || clock_timestamp()::text)::uuid,
+            md5(random()::text || clock_timestamp()::text)::uuid
+        );
+    END LOOP;
+END $$;

--- a/tests/chaos/scenarios/input/scenario2_input.sql
+++ b/tests/chaos/scenarios/input/scenario2_input.sql
@@ -1,0 +1,21 @@
+-- Scenario 2: UPDATE operations
+-- This scenario tests update replication with chaos
+
+-- First, insert some baseline records
+DO $$
+DECLARE 
+    i INT;
+BEGIN
+    FOR i IN 1..50 LOOP
+        INSERT INTO public.t1 (val, col1, col2)
+        VALUES (
+            floor(random() * 1000000)::int,
+            md5(random()::text || clock_timestamp()::text)::uuid,
+            md5(random()::text || clock_timestamp()::text)::uuid
+        );
+    END LOOP;
+END $$;
+
+-- Update records with a specific pattern
+UPDATE public.t1 
+SET val = val + 10000;

--- a/tests/chaos/scenarios/input/scenario3_input.sql
+++ b/tests/chaos/scenarios/input/scenario3_input.sql
@@ -1,0 +1,15 @@
+-- Scenario 3: DELETE operations
+-- This scenario tests delete replication with chaos
+
+BEGIN;
+    INSERT INTO T1
+    SELECT i,
+        RANDOM() * 1000000,
+            md5(random()::text || clock_timestamp()::text)::uuid,
+            md5(random()::text || clock_timestamp()::text)::uuid
+    FROM generate_series(1,300000) i;
+COMMIT;
+
+
+-- Delete records with specific condition
+DELETE FROM public.t1 WHERE id <= 250000;

--- a/tests/chaos/scenarios/input/scenario4_input.sql
+++ b/tests/chaos/scenarios/input/scenario4_input.sql
@@ -1,0 +1,60 @@
+-- Scenario 4: Mixed operations (INSERT, UPDATE, DELETE)
+-- This scenario tests complex transaction patterns under chaos
+
+-- Insert batch 1
+DO $$
+DECLARE 
+    i INT;
+BEGIN
+    FOR i IN 1..30 LOOP
+        INSERT INTO public.t1 (val, col1, col2)
+        VALUES (
+            floor(random() * 1000000)::int,
+            md5(random()::text || clock_timestamp()::text)::uuid,
+            md5(random()::text || clock_timestamp()::text)::uuid
+        );
+    END LOOP;
+END $$;
+
+SELECT pg_sleep(1);
+
+-- Update some records
+UPDATE public.t1 
+SET val = 999999
+WHERE val > 800000;
+
+SELECT pg_sleep(1);
+
+-- Insert batch 2
+DO $$
+DECLARE 
+    i INT;
+BEGIN
+    FOR i IN 1..20 LOOP
+        INSERT INTO public.t1 (val, col1, col2)
+        VALUES (
+            floor(random() * 1000000)::int,
+            md5(random()::text || clock_timestamp()::text)::uuid,
+            md5(random()::text || clock_timestamp()::text)::uuid
+        );
+    END LOOP;
+END $$;
+
+
+-- Delete some records
+DELETE FROM public.t1 WHERE val < 100000;
+
+-- Final insert
+DO $$
+DECLARE 
+    i INT;
+BEGIN
+    FOR i IN 1..10 LOOP
+        INSERT INTO public.t1 (val, col1, col2)
+        VALUES (
+            floor(random() * 1000000)::int,
+            md5(random()::text || clock_timestamp()::text)::uuid,
+            md5(random()::text || clock_timestamp()::text)::uuid
+        );
+    END LOOP;
+END $$;

--- a/tests/chaos/scenarios/input/scenario5_input.sql
+++ b/tests/chaos/scenarios/input/scenario5_input.sql
@@ -1,0 +1,8 @@
+BEGIN;
+    INSERT INTO T1
+    SELECT i,
+        RANDOM() * 1000000,
+            md5(random()::text || clock_timestamp()::text)::uuid,
+            md5(random()::text || clock_timestamp()::text)::uuid
+    FROM generate_series(1,2000000) i;
+COMMIT;

--- a/tests/chaos/scenarios/verify/scenario1_verify.sql
+++ b/tests/chaos/scenarios/verify/scenario1_verify.sql
@@ -1,0 +1,9 @@
+-- Scenario 1: Verification - Check if 100 records were replicated
+SELECT 
+    CASE 
+        WHEN COUNT(*) = 100 THEN 'PASS'
+        ELSE 'FAIL'
+    END AS test_result,
+    COUNT(*) AS actual_count,
+    100 AS expected_count
+FROM cdc_db.t1;

--- a/tests/chaos/scenarios/verify/scenario2_verify.sql
+++ b/tests/chaos/scenarios/verify/scenario2_verify.sql
@@ -1,0 +1,10 @@
+-- Scenario 2: Verification - Check if updates were replicated
+-- Count records where val >= 10000 (updated records)
+SELECT 
+    CASE 
+        WHEN COUNT(*) = 50 THEN 'PASS'
+        ELSE 'FAIL'
+    END AS test_result,
+    COUNT(*) AS updated_count
+FROM cdc_db.t1
+WHERE val >= 10000;

--- a/tests/chaos/scenarios/verify/scenario3_verify.sql
+++ b/tests/chaos/scenarios/verify/scenario3_verify.sql
@@ -1,0 +1,9 @@
+-- Scenario 3: Verification - Check if deletes were replicated
+-- Verify that some records were deleted (count should be less than 80)
+SELECT 
+    CASE 
+        WHEN COUNT(*) = 50000 THEN 'PASS'
+        ELSE 'FAIL'
+    END AS test_result,
+    COUNT(*) AS remaining_count
+FROM cdc_db.t1;

--- a/tests/chaos/scenarios/verify/scenario4_verify.sql
+++ b/tests/chaos/scenarios/verify/scenario4_verify.sql
@@ -1,0 +1,11 @@
+-- Scenario 4: Verification - Check if mixed operations were replicated
+-- Verify total count is reasonable and contains our marker value (999999)
+SELECT 
+    CASE 
+        WHEN COUNT(*) >= 30 AND EXISTS (SELECT 1 FROM cdc_db.t1 WHERE val = 999999) 
+        THEN 'PASS'
+        ELSE 'FAIL'
+    END AS test_result,
+    COUNT(*) AS total_count,
+    (SELECT COUNT(*) FROM cdc_db.t1 WHERE val = 999999) AS marker_count
+FROM cdc_db.t1;

--- a/tests/chaos/scenarios/verify/scenario5_verify.sql
+++ b/tests/chaos/scenarios/verify/scenario5_verify.sql
@@ -1,0 +1,14 @@
+-- Scenario 5: Verification - Check if high-volume data (5M rows) was replicated
+SELECT 
+    CASE 
+        WHEN COUNT(*) = 2000000 THEN 'PASS'
+        ELSE 'FAIL'
+    END AS test_result,
+    COUNT(*) AS actual_count,
+    2000000 AS expected_count,
+    CASE 
+        WHEN COUNT(*) = 2000000 THEN 'All 2M rows replicated successfully'
+        WHEN COUNT(*) > 0 THEN CONCAT('Partial replication: ', COUNT(*), ' of 2M rows')
+        ELSE 'No data replicated'
+    END AS status_message
+FROM cdc_db.t1;

--- a/tests/chaos/scripts/chaos_script.sh
+++ b/tests/chaos/scripts/chaos_script.sh
@@ -1,0 +1,147 @@
+#!/bin/bash
+#
+# Chaos Script - Randomly restart CDC application container
+# This script continuously restarts the specified container at random intervals
+# to test the graceful shutdown and recovery capabilities of the CDC application.
+#
+# Usage: ./chaos_script.sh <container_name>
+#
+
+set -e
+
+# Function to sleep for a random duration within a range
+sleep_in_range() {
+    local min=$1
+    local max=$2
+    local range=$((max - min))
+    local random_sleep=$((RANDOM % range + min))
+    echo "Sleeping for $random_sleep seconds..."
+    sleep "$random_sleep"
+}
+
+# Function to restart container
+restart_container() {
+    local container_id="$1"
+    local container_name="$2"
+    
+    echo "========================================"
+    echo "Restarting container: $container_name (ID: $container_id)"
+    echo "Timestamp: $(date '+%Y-%m-%d %H:%M:%S')"
+    echo "========================================"
+    
+    # Gracefully stop the container (respects stop_grace_period in docker-compose)
+    if docker stop "$container_id"; then
+        echo "✓ Container stopped successfully."
+    else
+        echo "✗ Failed to stop container: $container_id"
+        return 1
+    fi
+    
+    # Wait a moment before starting
+    sleep 5
+    
+    # Start the container
+    if docker start "$container_id"; then
+        echo "✓ Container started successfully."
+    else
+        echo "✗ Failed to start container: $container_id"
+        return 1
+    fi
+    
+    # Wait for container to be healthy before next restart
+    echo "Waiting for container to become healthy..."
+    local wait_count=0
+    local max_wait=60  # Wait up to 60 seconds for health check
+    
+    while [ $wait_count -lt $max_wait ]; do
+        local health_status=$(docker inspect --format='{{.State.Health.Status}}' "$container_id" 2>/dev/null || echo "unknown")
+        
+        if [ "$health_status" = "healthy" ]; then
+            echo "✓ Container is healthy."
+            break
+        elif [ "$health_status" = "unhealthy" ]; then
+            echo "⚠ Container is unhealthy, but continuing..."
+            break
+        fi
+        
+        sleep 2
+        wait_count=$((wait_count + 2))
+    done
+    
+    if [ $wait_count -ge $max_wait ]; then
+        echo "⚠ Health check timeout reached, continuing anyway..."
+    fi
+}
+
+# Main function to manage container chaos
+manage_container() {
+    local container_name="$1"
+    
+    echo "=========================================="
+    echo "Starting Chaos Script for: $container_name"
+    echo "Container will be restarted every 45-90 seconds"
+    echo "=========================================="
+    
+    while true; do
+        # Find container by name
+        local container_info
+        container_info=$(docker ps -a --filter "name=^${container_name}$" --format "{{.ID}} {{.Status}} {{.Names}}")
+        
+        if [ -n "$container_info" ]; then
+            local container_id status container_found_name
+            container_id=$(echo "$container_info" | awk '{print $1}')
+            status=$(echo "$container_info" | awk '{print $2}')
+            container_found_name=$(echo "$container_info" | awk '{print $NF}')
+            
+            echo ""
+            echo "Container Info:"
+            echo "  Name: $container_found_name"
+            echo "  ID: $container_id"
+            echo "  Status: $status"
+            
+            if [ -n "$status" ]; then
+                # Only restart if container is running
+                if [[ "$status" == Up* ]] || [[ "$status" == "running" ]]; then
+                    restart_container "$container_id" "$container_name"
+                    # Random sleep between 45-90 seconds before next restart
+                    sleep_in_range 45 90
+                else
+                    echo "Container is not running (status: $status). Attempting to start..."
+                    if docker start "$container_id"; then
+                        echo "✓ Container started successfully."
+                        sleep_in_range 30 45
+                    else
+                        echo "✗ Failed to start container."
+                        sleep 10
+                    fi
+                fi
+            fi
+        else
+            echo "⚠ Container '$container_name' not found. Retrying in 5 seconds..."
+            sleep 5
+        fi
+    done
+}
+
+# Main script execution
+container_name="$1"
+
+if [ -z "$container_name" ]; then
+    echo "Error: Container name not provided"
+    echo "Usage: $0 <container_name>"
+    echo "Example: $0 cdc_application"
+    exit 1
+fi
+
+# Verify container exists before starting chaos
+if ! docker ps -a --filter "name=^${container_name}$" --format "{{.Names}}" | grep -q "^${container_name}$"; then
+    echo "Error: Container '$container_name' does not exist"
+    echo "Available containers:"
+    docker ps -a --format "{{.Names}}"
+    exit 1
+fi
+
+echo "✓ Container '$container_name' found. Starting chaos testing..."
+echo ""
+
+manage_container "$container_name"

--- a/tests/chaos/scripts/quick_test.sh
+++ b/tests/chaos/scripts/quick_test.sh
@@ -1,0 +1,238 @@
+#!/bin/bash
+#
+# Quick Chaos Test - A simplified script for rapid local testing
+# This script runs a single scenario or all scenarios with reduced retry counts
+#
+
+
+# Load environment variables from .env file if it exists
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+ENV_FILE="$PROJECT_ROOT/env/.env"
+
+if [ -f "$ENV_FILE" ]; then
+    echo "Loading environment from: $ENV_FILE"
+    set -a
+    source "$ENV_FILE"
+    set +a
+else
+    echo "Warning: .env file not found at $ENV_FILE, using defaults"
+fi
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+# Configuration
+POSTGRES_HOST="${CDC_POSTGRES_HOST:-127.0.0.1}"
+POSTGRES_PORT="${CDC_POSTGRES_PORT:-5432}"
+POSTGRES_USER="${CDC_POSTGRES_USER:-postgres}"
+POSTGRES_PASSWORD="${CDC_POSTGRES_PASSWORD:-test.123}"
+POSTGRES_DB="${CDC_POSTGRES_DB:-postgres}"
+
+MYSQL_HOST="${CDC_MYSQL_HOST:-127.0.0.1}"
+MYSQL_PORT="${CDC_MYSQL_PORT:-3306}"
+MYSQL_USER="${CDC_MYSQL_USER:-root}"
+MYSQL_PASSWORD="${CDC_MYSQL_PASSWORD:-test.123}"
+MYSQL_DB="${CDC_MYSQL_DB:-cdc_db}"
+
+CONTAINER_NAME="${CDC_CONTAINER_NAME:-cdc_application}"
+SCENARIO="$1"
+MAX_RETRIES=20  # Reduced for quick testing
+RETRY_INTERVAL=10  # Reduced for quick testing
+CHAOS_SCRIPT_PID=""
+
+SCENARIOS_DIR="$SCRIPT_DIR/../scenarios"
+CHAOS_SCRIPT="$SCRIPT_DIR/chaos_script.sh"
+
+log_info() {
+    echo -e "${BLUE}[INFO]${NC} $*"
+}
+
+log_success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $*"
+}
+
+log_warning() {
+    echo -e "${YELLOW}[WARNING]${NC} $*"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $*"
+}
+
+cleanup() {
+    if [ -n "$CHAOS_SCRIPT_PID" ] && kill -0 "$CHAOS_SCRIPT_PID" 2>/dev/null; then
+        log_info "Stopping chaos script..."
+        kill "$CHAOS_SCRIPT_PID" 2>/dev/null || true
+        wait "$CHAOS_SCRIPT_PID" 2>/dev/null || true
+    fi
+}
+
+trap cleanup EXIT INT TERM
+
+execute_postgres_sql() {
+    local sql_file="$1"
+    PGPASSWORD="$POSTGRES_PASSWORD" psql \
+        -h "$POSTGRES_HOST" \
+        -p "$POSTGRES_PORT" \
+        -U "$POSTGRES_USER" \
+        -d "$POSTGRES_DB" \
+        -f "$sql_file" \
+        2>&1
+}
+
+verify_scenario() {
+    local verify_file="$1"
+    local result=$(mysql \
+        -h "$MYSQL_HOST" \
+        -P "$MYSQL_PORT" \
+        -u "$MYSQL_USER" \
+        -p"$MYSQL_PASSWORD" \
+        "$MYSQL_DB" \
+        -N -B \
+        < "$verify_file" 2>&1)
+    
+    if echo "$result" | grep -q "PASS"; then
+        return 0
+    else
+        log_warning "Verification: $result"
+        return 1
+    fi
+}
+
+cleanup_test_data() {
+    log_info "Cleaning test data..."
+    
+    PGPASSWORD="$POSTGRES_PASSWORD" psql \
+        -h "$POSTGRES_HOST" \
+        -p "$POSTGRES_PORT" \
+        -U "$POSTGRES_USER" \
+        -d "$POSTGRES_DB" \
+        -c "TRUNCATE TABLE public.t1;" 2>&1 > /dev/null || true
+    
+    mysql \
+        -h "$MYSQL_HOST" \
+        -P "$MYSQL_PORT" \
+        -u "$MYSQL_USER" \
+        -p"$MYSQL_PASSWORD" \
+        "$MYSQL_DB" \
+        -e "TRUNCATE TABLE t1;" 2>&1 > /dev/null || true
+    
+    sleep 3
+}
+
+run_scenario() {
+    local scenario_num="$1"
+    local input_file="$SCENARIOS_DIR/input/scenario${scenario_num}_input.sql"
+    local verify_file="$SCENARIOS_DIR/verify/scenario${scenario_num}_verify.sql"
+    
+    if [ ! -f "$input_file" ] || [ ! -f "$verify_file" ]; then
+        log_error "Scenario $scenario_num files not found"
+        return 1
+    fi
+    
+    log_info "=========================================="
+    log_info "Quick Test - Scenario $scenario_num"
+    log_info "=========================================="
+    
+    cleanup_test_data
+    
+    if ! execute_postgres_sql "$input_file" > /dev/null; then
+        log_error "Failed to execute input SQL"
+        return 1
+    fi
+    
+    log_info "Input executed. Verifying (max $MAX_RETRIES attempts)..."
+    
+    local retry_count=0
+    while [ $retry_count -lt $MAX_RETRIES ]; do
+        retry_count=$((retry_count + 1))
+        
+        if verify_scenario "$verify_file"; then
+            log_success "✓ Scenario $scenario_num PASSED (attempt $retry_count)"
+            return 0
+        fi
+        
+        if [ $retry_count -lt $MAX_RETRIES ]; then
+            echo -n "."
+            sleep "$RETRY_INTERVAL"
+        fi
+    done
+    
+    echo ""
+    log_error "✗ Scenario $scenario_num FAILED after $MAX_RETRIES attempts"
+    return 1
+}
+
+show_usage() {
+    echo "Usage: $0 [scenario_number|all]"
+    echo ""
+    echo "Quick chaos testing with reduced retry counts for faster feedback"
+    echo ""
+    echo "Examples:"
+    echo "  $0 1        # Run scenario 1 only"
+    echo "  $0 all      # Run all scenarios"
+    echo ""
+    echo "Available scenarios:"
+    ls "$SCENARIOS_DIR"/input/scenario*_input.sql 2>/dev/null | while read -r file; do
+        local num=$(basename "$file" | sed 's/scenario\([0-9]*\)_input.sql/\1/')
+        local desc=$(head -n 2 "$file" | tail -n 1 | sed 's/^-- //')
+        echo "  $num: $desc"
+    done
+}
+
+main() {
+    if [ -z "$SCENARIO" ]; then
+        show_usage
+        exit 1
+    fi
+    
+    # Check prerequisites
+    if ! docker ps -a --filter "name=^${CONTAINER_NAME}$" --format "{{.Names}}" | grep -q "^${CONTAINER_NAME}$"; then
+        log_error "Container '$CONTAINER_NAME' not found. Run 'make chaos-test-setup' first."
+        exit 1
+    fi
+    
+    if [ ! -f "$CHAOS_SCRIPT" ]; then
+        log_error "Chaos script not found: $CHAOS_SCRIPT"
+        exit 1
+    fi
+    
+    chmod +x "$CHAOS_SCRIPT"
+    
+    log_info "Starting chaos script..."
+    "$CHAOS_SCRIPT" "$CONTAINER_NAME" > /dev/null 2>&1 &
+    CHAOS_SCRIPT_PID=$!
+    log_info "Chaos script running (PID: $CHAOS_SCRIPT_PID)"
+    sleep 3
+    
+    if [ "$SCENARIO" = "all" ]; then
+        log_info "Running all scenarios..."
+        local passed=0
+        local failed=0
+        
+        for file in "$SCENARIOS_DIR"/input/scenario*_input.sql; do
+            local num=$(basename "$file" | sed 's/scenario\([0-9]*\)_input.sql/\1/')
+            if run_scenario "$num"; then
+                passed=$((passed + 1))
+            else
+                failed=$((failed + 1))
+            fi
+            echo ""
+        done
+        
+        log_info "=========================================="
+        log_info "Results: $passed passed, $failed failed"
+        log_info "=========================================="
+        
+        [ $failed -eq 0 ] && exit 0 || exit 1
+    else
+        run_scenario "$SCENARIO"
+    fi
+}
+
+main "$@"

--- a/tests/chaos/scripts/run_chaos_tests.sh
+++ b/tests/chaos/scripts/run_chaos_tests.sh
@@ -1,0 +1,331 @@
+#!/bin/bash
+#
+# Chaos Integration Test Runner
+# This script runs all test scenarios with chaos testing (random container restarts)
+# and verifies that CDC replication works correctly under adverse conditions.
+#
+# The script will:
+# 1. Start the chaos script in background to randomly restart cdc_application
+# 2. For each scenario:
+#    - Clean up previous test data
+#    - Execute input SQL on PostgreSQL
+#    - Wait and retry verification on MySQL until it passes (max 80 attempts, 45s intervals)
+#    - Move to next scenario
+# 3. Stop chaos script when all scenarios complete
+#
+
+set -e
+
+# Load environment variables from .env file if it exists
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+ENV_FILE="$PROJECT_ROOT/env/.env"
+
+if [ -f "$ENV_FILE" ]; then
+    echo "Loading environment from: $ENV_FILE"
+    set -a
+    source "$ENV_FILE"
+    set +a
+else
+    echo "Warning: .env file not found at $ENV_FILE, using defaults"
+fi
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Configuration
+POSTGRES_HOST="${CDC_POSTGRES_HOST:-127.0.0.1}"
+POSTGRES_PORT="${CDC_POSTGRES_PORT:-5432}"
+POSTGRES_USER="${CDC_POSTGRES_USER:-postgres}"
+POSTGRES_PASSWORD="${CDC_POSTGRES_PASSWORD:-test.123}"
+POSTGRES_DB="${CDC_POSTGRES_DB:-postgres}"
+
+MYSQL_HOST="${CDC_MYSQL_HOST:-127.0.0.1}"
+MYSQL_PORT="${CDC_MYSQL_PORT:-3306}"
+MYSQL_USER="${CDC_MYSQL_USER:-root}"
+MYSQL_PASSWORD="${CDC_MYSQL_PASSWORD:-test.123}"
+MYSQL_DB="${CDC_MYSQL_DB:-cdc_db}"
+
+CONTAINER_NAME="${CDC_CONTAINER_NAME:-cdc_application}"
+MAX_RETRIES=80
+RETRY_INTERVAL=45
+CHAOS_SCRIPT_PID=""
+
+# Script paths
+SCENARIOS_DIR="$SCRIPT_DIR/../scenarios"
+CHAOS_SCRIPT="$SCRIPT_DIR/chaos_script.sh"
+
+# Logging functions (output to stdout/stderr)
+log() {
+    local level="$1"
+    shift
+    local message="$*"
+    local timestamp=$(date '+%Y-%m-%d %H:%M:%S')
+    echo "[$timestamp] [$level] $message"
+}
+
+log_info() {
+    echo -e "${BLUE}[INFO]${NC} $*"
+}
+
+log_success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $*"
+}
+
+log_warning() {
+    echo -e "${YELLOW}[WARNING]${NC} $*" >&2
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $*" >&2
+}
+
+# Cleanup function
+cleanup() {
+    log_info "Cleaning up..."
+    
+    if [ -n "$CHAOS_SCRIPT_PID" ] && kill -0 "$CHAOS_SCRIPT_PID" 2>/dev/null; then
+        log_info "Stopping chaos script (PID: $CHAOS_SCRIPT_PID)..."
+        kill "$CHAOS_SCRIPT_PID" 2>/dev/null || true
+        wait "$CHAOS_SCRIPT_PID" 2>/dev/null || true
+    fi
+    
+    log_info "Cleanup complete."
+}
+
+# Set up trap for cleanup
+trap cleanup EXIT INT TERM
+
+# Function to execute PostgreSQL SQL
+execute_postgres_sql() {
+    local sql_file="$1"
+    log_info "Executing PostgreSQL SQL: $sql_file"
+    
+    PGPASSWORD="$POSTGRES_PASSWORD" psql \
+        -h "$POSTGRES_HOST" \
+        -p "$POSTGRES_PORT" \
+        -U "$POSTGRES_USER" \
+        -d "$POSTGRES_DB" \
+        -f "$sql_file" \
+        2>&1
+    
+    return ${PIPESTATUS[0]}
+}
+
+# Function to execute MySQL SQL and get result
+execute_mysql_sql() {
+    local sql_file="$1"
+    log_info "Executing MySQL SQL: $sql_file"
+    
+    mysql \
+        -h "$MYSQL_HOST" \
+        -P "$MYSQL_PORT" \
+        -u "$MYSQL_USER" \
+        -p"$MYSQL_PASSWORD" \
+        "$MYSQL_DB" \
+        < "$sql_file" \
+        2>&1
+    
+    return ${PIPESTATUS[0]}
+}
+
+# Function to verify test result
+verify_scenario() {
+    local verify_file="$1"
+    
+    local result=$(mysql \
+        -h "$MYSQL_HOST" \
+        -P "$MYSQL_PORT" \
+        -u "$MYSQL_USER" \
+        -p"$MYSQL_PASSWORD" \
+        "$MYSQL_DB" \
+        -N -B \
+        < "$verify_file" 2>&1)
+    
+    # Check if result contains "PASS"
+    if echo "$result" | grep -q "PASS"; then
+        return 0
+    else
+        log_warning "Verification result: $result"
+        return 1
+    fi
+}
+
+# Function to clean up test data
+cleanup_test_data() {
+    log_info "Cleaning up test data from both databases..."
+    
+    # Clean PostgreSQL
+    PGPASSWORD="$POSTGRES_PASSWORD" psql \
+        -h "$POSTGRES_HOST" \
+        -p "$POSTGRES_PORT" \
+        -U "$POSTGRES_USER" \
+        -d "$POSTGRES_DB" \
+        -c "TRUNCATE TABLE public.t1;" > /dev/null 2>&1 || true
+    
+    # Clean MySQL
+    mysql \
+        -h "$MYSQL_HOST" \
+        -P "$MYSQL_PORT" \
+        -u "$MYSQL_USER" \
+        -p"$MYSQL_PASSWORD" \
+        "$MYSQL_DB" \
+        -e "TRUNCATE TABLE t1;" \
+        2>&1 || true
+    
+    # Wait for truncate to replicate
+    sleep 5
+}
+
+# Function to run a single scenario
+run_scenario() {
+    local scenario_num="$1"
+    local input_file="$SCENARIOS_DIR/input/scenario${scenario_num}_input.sql"
+    local verify_file="$SCENARIOS_DIR/verify/scenario${scenario_num}_verify.sql"
+    
+    if [ ! -f "$input_file" ]; then
+        log_error "Input file not found: $input_file"
+        return 1
+    fi
+    
+    if [ ! -f "$verify_file" ]; then
+        log_error "Verify file not found: $verify_file"
+        return 1
+    fi
+    
+    log_info "========================================"
+    log_info "Running Scenario $scenario_num"
+    log_info "========================================"
+    
+    # Execute input SQL on PostgreSQL
+    if ! execute_postgres_sql "$input_file"; then
+        log_error "Failed to execute input SQL for scenario $scenario_num"
+        return 1
+    fi
+    
+    log_info "Input SQL executed successfully. Waiting for replication..."
+    
+    # Retry verification until it passes
+    local retry_count=0
+    local verification_passed=false
+    
+    while [ $retry_count -lt $MAX_RETRIES ]; do
+        retry_count=$((retry_count + 1))
+        log_info "Verification attempt $retry_count/$MAX_RETRIES for scenario $scenario_num..."
+        
+        if verify_scenario "$verify_file"; then
+            log_success "✓ Scenario $scenario_num PASSED on attempt $retry_count"
+            verification_passed=true
+            break
+        else
+            log_warning "✗ Scenario $scenario_num verification failed (attempt $retry_count/$MAX_RETRIES)"
+            
+            if [ $retry_count -lt $MAX_RETRIES ]; then
+                log_info "Waiting $RETRY_INTERVAL seconds before retry..."
+                sleep "$RETRY_INTERVAL"
+            fi
+        fi
+    done
+    
+    if [ "$verification_passed" = false ]; then
+        log_error "✗ Scenario $scenario_num FAILED after $MAX_RETRIES attempts"
+        return 1
+    fi
+    
+    return 0
+}
+
+# Main execution
+main() {
+    log_info "=========================================="
+    log_info "CDC Chaos Integration Test Suite"
+    log_info "=========================================="
+    log_info "Max retries per scenario: $MAX_RETRIES"
+    log_info "Retry interval: $RETRY_INTERVAL seconds"
+    log_info "Container under test: $CONTAINER_NAME"
+    log_info ""
+    
+    # Check if chaos script exists
+    if [ ! -f "$CHAOS_SCRIPT" ]; then
+        log_error "Chaos script not found: $CHAOS_SCRIPT"
+        exit 1
+    fi
+    
+    # Make chaos script executable
+    chmod +x "$CHAOS_SCRIPT"
+    
+    # Check if container exists
+    if ! docker ps -a --filter "name=^${CONTAINER_NAME}$" --format "{{.Names}}" | grep -q "^${CONTAINER_NAME}$"; then
+        log_error "Container '$CONTAINER_NAME' not found. Please start docker-compose first."
+        exit 1
+    fi
+    
+    # Wait for services to be ready
+    log_info "Waiting for services to be ready..."
+    sleep 10
+    
+    # Start chaos script in background
+    log_info "Starting chaos script for container: $CONTAINER_NAME"
+    "$CHAOS_SCRIPT" "$CONTAINER_NAME" > "$SCRIPT_DIR/chaos_script.log" 2>&1 &
+    CHAOS_SCRIPT_PID=$!
+    log_info "Chaos script started with PID: $CHAOS_SCRIPT_PID"
+    
+    # Wait a moment for chaos to begin
+    sleep 5
+    
+    # Find all scenario input files
+    local scenario_files=($(ls "$SCENARIOS_DIR"/input/scenario*_input.sql 2>/dev/null | sort))
+    local total_scenarios=${#scenario_files[@]}
+    
+    if [ $total_scenarios -eq 0 ]; then
+        log_error "No scenario files found in $SCENARIOS_DIR/input"
+        exit 1
+    fi
+    
+    log_info "Found $total_scenarios scenarios to run"
+    log_info ""
+    
+    # Run each scenario
+    local passed=0
+    local failed=0
+    
+    for scenario_file in "${scenario_files[@]}"; do
+        # Extract scenario number from filename (e.g., scenario1_input.sql -> 1)
+        local scenario_num=$(basename "$scenario_file" | sed 's/scenario\([0-9]*\)_input.sql/\1/')
+        
+        # Clean up before each scenario
+        cleanup_test_data
+        
+        if run_scenario "$scenario_num"; then
+            passed=$((passed + 1))
+        else
+            failed=$((failed + 1))
+            log_error "Scenario $scenario_num failed. Continuing to next scenario..."
+        fi
+        
+        log_info ""
+        sleep 5
+    done
+    
+    # Summary
+    log_info "=========================================="
+    log_info "Test Suite Complete"
+    log_info "=========================================="
+    log_info "Total scenarios: $total_scenarios"
+    log_success "Passed: $passed"
+    
+    if [ $failed -gt 0 ]; then
+        log_error "Failed: $failed"
+        exit 1
+    else
+        log_success "All scenarios passed!"
+        exit 0
+    fi
+}
+
+# Run main function
+main "$@"


### PR DESCRIPTION
- Add chaos integration test script with PostgreSQL container scenarios
- Verify CDC application graceful shutdown behavior
- Add docker-compose.chaos-test.yml for chaos testing setup
- Add GitHub Actions workflow for chaos integration tests
- Upgrade pg_walstream dependency from 0.2.0 to 0.2.1
- Add test scenarios for verifying CDC replication during shutdown
- remove lsn guard and enhance lsn_tracker

for #39 