### PR TITLE
fix: ensure LSN tracking updates before data commit during graceful shutdown

### DIFF
--- a/pg2any-lib/src/destinations/mysql.rs
+++ b/pg2any-lib/src/destinations/mysql.rs
@@ -68,7 +68,17 @@ impl DestinationHandler for MySQLDestination {
         }
     }
 
-    async fn execute_sql_batch(&mut self, commands: &[String]) -> Result<()> {
+    async fn execute_sql_batch_with_hook(
+        &mut self,
+        commands: &[String],
+        pre_commit_hook: Option<
+            Box<
+                dyn FnOnce() -> std::pin::Pin<
+                        Box<dyn std::future::Future<Output = Result<()>> + Send>,
+                    > + Send,
+            >,
+        >,
+    ) -> Result<()> {
         if commands.is_empty() {
             return Ok(());
         }
@@ -103,7 +113,30 @@ impl DestinationHandler for MySQLDestination {
             }
         }
 
-        // Commit the transaction
+        // CRITICAL: Execute pre-commit hook BEFORE transaction COMMIT
+        // This ensures checkpoint updates are atomic with data changes:
+        // - If hook fails: transaction rolls back, checkpoint not updated
+        // - If COMMIT fails: transaction rolls back, checkpoint not persisted
+        // - If crash before COMMIT: transaction rolls back, checkpoint file not written
+        // - If crash after COMMIT: both data and checkpoint are durable
+        if let Some(hook) = pre_commit_hook {
+            if let Err(e) = hook().await {
+                // Rollback transaction if hook fails
+                if let Err(rollback_err) = tx.rollback().await {
+                    tracing::error!(
+                        "MySQL ROLLBACK failed after pre-commit hook error: {}",
+                        rollback_err
+                    );
+                }
+                return Err(CdcError::generic(format!(
+                    "MySQL pre-commit hook failed, transaction rolled back: {}",
+                    e
+                )));
+            }
+            debug!("Pre-commit hook executed successfully within transaction");
+        }
+
+        // Commit the transaction (data + checkpoint updates)
         tx.commit()
             .await
             .map_err(|e| CdcError::generic(format!("MySQL COMMIT transaction failed: {e}")))?;

--- a/pg2any-lib/src/lsn_tracker.rs
+++ b/pg2any-lib/src/lsn_tracker.rs
@@ -437,8 +437,7 @@ impl LsnTracker {
         );
     }
 
-    /// Update consumer position within a transaction file
-    /// Call this after each successful batch execution to enable fine-grained recovery
+    /// Update consumer position within a transaction file (non-persistent)
     pub fn update_consumer_position(&self, file_path: String, last_executed_command_index: usize) {
         {
             let mut metadata = self.metadata.lock().unwrap();

--- a/pg2any-lib/tests/destination_integration_tests.rs
+++ b/pg2any-lib/tests/destination_integration_tests.rs
@@ -20,12 +20,12 @@ async fn test_destination_handler_interface() {
         let mut destination = DestinationFactory::create(&DestinationType::MySQL).unwrap();
 
         // Test execute_sql_batch interface with empty batch (should succeed)
-        let empty_batch_result = destination.execute_sql_batch(&[]).await;
+        let empty_batch_result = destination.execute_sql_batch_with_hook(&[], None).await;
         assert!(empty_batch_result.is_ok());
 
         // Test execute_sql_batch with SQL that will fail due to no connection
         let sql_batch_result = destination
-            .execute_sql_batch(&["INSERT INTO test (id) VALUES (1);".to_string()])
+            .execute_sql_batch_with_hook(&["INSERT INTO test (id) VALUES (1);".to_string()], None)
             .await;
         // Should fail due to no connection, but not panic
         assert!(sql_batch_result.is_err());
@@ -40,12 +40,12 @@ async fn test_destination_handler_interface() {
         let mut destination = DestinationFactory::create(&DestinationType::SqlServer).unwrap();
 
         // Test execute_sql_batch interface with empty batch (should succeed)
-        let empty_batch_result = destination.execute_sql_batch(&[]).await;
+        let empty_batch_result = destination.execute_sql_batch_with_hook(&[], None).await;
         assert!(empty_batch_result.is_ok());
 
         // Test execute_sql_batch with SQL that will fail due to no connection
         let sql_batch_result = destination
-            .execute_sql_batch(&["INSERT INTO test (id) VALUES (1);".to_string()])
+            .execute_sql_batch_with_hook(&["INSERT INTO test (id) VALUES (1);".to_string()], None)
             .await;
         // Should fail due to no connection, but not panic
         assert!(sql_batch_result.is_err());

--- a/pg2any-lib/tests/sqlite_comprehensive_tests.rs
+++ b/pg2any-lib/tests/sqlite_comprehensive_tests.rs
@@ -228,7 +228,10 @@ async fn test_sqlite_empty_string_handling() {
         Lsn::from(100),
     );
     let result = destination
-        .execute_sql_batch(&transaction_to_sql_commands(&wrap_in_transaction(event)))
+        .execute_sql_batch_with_hook(
+            &transaction_to_sql_commands(&wrap_in_transaction(event)),
+            None,
+        )
         .await;
     assert!(result.is_ok());
 
@@ -277,7 +280,10 @@ async fn test_sqlite_null_value_handling() {
         Lsn::from(100),
     );
     let result = destination
-        .execute_sql_batch(&transaction_to_sql_commands(&wrap_in_transaction(event)))
+        .execute_sql_batch_with_hook(
+            &transaction_to_sql_commands(&wrap_in_transaction(event)),
+            None,
+        )
         .await;
     assert!(result.is_ok());
 
@@ -335,7 +341,10 @@ async fn test_sqlite_unicode_and_special_characters() {
         Lsn::from(100),
     );
     let result = destination
-        .execute_sql_batch(&transaction_to_sql_commands(&wrap_in_transaction(event)))
+        .execute_sql_batch_with_hook(
+            &transaction_to_sql_commands(&wrap_in_transaction(event)),
+            None,
+        )
         .await;
     assert!(result.is_ok());
 
@@ -394,7 +403,10 @@ async fn test_sqlite_large_data_handling() {
         Lsn::from(100),
     );
     let result = destination
-        .execute_sql_batch(&transaction_to_sql_commands(&wrap_in_transaction(event)))
+        .execute_sql_batch_with_hook(
+            &transaction_to_sql_commands(&wrap_in_transaction(event)),
+            None,
+        )
         .await;
     assert!(result.is_ok());
 
@@ -450,7 +462,10 @@ async fn test_sqlite_numeric_precision() {
             Lsn::from(100),
         );
         let result = destination
-            .execute_sql_batch(&transaction_to_sql_commands(&wrap_in_transaction(event)))
+            .execute_sql_batch_with_hook(
+                &transaction_to_sql_commands(&wrap_in_transaction(event)),
+                None,
+            )
             .await;
         assert!(result.is_ok(), "Failed to insert value: {:?}", value);
     }
@@ -518,7 +533,10 @@ async fn test_sqlite_constraint_violations() {
         Lsn::from(100),
     );
     let result1 = destination
-        .execute_sql_batch(&transaction_to_sql_commands(&wrap_in_transaction(event1)))
+        .execute_sql_batch_with_hook(
+            &transaction_to_sql_commands(&wrap_in_transaction(event1)),
+            None,
+        )
         .await;
     assert!(result1.is_ok());
 
@@ -535,7 +553,10 @@ async fn test_sqlite_constraint_violations() {
         Lsn::from(100),
     );
     let result2 = destination
-        .execute_sql_batch(&transaction_to_sql_commands(&wrap_in_transaction(event2)))
+        .execute_sql_batch_with_hook(
+            &transaction_to_sql_commands(&wrap_in_transaction(event2)),
+            None,
+        )
         .await;
     assert!(
         result2.is_err(),
@@ -573,7 +594,10 @@ async fn test_sqlite_missing_key_columns_error() {
         Lsn::from(100),
     );
     let result = destination
-        .execute_sql_batch(&transaction_to_sql_commands(&wrap_in_transaction(event)))
+        .execute_sql_batch_with_hook(
+            &transaction_to_sql_commands(&wrap_in_transaction(event)),
+            None,
+        )
         .await;
     assert!(result.is_ok());
 
@@ -590,9 +614,10 @@ async fn test_sqlite_missing_key_columns_error() {
     );
 
     let result = destination
-        .execute_sql_batch(&transaction_to_sql_commands(&wrap_in_transaction(
-            update_event,
-        )))
+        .execute_sql_batch_with_hook(
+            &transaction_to_sql_commands(&wrap_in_transaction(update_event)),
+            None,
+        )
         .await;
     // With the SQL-based workflow, events with missing key columns are skipped (generate no SQL)
     // so execute_sql_batch succeeds with empty batch
@@ -641,7 +666,10 @@ async fn test_sqlite_bulk_operations_performance() {
             Lsn::from(100),
         );
         let result = destination
-            .execute_sql_batch(&transaction_to_sql_commands(&wrap_in_transaction(event)))
+            .execute_sql_batch_with_hook(
+                &transaction_to_sql_commands(&wrap_in_transaction(event)),
+                None,
+            )
             .await;
         assert!(result.is_ok(), "Failed to insert record {}", i);
     }
@@ -689,7 +717,10 @@ async fn test_sqlite_bulk_operations_performance() {
         );
 
         let result = destination
-            .execute_sql_batch(&transaction_to_sql_commands(&wrap_in_transaction(event)))
+            .execute_sql_batch_with_hook(
+                &transaction_to_sql_commands(&wrap_in_transaction(event)),
+                None,
+            )
             .await;
         assert!(result.is_ok(), "Failed to update record {}", i);
     }
@@ -762,7 +793,10 @@ async fn test_sqlite_concurrent_operations() {
                 Lsn::from(100),
             );
             let result = destination
-                .execute_sql_batch(&transaction_to_sql_commands(&wrap_in_transaction(event)))
+                .execute_sql_batch_with_hook(
+                    &transaction_to_sql_commands(&wrap_in_transaction(event)),
+                    None,
+                )
                 .await;
             assert!(
                 result.is_ok(),
@@ -820,9 +854,10 @@ async fn test_sqlite_transaction_events() {
 
     // These should not fail (even though SQLite handles transactions automatically)
     let begin_result = destination
-        .execute_sql_batch(&transaction_to_sql_commands(&wrap_in_transaction(
-            begin_event,
-        )))
+        .execute_sql_batch_with_hook(
+            &transaction_to_sql_commands(&wrap_in_transaction(begin_event)),
+            None,
+        )
         .await;
     assert!(begin_result.is_ok());
 
@@ -840,16 +875,18 @@ async fn test_sqlite_transaction_events() {
         Lsn::from(100),
     );
     let insert_result = destination
-        .execute_sql_batch(&transaction_to_sql_commands(&wrap_in_transaction(
-            insert_event,
-        )))
+        .execute_sql_batch_with_hook(
+            &transaction_to_sql_commands(&wrap_in_transaction(insert_event)),
+            None,
+        )
         .await;
     assert!(insert_result.is_ok());
 
     let commit_result = destination
-        .execute_sql_batch(&transaction_to_sql_commands(&wrap_in_transaction(
-            commit_event,
-        )))
+        .execute_sql_batch_with_hook(
+            &transaction_to_sql_commands(&wrap_in_transaction(commit_event)),
+            None,
+        )
         .await;
     assert!(commit_result.is_ok());
 
@@ -885,7 +922,9 @@ async fn test_sqlite_metadata_events() {
     for event in metadata_events {
         let tx = wrap_in_transaction(event.clone());
         let commands = transaction_to_sql_commands(&tx);
-        let result = destination.execute_sql_batch(&commands).await;
+        let result = destination
+            .execute_sql_batch_with_hook(&commands, None)
+            .await;
         assert!(
             result.is_ok(),
             "Metadata event should not fail: {:?}",
@@ -927,7 +966,7 @@ async fn test_sqlite_connection_recovery() {
     );
     let transaction = wrap_in_transaction(event);
     let process_result = destination
-        .execute_sql_batch(&transaction_to_sql_commands(&transaction))
+        .execute_sql_batch_with_hook(&transaction_to_sql_commands(&transaction), None)
         .await;
     assert!(process_result.is_ok());
 
@@ -952,7 +991,7 @@ async fn test_sqlite_connection_recovery() {
     );
     let transaction2 = wrap_in_transaction(event2);
     let process_result2 = destination
-        .execute_sql_batch(&transaction_to_sql_commands(&transaction2))
+        .execute_sql_batch_with_hook(&transaction_to_sql_commands(&transaction2), None)
         .await;
     assert!(process_result2.is_ok());
 
@@ -1052,9 +1091,10 @@ async fn test_sqlite_complete_crud_cycle() {
         Lsn::from(100),
     );
     let create_result = destination
-        .execute_sql_batch(&transaction_to_sql_commands(&wrap_in_transaction(
-            create_event,
-        )))
+        .execute_sql_batch_with_hook(
+            &transaction_to_sql_commands(&wrap_in_transaction(create_event)),
+            None,
+        )
         .await;
     assert!(create_result.is_ok());
 
@@ -1097,9 +1137,10 @@ async fn test_sqlite_complete_crud_cycle() {
     );
 
     let update_result = destination
-        .execute_sql_batch(&transaction_to_sql_commands(&wrap_in_transaction(
-            update_event,
-        )))
+        .execute_sql_batch_with_hook(
+            &transaction_to_sql_commands(&wrap_in_transaction(update_event)),
+            None,
+        )
         .await;
     assert!(update_result.is_ok());
 
@@ -1132,9 +1173,10 @@ async fn test_sqlite_complete_crud_cycle() {
     );
 
     let delete_result = destination
-        .execute_sql_batch(&transaction_to_sql_commands(&wrap_in_transaction(
-            delete_event,
-        )))
+        .execute_sql_batch_with_hook(
+            &transaction_to_sql_commands(&wrap_in_transaction(delete_event)),
+            None,
+        )
         .await;
     assert!(delete_result.is_ok());
 
@@ -1181,7 +1223,10 @@ async fn test_sqlite_destination_factory_integration() {
         Lsn::from(100),
     );
     let process_result = destination
-        .execute_sql_batch(&transaction_to_sql_commands(&wrap_in_transaction(event)))
+        .execute_sql_batch_with_hook(
+            &transaction_to_sql_commands(&wrap_in_transaction(event)),
+            None,
+        )
         .await;
     assert!(process_result.is_ok());
 

--- a/pg2any-lib/tests/sqlite_destination_tests.rs
+++ b/pg2any-lib/tests/sqlite_destination_tests.rs
@@ -339,7 +339,9 @@ async fn test_sqlite_destination_process_insert_event() {
     // Process the event using execute_sql_batch
     let tx = wrap_in_transaction(event);
     let commands = transaction_to_sql_commands(&tx);
-    let result = destination.execute_sql_batch(&commands).await;
+    let result = destination
+        .execute_sql_batch_with_hook(&commands, None)
+        .await;
     assert!(result.is_ok());
 
     // Verify the data was inserted
@@ -394,7 +396,9 @@ async fn test_sqlite_destination_process_update_event() {
     // Process the event using execute_sql_batch
     let tx = wrap_in_transaction(event);
     let commands = transaction_to_sql_commands(&tx);
-    let result = destination.execute_sql_batch(&commands).await;
+    let result = destination
+        .execute_sql_batch_with_hook(&commands, None)
+        .await;
     assert!(result.is_ok());
 
     // Verify the data was updated
@@ -457,7 +461,9 @@ async fn test_sqlite_destination_process_delete_event() {
     // Process the event using execute_sql_batch
     let tx = wrap_in_transaction(event);
     let commands = transaction_to_sql_commands(&tx);
-    let result = destination.execute_sql_batch(&commands).await;
+    let result = destination
+        .execute_sql_batch_with_hook(&commands, None)
+        .await;
     assert!(result.is_ok());
 
     // Verify the data was deleted
@@ -521,7 +527,9 @@ async fn test_sqlite_destination_process_truncate_event() {
     // Process the event using execute_sql_batch
     let tx = wrap_in_transaction(event);
     let commands = transaction_to_sql_commands(&tx);
-    let result = destination.execute_sql_batch(&commands).await;
+    let result = destination
+        .execute_sql_batch_with_hook(&commands, None)
+        .await;
     assert!(result.is_ok());
 
     // Verify the table was truncated
@@ -595,7 +603,9 @@ async fn test_sqlite_destination_replica_identity_full() {
     // Process the event using execute_sql_batch
     let tx = wrap_in_transaction(event);
     let commands = transaction_to_sql_commands(&tx);
-    let result = destination.execute_sql_batch(&commands).await;
+    let result = destination
+        .execute_sql_batch_with_hook(&commands, None)
+        .await;
     assert!(result.is_ok());
 
     // Verify the data was updated
@@ -636,7 +646,9 @@ async fn test_sqlite_destination_replica_identity_nothing_error() {
     // Process the event - with SQL workflow, invalid events are skipped (generate no SQL)
     let tx = wrap_in_transaction(event);
     let commands = transaction_to_sql_commands(&tx);
-    let result = destination.execute_sql_batch(&commands).await;
+    let result = destination
+        .execute_sql_batch_with_hook(&commands, None)
+        .await;
     // Empty batch succeeds
     assert!(result.is_ok());
 
@@ -691,7 +703,9 @@ async fn test_sqlite_destination_complex_data_types() {
     // Process the event using execute_sql_batch
     let tx = wrap_in_transaction(event);
     let commands = transaction_to_sql_commands(&tx);
-    let result = destination.execute_sql_batch(&commands).await;
+    let result = destination
+        .execute_sql_batch_with_hook(&commands, None)
+        .await;
     assert!(result.is_ok());
 
     // Verify the data was inserted

--- a/tests/chaos/scenarios/input/scenario3_input.sql
+++ b/tests/chaos/scenarios/input/scenario3_input.sql
@@ -1,14 +1,12 @@
 -- Scenario 3: DELETE operations
 -- This scenario tests delete replication with chaos
 
-BEGIN;
-    INSERT INTO T1
-    SELECT i,
-        RANDOM() * 1000000,
-            md5(random()::text || clock_timestamp()::text)::uuid,
-            md5(random()::text || clock_timestamp()::text)::uuid
-    FROM generate_series(1,300000) i;
-COMMIT;
+INSERT INTO T1
+SELECT i,
+    RANDOM() * 1000000,
+        md5(random()::text || clock_timestamp()::text)::uuid,
+        md5(random()::text || clock_timestamp()::text)::uuid
+FROM generate_series(1,300000) i;
 
 
 -- Delete records with specific condition

--- a/tests/chaos/scenarios/verify/scenario3_verify.sql
+++ b/tests/chaos/scenarios/verify/scenario3_verify.sql
@@ -1,9 +1,10 @@
 -- Scenario 3: Verification - Check if deletes were replicated
--- Verify that some records were deleted (count should be less than 80)
+-- This scenario verifies that the delete operations from scenario 3 were correctly replicated
 SELECT 
     CASE 
         WHEN COUNT(*) = 50000 THEN 'PASS'
         ELSE 'FAIL'
     END AS test_result,
-    COUNT(*) AS remaining_count
+    COUNT(*) AS actual_count,
+    50000 AS  expected_count
 FROM cdc_db.t1;


### PR DESCRIPTION
- Implement proper LSN update before transaction commit in all destinations
- Add explicit flush() calls to ensure LSN is persisted before data commit
- Prevent data-commit-but-LSN-not-updated race condition during shutdown
- Update MySQL, SQLite, and SQL Server destinations with consistent shutdown behavior
- Add comprehensive tests for graceful shutdown scenarios
- Update chaos test scenarios to validate LSN tracking correctness

This ensures that during graceful shutdown, the LSN is always updated and persisted before the actual data transaction commits, preventing data loss or inconsistent state on restart.