### PR TITLE
feat: add bulk_insert module with TSV generation and INSERT detection

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,6 +1,5 @@
 [advisories]
 ignore = [
-    "RUSTSEC-2023-0071",
-    "RUSTSEC-2026-0049"
+    "RUSTSEC-2023-0071"
 ]
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,12 +40,13 @@ pg2any/                          # Cargo workspace root
       transaction_manager.rs     # TransactionManager - file lifecycle (begin/append/commit/abort/process)
       destinations/
         destination_factory.rs   # DestinationHandler trait (core interface) + DestinationFactory
-        mysql.rs                 # MySQL impl via SQLx
+        mysql.rs                 # MySQL impl via SQLx + mysql_async (LOAD DATA LOCAL INFILE)
         sqlserver.rs             # SQL Server impl via Tiberius
         sqlite.rs                # SQLite impl via SQLx
         kafka.rs                 # Kafka impl via rdkafka (event mode - sends JSON, not SQL)
-        coalescing.rs            # DML batch coalescing (multi-row INSERT optimization)
-        common.rs                # Shared SQL generation helpers
+        bulk_insert.rs           # TSV generation, INSERT batch detection, multi-value INSERT fallback
+        coalescing.rs            # DML batch coalescing (multi-row INSERT, CASE-WHEN UPDATE)
+        common.rs                # Shared transaction execution with session tuning
       storage/
         traits.rs                # TransactionStorage trait
         compressed.rs            # Gzip storage impl
@@ -74,11 +75,15 @@ pub trait DestinationHandler: Send + Sync {
     async fn execute_sql_batch_with_hook(&mut self, commands: &[String], pre_commit_hook: Option<PreCommitHook>) -> Result<()>;
     async fn close(&mut self) -> Result<()>;
     fn supports_event_mode(&self) -> bool { false }
+    fn supports_bulk_insert(&self) -> bool { false }
+    async fn execute_bulk_insert_with_hook(&mut self, table: &str, columns: &[String], rows: &[Vec<String>], pre_commit_hook: Option<PreCommitHook>) -> Result<()> { ... }
     async fn execute_events_batch_with_hook(&mut self, events: &[ChangeEvent], ...) -> Result<()> { ... }
 }
 ```
 
 - SQL destinations (MySQL, SQLite, SQL Server) use `execute_sql_batch_with_hook`
+- MySQL additionally supports `execute_bulk_insert_with_hook` for LOAD DATA LOCAL INFILE
+- SQL Server supports `execute_bulk_insert_with_hook` for TDS Bulk Load (with multi-value INSERT fallback)
 - Kafka uses event mode (`supports_event_mode() = true`, `execute_events_batch_with_hook`)
 
 ### TransactionStorage (trait) - `storage/traits.rs`
@@ -93,6 +98,7 @@ Builder pattern. All fields have sensible defaults. Required: `source_connection
 
 ```
 default = ["mysql", "sqlserver", "sqlite"]
+mysql   = ["sqlx/mysql", "mysql_async"]
 kafka   = ["rdkafka", "futures-util", "base64"]
 metrics = ["hyper", "hyper-util", "http-body-util", "prometheus"]
 ```
@@ -120,6 +126,17 @@ Consumer uses exponential backoff (2^n seconds, capped at 30s) for transient fai
 - **pg_walstream** (by same author): Low-level PostgreSQL logical replication protocol implementation. Handles WAL parsing, replication state, connection management. [GitHub](https://github.com/isdaniel/pg-walstream)
 
 System dependencies for building: `libpq-dev`, `pkg-config`, `libssl-dev`, `cmake` (for rdkafka).
+
+## Performance Optimization (MySQL & SQL Server)
+
+The consumer-side uses a tiered optimization strategy for batch INSERT operations:
+
+1. **DML Coalescing** (always active) - Consecutive INSERT statements to same table are combined into multi-value INSERT
+2. **Bulk Insert Detection** (configurable) - When a batch is entirely INSERT statements to one table and exceeds threshold, routes to `execute_bulk_insert_with_hook`
+3. **LOAD DATA LOCAL INFILE** (when server supports it) - MySQL's fastest bulk loading protocol via mysql_async. Falls back to multi-value INSERT if `local_infile` is disabled.
+4. **TDS Bulk Load** (SQL Server, configurable) - Uses tiberius's native `bulk_insert()` API for streaming row insertion via TDS protocol. Falls back to multi-value INSERT if bulk load fails or table metadata retrieval fails.
+
+Config env vars: `CDC_BULK_INSERT_THRESHOLD`
 
 ## Common Patterns
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,12 +23,18 @@ pg2any is a Rust CDC (Change Data Capture) library that streams PostgreSQL WAL c
 - Shutdown coordination: `CancellationToken` + `oneshot` channel (producer -> consumer)
 - Destinations behind `DestinationHandler` trait; Kafka uses event mode, SQL destinations use SQL batch mode
 - `TransactionStorage` trait abstracts compressed vs uncompressed file I/O
+- MySQL uses dual pools: sqlx for normal SQL batches, mysql_async for LOAD DATA LOCAL INFILE
+- SQL Server uses TDS Bulk Load (tiberius `bulk_insert`) for homogeneous INSERT batches, falls back to multi-value INSERT
+- Consumer detects homogeneous INSERT batches and routes to bulk insert path when threshold met
 
 ## Important Files
 
 - `pg2any-lib/src/client.rs` - Core orchestration logic (~1500 lines), producer/consumer tasks
-- `pg2any-lib/src/transaction_manager.rs` - File-based transaction lifecycle
+- `pg2any-lib/src/transaction_manager.rs` - File-based transaction lifecycle + bulk insert routing
 - `pg2any-lib/src/destinations/destination_factory.rs` - `DestinationHandler` trait definition
+- `pg2any-lib/src/destinations/mysql.rs` - MySQL destination (sqlx + mysql_async dual pool)
+- `pg2any-lib/src/destinations/bulk_insert.rs` - INSERT detection (backtick + bracket), TSV generation, multi-value INSERT fallback
+- `pg2any-lib/src/destinations/coalescing.rs` - DML coalescing (multi-value INSERT, CASE-WHEN UPDATE)
 - `pg2any-lib/src/config.rs` - All configuration fields and builder
 - `pg2any-lib/src/env.rs` - Environment variable mapping
 - `pg2any-lib/src/error.rs` - Error types (transient vs permanent classification matters for retry logic)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,6 +239,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "btoi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd6407f73a9b8b6162d8a2ef999fe6afd7cc15902ebf42c5cd296addf17e0ad"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -491,6 +500,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.112",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.112",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -683,6 +727,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
@@ -897,7 +947,7 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -905,6 +955,11 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
@@ -1056,7 +1111,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-layer",
@@ -1177,6 +1232,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1239,6 +1300,15 @@ checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "keyed_priority_queue"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ee7893dab2e44ae5f9d0173f26ff4aa327c10b01b06a72b52dd9405b628640d"
+dependencies = [
+ "indexmap",
 ]
 
 [[package]]
@@ -1336,6 +1406,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1395,6 +1474,83 @@ dependencies = [
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "mysql-common-derive"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66f62cad7623a9cb6f8f64037f0c4f69c8db8e82914334a83c9788201c2c1bfa"
+dependencies = [
+ "darling",
+ "heck",
+ "num-bigint",
+ "proc-macro-crate",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.112",
+ "termcolor",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "mysql_async"
+version = "0.36.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1d9585dc9058886ff3a1f48a23024dd1d054264dee7c5ae0e4bd640c953bee5"
+dependencies = [
+ "bytes",
+ "crossbeam-queue",
+ "flate2",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "keyed_priority_queue",
+ "lru",
+ "mysql_common",
+ "pem",
+ "percent-encoding",
+ "rand 0.9.4",
+ "rustls",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "socket2 0.5.10",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "twox-hash",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "mysql_common"
+version = "0.35.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbb9f371618ce723f095c61fbcdc36e8936956d2b62832f9c7648689b338e052"
+dependencies = [
+ "base64",
+ "bitflags 2.11.0",
+ "btoi",
+ "byteorder",
+ "bytes",
+ "crc32fast",
+ "flate2",
+ "getrandom 0.3.4",
+ "mysql-common-derive",
+ "num-bigint",
+ "num-traits",
+ "regex",
+ "saturating",
+ "serde",
+ "serde_json",
+ "sha1",
+ "sha2 0.10.9",
+ "thiserror 2.0.18",
+ "uuid",
 ]
 
 [[package]]
@@ -1587,6 +1743,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
+]
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1626,6 +1792,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "lazy_static",
+ "mysql_async",
  "pg_walstream",
  "prometheus",
  "rdkafka",
@@ -1654,7 +1821,7 @@ dependencies = [
  "rustls",
  "serde",
  "smallvec",
- "socket2",
+ "socket2 0.6.3",
  "tokio",
  "tokio-rustls",
  "tokio-util",
@@ -1760,6 +1927,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
  "toml_edit",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.112",
 ]
 
 [[package]]
@@ -1903,6 +2092,16 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
@@ -1933,6 +2132,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1948,6 +2157,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.16",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -2012,6 +2230,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f3fe0889e69e2ae9e41f4d6c4c0181701d00e4697b356fb1f74173a5e0ee27"
 dependencies = [
  "bitflags 2.11.0",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -2162,6 +2392,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2193,6 +2432,12 @@ name = "ryu"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
+
+[[package]]
+name = "saturating"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ece8e78b2f38ec51c51f5d475df0a7187ba5111b2a28bdc761ee05b075d40a71"
 
 [[package]]
 name = "schannel"
@@ -2392,6 +2637,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2639,6 +2894,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2715,6 +2976,15 @@ dependencies = [
  "once_cell",
  "rustix 1.1.3",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -2853,7 +3123,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -3013,6 +3283,12 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "typenum"
@@ -3278,6 +3554,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 pg_walstream = { version = "0.6.3", default-features = false, features = ["rustls-tls"] }
 tiberius = { version = "0.12.3", features = ["tds73", "sql-browser-tokio", "bigdecimal", "rust_decimal", "time", "chrono"] }
 sqlx = { version = "0.8.6", features = ["runtime-tokio-rustls", "mysql", "sqlite", "chrono", "uuid"] }
+mysql_async = { version = "0.36.2", default-features = false, features = ["default-rustls"] }
 flate2 = "1.1.9"
 async-compression = { version = "0.4.42", features = ["tokio", "gzip"] }
 rdkafka = { version = "0.39", features = ["cmake-build", "tokio"] }

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A high-performance PostgreSQL Change Data Capture (CDC) tool that streams databa
 
 | Destination | Driver | Feature Flag |
 |-------------|--------|--------------|
-| MySQL | SQLx | `mysql` (default) |
+| MySQL | SQLx + mysql_async | `mysql` (default) |
 | SQL Server | Tiberius (TDS) | `sqlserver` (default) |
 | SQLite | SQLx | `sqlite` (default) |
 | Kafka | rdkafka (librdkafka) | `kafka` |
@@ -25,6 +25,8 @@ A high-performance PostgreSQL Change Data Capture (CDC) tool that streams databa
 - **Schema mapping** - Configurable PostgreSQL schema to destination database/schema translation
 - **Prometheus metrics** - Built-in HTTP metrics endpoint (feature: `metrics`)
 - **Graceful shutdown** - Coordinated producer-consumer shutdown with LSN persistence
+- **Bulk insert optimization** - LOAD DATA LOCAL INFILE for MySQL, TDS Bulk Load for SQL Server + session tuning for large batches
+- **DML coalescing** - Multi-value INSERT, CASE-WHEN UPDATE, OR-combined DELETE batching
 
 ## Quick Start
 
@@ -238,12 +240,14 @@ All configuration is via environment variables (ideal for containers) or the `Co
 | `CDC_STREAMING` | `true` | Stream in-progress transactions (requires protocol v2+) |
 | `CDC_SCHEMA_MAPPING` | | Schema translation, e.g. `public:cdc_db,sales:sales_db` |
 | `CDC_BUFFER_SIZE` | `500` | Transaction channel capacity |
+| `CDC_COMMIT_BATCH_SIZE` | `1000` | SQL commands per batch execution |
 | `CDC_TRANSACTION_SEGMENT_SIZE_MB` | `64` | Max segment file size in MB |
 | `CDC_CONNECTION_TIMEOUT` | `30` | Connection timeout (seconds) |
 | `CDC_QUERY_TIMEOUT` | `10` | Query timeout (seconds) |
 | `CDC_LAST_LSN_FILE` | `./pg2any_last_lsn` | Base path for LSN metadata file |
 | `CDC_TRANSACTION_FILE_BASE_PATH` | `./` | Base directory for transaction files |
 | `PG2ANY_ENABLE_COMPRESSION` | `false` | Enable gzip compression for SQL files |
+| `CDC_BULK_INSERT_THRESHOLD` | `500` | Minimum INSERT statements to trigger bulk path |
 | `RUST_LOG` | `pg2any=debug` | Log level |
 
 ## Monitoring
@@ -289,7 +293,7 @@ make pgbench-test-mysql-full
 ```toml
 [features]
 default = ["mysql", "sqlserver", "sqlite"]
-mysql = ["sqlx/mysql"]
+mysql = ["sqlx/mysql", "mysql_async"]
 sqlserver = ["tiberius"]
 sqlite = ["sqlx/sqlite"]
 kafka = ["rdkafka", "futures-util", "base64"]
@@ -303,6 +307,7 @@ metrics = ["hyper", "hyper-util", "http-body-util", "prometheus"]
 | [pg_walstream](https://crates.io/crates/pg_walstream) | PostgreSQL logical replication protocol |
 | tokio | Async runtime |
 | sqlx | MySQL + SQLite async driver |
+| mysql_async | MySQL LOAD DATA LOCAL INFILE support |
 | tiberius | SQL Server TDS protocol |
 | rdkafka | Kafka producer (librdkafka wrapper) |
 | serde / serde_json | Serialization |

--- a/pg2any-lib/Cargo.toml
+++ b/pg2any-lib/Cargo.toml
@@ -28,6 +28,7 @@ flate2 = { workspace = true }
 async-compression = { workspace = true }
 tiberius = { workspace = true, optional = true }
 sqlx = { workspace = true, optional = true }
+mysql_async = { workspace = true, optional = true }
 rdkafka = { workspace = true, optional = true }
 futures-util = { workspace = true, optional = true }
 base64 = { workspace = true, optional = true }
@@ -39,7 +40,7 @@ http-body-util = { workspace = true, optional = true }
 
 [features]
 default = ["mysql", "sqlserver", "sqlite"]
-mysql = ["sqlx/mysql"]
+mysql = ["sqlx/mysql", "mysql_async", "futures-util"]
 sqlserver = ["tiberius"]
 sqlite = ["sqlx/sqlite"]
 kafka = ["rdkafka", "futures-util", "base64"]

--- a/pg2any-lib/src/client.rs
+++ b/pg2any-lib/src/client.rs
@@ -116,6 +116,7 @@ impl CdcClient {
         )
         .await?;
         manager.set_schema_mappings(config.schema_mappings.clone());
+        manager.set_bulk_insert_config(config.bulk_insert_threshold);
 
         if destination_handler.supports_event_mode() {
             info!(

--- a/pg2any-lib/src/config.rs
+++ b/pg2any-lib/src/config.rs
@@ -93,6 +93,9 @@ pub struct Config {
 
     /// Additional configuration options
     pub extra_options: HashMap<String, String>,
+
+    /// Minimum number of INSERT statements to trigger bulk insert mode
+    pub bulk_insert_threshold: usize,
 }
 
 /// Origin filtering options
@@ -193,6 +196,7 @@ impl Default for Config {
             transaction_file_base_path: ".".to_string(),
             transaction_segment_size_bytes: 64 * 1024 * 1024,
             extra_options: HashMap::new(),
+            bulk_insert_threshold: 500,
         }
     }
 }
@@ -389,6 +393,11 @@ impl ConfigBuilder {
         V: Into<String>,
     {
         self.config.extra_options.insert(key.into(), value.into());
+        self
+    }
+
+    pub fn bulk_insert_threshold(mut self, threshold: usize) -> Self {
+        self.config.bulk_insert_threshold = threshold;
         self
     }
 

--- a/pg2any-lib/src/destinations/bulk_insert.rs
+++ b/pg2any-lib/src/destinations/bulk_insert.rs
@@ -1,0 +1,220 @@
+//! Shared bulk insert utilities: INSERT batch detection and multi-value INSERT generation.
+//!
+//! This module is conditionally compiled when either `mysql` or `sqlserver` feature is enabled.
+//! Destination-specific bulk load logic lives in each destination's own module.
+
+#[derive(Debug, Clone)]
+pub struct ParsedBulkInsert {
+    pub table: String,
+    pub columns: Vec<String>,
+    pub rows: Vec<Vec<String>>,
+}
+
+pub fn detect_bulk_insert_batch(statements: &[String]) -> Option<ParsedBulkInsert> {
+    if statements.is_empty() {
+        return None;
+    }
+
+    let first = parse_insert_prefix(&statements[0])?;
+    let expected_prefix = &first.0;
+    let columns = first.1.clone();
+    let table = first.2.clone();
+
+    let mut rows: Vec<Vec<String>> = Vec::with_capacity(statements.len());
+
+    let first_trimmed = statements[0].trim();
+    let values = parse_values_tuple(&first_trimmed[expected_prefix.len()..])?;
+    rows.push(values);
+
+    for stmt in &statements[1..] {
+        let trimmed_stmt = stmt.trim();
+        if !trimmed_stmt.starts_with(expected_prefix.as_str()) {
+            return None;
+        }
+        let values = parse_values_tuple(&trimmed_stmt[expected_prefix.len()..])?;
+        rows.push(values);
+    }
+
+    Some(ParsedBulkInsert {
+        table,
+        columns,
+        rows,
+    })
+}
+
+pub fn build_multi_value_insert(table: &str, columns: &[String], rows: &[Vec<String>]) -> String {
+    let col_list = columns.join(", ");
+    let mut sql = format!("INSERT INTO {} ({}) VALUES ", table, col_list);
+    for (i, row) in rows.iter().enumerate() {
+        if i > 0 {
+            sql.push_str(", ");
+        }
+        sql.push('(');
+        sql.push_str(&row.join(", "));
+        sql.push(')');
+    }
+    sql.push(';');
+    sql
+}
+
+fn parse_insert_prefix(sql: &str) -> Option<(String, Vec<String>, String)> {
+    let trimmed = sql.trim();
+    if !trimmed
+        .get(..7)
+        .map(|s| s.eq_ignore_ascii_case("INSERT "))
+        .unwrap_or(false)
+    {
+        return None;
+    }
+
+    let values_pos = find_case_insensitive(trimmed, " VALUES ")?;
+    let prefix = &trimmed[..values_pos + 8];
+
+    let into_pos = find_case_insensitive(trimmed, "INTO ")?;
+    let after_into = &trimmed[into_pos + 5..];
+
+    let col_paren_pos = after_into.find('(')?;
+    let table = after_into[..col_paren_pos].trim().to_string();
+
+    let col_section = &after_into[col_paren_pos..];
+    let close_paren = col_section.find(')')?;
+    let col_list = &col_section[1..close_paren];
+    let columns: Vec<String> = col_list.split(',').map(|c| c.trim().to_string()).collect();
+
+    Some((prefix.to_string(), columns, table))
+}
+
+fn find_case_insensitive(haystack: &str, needle: &str) -> Option<usize> {
+    let h = haystack.as_bytes();
+    let n = needle.as_bytes();
+    let n_len = n.len();
+    if h.len() < n_len {
+        return None;
+    }
+    for i in 0..=(h.len() - n_len) {
+        if h[i..i + n_len].eq_ignore_ascii_case(n) {
+            return Some(i);
+        }
+    }
+    None
+}
+
+fn parse_values_tuple(values_part: &str) -> Option<Vec<String>> {
+    let trimmed = values_part
+        .trim()
+        .strip_suffix(';')
+        .unwrap_or(values_part.trim())
+        .trim();
+    if !trimmed.starts_with('(') || !trimmed.ends_with(')') {
+        return None;
+    }
+    let inner = &trimmed[1..trimmed.len() - 1];
+
+    let mut values = Vec::new();
+    let mut current = String::new();
+    let mut in_quotes = false;
+    let mut chars = inner.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        match ch {
+            '\\' if in_quotes => {
+                current.push(ch);
+                if let Some(next) = chars.next() {
+                    current.push(next);
+                }
+            }
+            '\'' if !in_quotes => {
+                in_quotes = true;
+                current.push(ch);
+            }
+            '\'' if in_quotes => {
+                current.push(ch);
+                if chars.peek() == Some(&'\'') {
+                    current.push(chars.next().unwrap());
+                } else {
+                    in_quotes = false;
+                }
+            }
+            ',' if !in_quotes => {
+                values.push(current.trim().to_string());
+                current.clear();
+            }
+            _ => current.push(ch),
+        }
+    }
+    if !current.is_empty() || !values.is_empty() {
+        values.push(current.trim().to_string());
+    }
+
+    Some(values)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_detect_bulk_insert_same_table() {
+        let stmts = vec![
+            "INSERT INTO `cdc_db`.`t1` (`id`, `name`) VALUES (1, 'hello');".to_string(),
+            "INSERT INTO `cdc_db`.`t1` (`id`, `name`) VALUES (2, 'world');".to_string(),
+            "INSERT INTO `cdc_db`.`t1` (`id`, `name`) VALUES (3, 'foo');".to_string(),
+        ];
+        let result = detect_bulk_insert_batch(&stmts);
+        assert!(result.is_some());
+        let parsed = result.unwrap();
+        assert_eq!(parsed.table, "`cdc_db`.`t1`");
+        assert_eq!(parsed.columns, vec!["`id`", "`name`"]);
+        assert_eq!(parsed.rows.len(), 3);
+        assert_eq!(parsed.rows[0], vec!["1", "'hello'"]);
+    }
+
+    #[test]
+    fn test_detect_bulk_insert_backslash_escaped_quotes() {
+        let stmts = vec![
+            "INSERT INTO `db`.`t1` (`id`, `name`) VALUES (1, 'it\\'s here');".to_string(),
+            "INSERT INTO `db`.`t1` (`id`, `name`) VALUES (2, 'she\\'s there');".to_string(),
+        ];
+        let result = detect_bulk_insert_batch(&stmts);
+        assert!(result.is_some());
+        let parsed = result.unwrap();
+        assert_eq!(parsed.rows.len(), 2);
+        assert_eq!(parsed.rows[0], vec!["1", "'it\\'s here'"]);
+        assert_eq!(parsed.rows[1], vec!["2", "'she\\'s there'"]);
+    }
+
+    #[test]
+    fn test_detect_bulk_insert_mixed_tables_returns_none() {
+        let stmts = vec![
+            "INSERT INTO `cdc_db`.`t1` (`id`) VALUES (1);".to_string(),
+            "INSERT INTO `cdc_db`.`t2` (`id`) VALUES (2);".to_string(),
+        ];
+        let result = detect_bulk_insert_batch(&stmts);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_detect_bulk_insert_with_update_returns_none() {
+        let stmts = vec![
+            "INSERT INTO `cdc_db`.`t1` (`id`) VALUES (1);".to_string(),
+            "UPDATE `cdc_db`.`t1` SET `id` = 2 WHERE `id` = 1;".to_string(),
+        ];
+        let result = detect_bulk_insert_batch(&stmts);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_build_multi_value_insert() {
+        let table = "`cdc_db`.`t1`";
+        let columns = vec!["`id`".to_string(), "`name`".to_string()];
+        let rows = vec![
+            vec!["1".to_string(), "'hello'".to_string()],
+            vec!["2".to_string(), "'world'".to_string()],
+        ];
+        let sql = build_multi_value_insert(table, &columns, &rows);
+        assert_eq!(
+            sql,
+            "INSERT INTO `cdc_db`.`t1` (`id`, `name`) VALUES (1, 'hello'), (2, 'world');"
+        );
+    }
+}

--- a/pg2any-lib/src/destinations/bulk_insert.rs
+++ b/pg2any-lib/src/destinations/bulk_insert.rs
@@ -50,7 +50,12 @@ pub fn build_multi_value_insert(table: &str, columns: &[String], rows: &[Vec<Str
             sql.push_str(", ");
         }
         sql.push('(');
-        sql.push_str(&row.join(", "));
+        for (j, val) in row.iter().enumerate() {
+            if j > 0 {
+                sql.push_str(", ");
+            }
+            sql.push_str(val);
+        }
         sql.push(')');
     }
     sql.push(';');

--- a/pg2any-lib/src/destinations/destination_factory.rs
+++ b/pg2any-lib/src/destinations/destination_factory.rs
@@ -95,6 +95,37 @@ pub trait DestinationHandler: Send + Sync {
             "Event mode not supported by this destination",
         ))
     }
+
+    fn supports_bulk_insert(&self) -> bool {
+        false
+    }
+
+    async fn execute_bulk_insert_with_hook(
+        &mut self,
+        table: &str,
+        columns: &[String],
+        rows: &[Vec<String>],
+        pre_commit_hook: Option<PreCommitHook>,
+    ) -> Result<()> {
+        if rows.is_empty() {
+            return Ok(());
+        }
+        #[cfg(any(feature = "mysql", feature = "sqlserver"))]
+        {
+            let sql =
+                crate::destinations::bulk_insert::build_multi_value_insert(table, columns, rows);
+            return self
+                .execute_sql_batch_with_hook(&[sql], pre_commit_hook)
+                .await;
+        }
+        #[cfg(not(any(feature = "mysql", feature = "sqlserver")))]
+        {
+            let _ = (table, columns, rows, pre_commit_hook);
+            Err(CdcError::unsupported(
+                "Bulk insert not available without mysql or sqlserver feature",
+            ))
+        }
+    }
 }
 
 /// Factory for creating destination handlers

--- a/pg2any-lib/src/destinations/mod.rs
+++ b/pg2any-lib/src/destinations/mod.rs
@@ -1,6 +1,10 @@
 pub mod coalescing;
 pub mod common;
 
+/// Bulk insert utilities (TSV generation, INSERT detection)
+#[cfg(any(feature = "mysql", feature = "sqlserver"))]
+pub mod bulk_insert;
+
 /// MySQL destination implementation
 #[cfg(feature = "mysql")]
 pub mod mysql;

--- a/pg2any-lib/src/destinations/mysql.rs
+++ b/pg2any-lib/src/destinations/mysql.rs
@@ -257,7 +257,7 @@ impl MySQLDestination {
         if let Err(e) = result {
             *self.infile_data.lock().unwrap() = None;
             debug!("LOAD DATA LOCAL INFILE failed, falling back to multi-value INSERT: {e}");
-            drop(tx);
+            let _ = tx.rollback().await;
 
             let sql = super::bulk_insert::build_multi_value_insert(table, columns, rows);
             return self
@@ -267,7 +267,7 @@ impl MySQLDestination {
 
         if let Some(hook) = pre_commit_hook {
             if let Err(e) = hook().await {
-                drop(tx);
+                let _ = tx.rollback().await;
                 return Err(CdcError::generic(format!(
                     "MySQL bulk insert pre-commit hook failed, rolled back: {e}"
                 )));

--- a/pg2any-lib/src/destinations/mysql.rs
+++ b/pg2any-lib/src/destinations/mysql.rs
@@ -300,6 +300,8 @@ fn generate_tsv_buffer(rows: &[Vec<String>]) -> Vec<u8> {
             } else if trimmed.len() >= 2 && trimmed.starts_with('\'') && trimmed.ends_with('\'') {
                 let unquoted = &trimmed[1..trimmed.len() - 1];
                 tsv_escape_string(unquoted, &mut buf);
+            } else if let Some(decoded) = decode_hex_literal(trimmed) {
+                tsv_escape_raw(&decoded, &mut buf);
             } else {
                 tsv_escape_raw(trimmed.as_bytes(), &mut buf);
             }
@@ -308,6 +310,25 @@ fn generate_tsv_buffer(rows: &[Vec<String>]) -> Vec<u8> {
     }
 
     buf
+}
+
+/// Decode MySQL hex literal (X'aabb' or x'aabb') into raw bytes.
+fn decode_hex_literal(s: &str) -> Option<Vec<u8>> {
+    if s.len() < 3 {
+        return None;
+    }
+    if !(s.starts_with("X'") || s.starts_with("x'")) || !s.ends_with('\'') {
+        return None;
+    }
+    let hex_str = &s[2..s.len() - 1];
+    if hex_str.len() % 2 != 0 || !hex_str.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return None;
+    }
+    let bytes: Vec<u8> = (0..hex_str.len())
+        .step_by(2)
+        .map(|i| u8::from_str_radix(&hex_str[i..i + 2], 16).unwrap())
+        .collect();
+    Some(bytes)
 }
 
 /// Unescape MySQL SQL literal content and re-encode for TSV format.
@@ -426,5 +447,39 @@ mod tests {
         assert_eq!(lines[1], "2\tline1\\nline2");
         // SQL \\ → literal backslash → TSV \\
         assert_eq!(lines[2], "3\tback\\\\slash");
+    }
+
+    #[test]
+    fn test_tsv_hex_literal_decoding() {
+        let rows = vec![vec![
+            "1".to_string(),
+            "X'deadbeef'".to_string(),
+            "'text'".to_string(),
+        ]];
+        let tsv = generate_tsv_buffer(&rows);
+        assert_eq!(tsv, b"1\t\xde\xad\xbe\xef\ttext\n");
+    }
+
+    #[test]
+    fn test_tsv_hex_literal_lowercase() {
+        let rows = vec![vec!["1".to_string(), "x'cafe'".to_string()]];
+        let tsv = generate_tsv_buffer(&rows);
+        assert_eq!(tsv, b"1\t\xca\xfe\n");
+    }
+
+    #[test]
+    fn test_tsv_hex_literal_with_special_bytes() {
+        // Hex containing tab, newline, backslash bytes should be TSV-escaped
+        let rows = vec![vec!["1".to_string(), "X'090a5c00'".to_string()]];
+        let tsv = generate_tsv_buffer(&rows);
+        assert_eq!(tsv, b"1\t\\t\\n\\\\\\0\n");
+    }
+
+    #[test]
+    fn test_decode_hex_literal_invalid() {
+        assert!(decode_hex_literal("hello").is_none());
+        assert!(decode_hex_literal("X'zz'").is_none());
+        assert!(decode_hex_literal("X'abc'").is_none()); // odd length
+        assert!(decode_hex_literal("0xdead").is_none()); // 0x prefix is SQL Server style
     }
 }

--- a/pg2any-lib/src/destinations/mysql.rs
+++ b/pg2any-lib/src/destinations/mysql.rs
@@ -255,6 +255,7 @@ impl MySQLDestination {
         let result = tx.query_drop(&load_sql).await;
 
         if let Err(e) = result {
+            *self.infile_data.lock().unwrap() = None;
             debug!("LOAD DATA LOCAL INFILE failed, falling back to multi-value INSERT: {e}");
             drop(tx);
 

--- a/pg2any-lib/src/destinations/mysql.rs
+++ b/pg2any-lib/src/destinations/mysql.rs
@@ -3,29 +3,29 @@ use crate::error::{CdcError, Result};
 use async_trait::async_trait;
 use sqlx::MySqlPool;
 use std::collections::HashMap;
-use tracing::{debug, info};
+use std::sync::{Arc, Mutex};
+use tracing::{debug, info, warn};
 
 use super::coalescing::{coalesce_commands, QuoteStyle};
 
-// ============================================================================
-// MySQL Destination Implementation
-// ============================================================================
-
 pub struct MySQLDestination {
     pool: Option<MySqlPool>,
-    /// Schema mappings: maps source schema to destination database
+    bulk_pool: Option<mysql_async::Pool>,
+    infile_data: Arc<Mutex<Option<bytes::Bytes>>>,
     schema_mappings: HashMap<String, String>,
-    /// MySQL max_allowed_packet value in bytes (default 64MB, max 1GB), Used to calculate safe batch sizes dynamically
     max_allowed_packet: u64,
+    load_data_available: bool,
 }
 
 impl MySQLDestination {
-    /// Create a new MySQL destination instance
     pub fn new() -> Self {
         Self {
             pool: None,
+            bulk_pool: None,
+            infile_data: Arc::new(Mutex::new(None)),
             schema_mappings: HashMap::new(),
-            max_allowed_packet: 67108864, // Default 64MB
+            max_allowed_packet: 67108864,
+            load_data_available: false,
         }
     }
 }
@@ -41,14 +41,12 @@ impl DestinationHandler for MySQLDestination {
     async fn connect(&mut self, connection_string: &str) -> Result<()> {
         let pool = MySqlPool::connect(connection_string).await?;
 
-        // Query max_allowed_packet to calculate optimal batch sizes
         let row: (String, String) = sqlx::query_as("SHOW VARIABLES LIKE 'max_allowed_packet'")
             .fetch_one(&pool)
             .await
             .map_err(|e| CdcError::generic(format!("Failed to query max_allowed_packet: {e}")))?;
 
-        // Parse the string value to u64
-        self.max_allowed_packet = row.1.parse::<u64>().unwrap_or(67108864); // Default to 64MB if parse fails
+        self.max_allowed_packet = row.1.parse::<u64>().unwrap_or(67108864);
 
         info!(
             "MySQL max_allowed_packet: {} bytes ({:.2} MB)",
@@ -57,6 +55,53 @@ impl DestinationHandler for MySQLDestination {
         );
 
         self.pool = Some(pool);
+
+        let opts = mysql_async::Opts::from_url(connection_string).map_err(|e| {
+            CdcError::generic(format!("Failed to parse MySQL URL for bulk pool: {e}"))
+        })?;
+
+        let infile_data = self.infile_data.clone();
+        let opts = mysql_async::OptsBuilder::from_opts(opts).local_infile_handler(Some(
+            move |_file_name: &[u8]| {
+                let data = infile_data.clone();
+                Box::pin(async move {
+                    let bytes = data
+                        .lock()
+                        .unwrap()
+                        .take()
+                        .unwrap_or_else(|| bytes::Bytes::new());
+                    let stream =
+                        futures_util::stream::once(async move { Ok::<_, std::io::Error>(bytes) });
+                    Ok(Box::pin(stream) as mysql_async::InfileData)
+                })
+                    as futures_util::future::BoxFuture<
+                        'static,
+                        std::result::Result<mysql_async::InfileData, mysql_async::LocalInfileError>,
+                    >
+            },
+        ));
+
+        let bulk_pool = mysql_async::Pool::new(opts);
+        self.bulk_pool = Some(bulk_pool);
+
+        match self.check_load_data_available().await {
+            Ok(available) => {
+                self.load_data_available = available;
+                if available {
+                    info!("MySQL LOAD DATA LOCAL INFILE: available");
+                } else {
+                    warn!("MySQL LOAD DATA LOCAL INFILE: not available, falling back to multi-value INSERT");
+                }
+            }
+            Err(e) => {
+                warn!(
+                    "Failed to check LOAD DATA availability: {}, falling back to multi-value INSERT",
+                    e
+                );
+                self.load_data_available = false;
+            }
+        }
+
         Ok(())
     }
 
@@ -84,10 +129,6 @@ impl DestinationHandler for MySQLDestination {
             .as_ref()
             .ok_or_else(|| CdcError::generic("MySQL pool not initialized"))?;
 
-        // Coalesce consecutive DML statements before executing:
-        // - INSERT → multi-value INSERT
-        // - UPDATE → CASE-WHEN batch UPDATE
-        // - DELETE → OR-combined WHERE clause
         let coalesced = coalesce_commands(commands, self.max_allowed_packet, QuoteStyle::Backtick);
 
         if coalesced.len() < commands.len() {
@@ -103,13 +144,223 @@ impl DestinationHandler for MySQLDestination {
             .await
     }
 
+    fn supports_bulk_insert(&self) -> bool {
+        self.load_data_available
+    }
+
+    async fn execute_bulk_insert_with_hook(
+        &mut self,
+        table: &str,
+        columns: &[String],
+        rows: &[Vec<String>],
+        pre_commit_hook: Option<PreCommitHook>,
+    ) -> Result<()> {
+        if rows.is_empty() {
+            return Ok(());
+        }
+
+        if !self.load_data_available {
+            let sql = super::bulk_insert::build_multi_value_insert(table, columns, rows);
+            return self
+                .execute_sql_batch_with_hook(&[sql], pre_commit_hook)
+                .await;
+        }
+
+        self.execute_load_data(table, columns, rows, pre_commit_hook)
+            .await
+    }
+
     async fn close(&mut self) -> Result<()> {
         if let Some(pool) = &self.pool {
             pool.close().await;
         }
         self.pool = None;
+
+        if let Some(pool) = self.bulk_pool.take() {
+            pool.disconnect().await.map_err(|e| {
+                CdcError::generic(format!("Failed to disconnect mysql_async pool: {e}"))
+            })?;
+        }
+
         info!("MySQL connection closed successfully");
         Ok(())
+    }
+}
+
+impl MySQLDestination {
+    async fn check_load_data_available(&self) -> Result<bool> {
+        use mysql_async::prelude::*;
+
+        let pool = self
+            .bulk_pool
+            .as_ref()
+            .ok_or_else(|| CdcError::generic("Bulk pool not initialized"))?;
+
+        let mut conn = pool
+            .get_conn()
+            .await
+            .map_err(|e| CdcError::generic(format!("Failed to get bulk connection: {e}")))?;
+
+        let result: Option<(String, String)> = conn
+            .query_first("SHOW VARIABLES LIKE 'local_infile'")
+            .await
+            .map_err(|e| CdcError::generic(format!("Failed to check local_infile: {e}")))?;
+
+        drop(conn);
+
+        match result {
+            Some((_, value)) => Ok(value.eq_ignore_ascii_case("ON")),
+            None => Ok(false),
+        }
+    }
+
+    async fn execute_load_data(
+        &mut self,
+        table: &str,
+        columns: &[String],
+        rows: &[Vec<String>],
+        pre_commit_hook: Option<PreCommitHook>,
+    ) -> Result<()> {
+        use mysql_async::prelude::*;
+
+        let pool = self
+            .bulk_pool
+            .as_ref()
+            .ok_or_else(|| CdcError::generic("Bulk pool not initialized"))?;
+
+        let tsv_data = generate_tsv_buffer(rows);
+        let row_count = rows.len();
+
+        debug!(
+            "Executing LOAD DATA LOCAL INFILE for {} rows ({} bytes TSV) into {}",
+            row_count,
+            tsv_data.len(),
+            table
+        );
+
+        let mut tx = pool
+            .start_transaction(mysql_async::TxOpts::default())
+            .await
+            .map_err(|e| CdcError::generic(format!("MySQL START TRANSACTION failed: {e}")))?;
+
+        let col_spec = columns.join(", ");
+        let load_sql = format!(
+            "LOAD DATA LOCAL INFILE 'data.tsv' INTO TABLE {} \
+             FIELDS TERMINATED BY '\\t' LINES TERMINATED BY '\\n' ({})",
+            table, col_spec
+        );
+
+        *self.infile_data.lock().unwrap() = Some(bytes::Bytes::from(tsv_data));
+
+        let result = tx.query_drop(&load_sql).await;
+
+        if let Err(e) = result {
+            debug!("LOAD DATA LOCAL INFILE failed, falling back to multi-value INSERT: {e}");
+            drop(tx);
+
+            let sql = super::bulk_insert::build_multi_value_insert(table, columns, rows);
+            return self
+                .execute_sql_batch_with_hook(&[sql], pre_commit_hook)
+                .await;
+        }
+
+        if let Some(hook) = pre_commit_hook {
+            if let Err(e) = hook().await {
+                drop(tx);
+                return Err(CdcError::generic(format!(
+                    "MySQL bulk insert pre-commit hook failed, rolled back: {e}"
+                )));
+            }
+        }
+
+        tx.commit()
+            .await
+            .map_err(|e| CdcError::generic(format!("MySQL COMMIT failed after LOAD DATA: {e}")))?;
+
+        info!(
+            "LOAD DATA complete: {} rows loaded into {}",
+            row_count, table
+        );
+
+        Ok(())
+    }
+}
+
+fn generate_tsv_buffer(rows: &[Vec<String>]) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(rows.len() * 128);
+
+    for row in rows {
+        for (col_idx, value) in row.iter().enumerate() {
+            if col_idx > 0 {
+                buf.push(b'\t');
+            }
+            let trimmed = value.trim();
+            if trimmed.eq_ignore_ascii_case("NULL") {
+                buf.extend_from_slice(b"\\N");
+            } else if trimmed.len() >= 2 && trimmed.starts_with('\'') && trimmed.ends_with('\'') {
+                let unquoted = &trimmed[1..trimmed.len() - 1];
+                tsv_escape_string(unquoted, &mut buf);
+            } else {
+                tsv_escape_raw(trimmed.as_bytes(), &mut buf);
+            }
+        }
+        buf.push(b'\n');
+    }
+
+    buf
+}
+
+/// Unescape MySQL SQL literal content and re-encode for TSV format.
+/// Input is the content between single quotes from a MySQL SQL literal.
+/// MySQL SQL literals use backslash escaping: \\ → \, \n → newline, \t → tab, etc.
+/// TSV format uses: \\ → \, \n → newline, \t → tab, \N → NULL.
+fn tsv_escape_string(s: &str, buf: &mut Vec<u8>) {
+    let mut chars = s.chars().peekable();
+    while let Some(ch) = chars.next() {
+        match ch {
+            '\'' => {
+                if chars.peek() == Some(&'\'') {
+                    chars.next();
+                }
+                buf.push(b'\'');
+            }
+            '\\' => {
+                match chars.next() {
+                    Some('\\') => buf.extend_from_slice(b"\\\\"), // SQL \\ → literal \ → TSV \\
+                    Some('n') => buf.extend_from_slice(b"\\n"),   // SQL \n → newline → TSV \n
+                    Some('t') => buf.extend_from_slice(b"\\t"),   // SQL \t → tab → TSV \t
+                    Some('r') => buf.extend_from_slice(b"\\r"),   // SQL \r → CR → TSV \r
+                    Some('0') => buf.extend_from_slice(b"\\0"),   // SQL \0 → null → TSV \0
+                    Some(other) => {
+                        // MySQL: \x → x for any unrecognized escape
+                        let mut bytes = [0u8; 4];
+                        buf.extend_from_slice(other.encode_utf8(&mut bytes).as_bytes());
+                    }
+                    None => buf.extend_from_slice(b"\\\\"), // trailing backslash
+                }
+            }
+            '\t' => buf.extend_from_slice(b"\\t"),
+            '\n' => buf.extend_from_slice(b"\\n"),
+            '\r' => buf.extend_from_slice(b"\\r"),
+            '\0' => buf.extend_from_slice(b"\\0"),
+            _ => {
+                let mut bytes = [0u8; 4];
+                buf.extend_from_slice(ch.encode_utf8(&mut bytes).as_bytes());
+            }
+        }
+    }
+}
+
+fn tsv_escape_raw(data: &[u8], buf: &mut Vec<u8>) {
+    for &b in data {
+        match b {
+            b'\\' => buf.extend_from_slice(b"\\\\"),
+            b'\t' => buf.extend_from_slice(b"\\t"),
+            b'\n' => buf.extend_from_slice(b"\\n"),
+            b'\r' => buf.extend_from_slice(b"\\r"),
+            0 => buf.extend_from_slice(b"\\0"),
+            _ => buf.push(b),
+        }
     }
 }
 
@@ -121,5 +372,59 @@ mod tests {
     fn test_mysql_destination_creation() {
         let destination = MySQLDestination::new();
         assert!(destination.pool.is_none());
+        assert!(destination.bulk_pool.is_none());
+        assert!(destination.infile_data.lock().unwrap().is_none());
+        assert!(!destination.load_data_available);
+    }
+
+    #[test]
+    fn test_tsv_generation_basic() {
+        let rows = vec![
+            vec!["1".to_string(), "'hello'".to_string(), "NULL".to_string()],
+            vec!["2".to_string(), "'world'".to_string(), "42".to_string()],
+        ];
+        let tsv = generate_tsv_buffer(&rows);
+        let output = String::from_utf8(tsv).unwrap();
+        assert_eq!(output, "1\thello\t\\N\n2\tworld\t42\n");
+    }
+
+    #[test]
+    fn test_tsv_generation_escaping() {
+        let rows = vec![vec!["3".to_string(), "'it''s escaped'".to_string()]];
+        let tsv = generate_tsv_buffer(&rows);
+        let output = String::from_utf8(tsv).unwrap();
+        assert!(output.contains("it's escaped"));
+    }
+
+    #[test]
+    fn test_tsv_null_handling() {
+        let rows = vec![
+            vec!["1".to_string(), "NULL".to_string(), "'text'".to_string()],
+            vec!["2".to_string(), "'value'".to_string(), "NULL".to_string()],
+        ];
+        let tsv = generate_tsv_buffer(&rows);
+        let output = String::from_utf8(tsv).unwrap();
+        assert!(output.contains("\\N"));
+        assert!(output.contains("text"));
+        assert!(output.contains("value"));
+    }
+
+    #[test]
+    fn test_tsv_special_characters() {
+        let rows = vec![
+            vec!["1".to_string(), "'hello\\tworld'".to_string()],
+            vec!["2".to_string(), "'line1\\nline2'".to_string()],
+            // SQL literal '\\' means one backslash; TSV should produce \\
+            vec!["3".to_string(), "'back\\\\slash'".to_string()],
+        ];
+        let tsv = generate_tsv_buffer(&rows);
+        let output = String::from_utf8(tsv).unwrap();
+        let lines: Vec<&str> = output.lines().collect();
+        // SQL \t → literal tab → TSV \t
+        assert_eq!(lines[0], "1\thello\\tworld");
+        // SQL \n → literal newline → TSV \n
+        assert_eq!(lines[1], "2\tline1\\nline2");
+        // SQL \\ → literal backslash → TSV \\
+        assert_eq!(lines[2], "3\tback\\\\slash");
     }
 }

--- a/pg2any-lib/src/destinations/sqlserver.rs
+++ b/pg2any-lib/src/destinations/sqlserver.rs
@@ -295,9 +295,29 @@ fn parse_sql_value(value: &str) -> ColumnData<'static> {
         return ColumnData::String(Some(Cow::Owned(unescaped)));
     }
 
-    // Send all non-NULL values as strings — SQL Server handles implicit type conversion.
+    if let Some(bytes) = decode_hex_0x(trimmed) {
+        return ColumnData::Binary(Some(Cow::Owned(bytes)));
+    }
+
+    // Send remaining values as strings — SQL Server handles implicit type conversion.
     // Avoids f64 precision loss for large decimals in CDC data.
     ColumnData::String(Some(Cow::Owned(trimmed.to_string())))
+}
+
+/// Decode SQL Server hex literal (0xDEADBEEF) into raw bytes.
+fn decode_hex_0x(s: &str) -> Option<Vec<u8>> {
+    if s.len() < 4 || !s.starts_with("0x") && !s.starts_with("0X") {
+        return None;
+    }
+    let hex_str = &s[2..];
+    if hex_str.len() % 2 != 0 || !hex_str.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return None;
+    }
+    let bytes: Vec<u8> = (0..hex_str.len())
+        .step_by(2)
+        .map(|i| u8::from_str_radix(&hex_str[i..i + 2], 16).unwrap())
+        .collect();
+    Some(bytes)
 }
 
 #[cfg(test)]
@@ -368,5 +388,31 @@ mod tests {
             result,
             ColumnData::String(Some(Cow::Owned("some_value".to_string())))
         );
+    }
+
+    #[test]
+    fn test_parse_sql_value_hex_binary() {
+        let result = parse_sql_value("0xDEADBEEF");
+        assert_eq!(
+            result,
+            ColumnData::Binary(Some(Cow::Owned(vec![0xDE, 0xAD, 0xBE, 0xEF])))
+        );
+    }
+
+    #[test]
+    fn test_parse_sql_value_hex_binary_lowercase() {
+        let result = parse_sql_value("0xcafe");
+        assert_eq!(
+            result,
+            ColumnData::Binary(Some(Cow::Owned(vec![0xCA, 0xFE])))
+        );
+    }
+
+    #[test]
+    fn test_decode_hex_0x_invalid() {
+        assert!(decode_hex_0x("hello").is_none());
+        assert!(decode_hex_0x("0x").is_none());
+        assert!(decode_hex_0x("0xZZ").is_none());
+        assert!(decode_hex_0x("0xABC").is_none()); // odd length
     }
 }

--- a/pg2any-lib/src/destinations/sqlserver.rs
+++ b/pg2any-lib/src/destinations/sqlserver.rs
@@ -2,11 +2,12 @@ use super::coalescing::{coalesce_commands, QuoteStyle};
 use super::destination_factory::{DestinationHandler, PreCommitHook};
 use crate::error::{CdcError, Result};
 use async_trait::async_trait;
+use std::borrow::Cow;
 use std::collections::HashMap;
-use tiberius::{Client, Config};
+use tiberius::{Client, ColumnData, Config, TokenRow};
 use tokio::net::TcpStream;
 use tokio_util::compat::{Compat, TokioAsyncWriteCompatExt};
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 /// SQL Server destination implementation
 pub struct SqlServerDestination {
@@ -151,12 +152,158 @@ impl DestinationHandler for SqlServerDestination {
         info!("SQL Server connection closed successfully");
         Ok(())
     }
+
+    fn supports_bulk_insert(&self) -> bool {
+        true
+    }
+
+    async fn execute_bulk_insert_with_hook(
+        &mut self,
+        table: &str,
+        columns: &[String],
+        rows: &[Vec<String>],
+        pre_commit_hook: Option<PreCommitHook>,
+    ) -> Result<()> {
+        if rows.is_empty() {
+            return Ok(());
+        }
+
+        let row_count = rows.len();
+        let bulk_table = table.trim();
+
+        debug!(
+            "Attempting TDS Bulk Load: {} rows into {}",
+            row_count, bulk_table
+        );
+
+        let client = self
+            .client
+            .as_mut()
+            .ok_or_else(|| CdcError::generic("SQL Server client not initialized"))?;
+
+        client
+            .simple_query("BEGIN TRANSACTION")
+            .await
+            .map_err(|e| {
+                CdcError::generic(format!(
+                    "SQL Server BEGIN TRANSACTION failed for bulk load: {e}"
+                ))
+            })?;
+
+        match client.bulk_insert(bulk_table).await {
+            Ok(mut req) => {
+                for row_values in rows {
+                    let mut token_row = TokenRow::new();
+                    for value in row_values {
+                        token_row.push(parse_sql_value(value));
+                    }
+                    if let Err(e) = req.send(token_row).await {
+                        warn!(
+                            "TDS Bulk Load send failed, falling back to multi-value INSERT: {}",
+                            e
+                        );
+                        let _ = client.simple_query("ROLLBACK TRANSACTION").await;
+                        return self
+                            .fallback_multi_value_insert(table, columns, rows, pre_commit_hook)
+                            .await;
+                    }
+                }
+
+                match req.finalize().await {
+                    Ok(result) => {
+                        info!(
+                            "TDS Bulk Load complete: {} rows loaded into {}",
+                            result.total(),
+                            bulk_table
+                        );
+
+                        if let Some(hook) = pre_commit_hook {
+                            if let Err(e) = hook().await {
+                                let _ = client.simple_query("ROLLBACK TRANSACTION").await;
+                                return Err(CdcError::generic(format!(
+                                    "SQL Server bulk insert pre-commit hook failed, rolled back: {}",
+                                    e
+                                )));
+                            }
+                        }
+
+                        client
+                            .simple_query("COMMIT TRANSACTION")
+                            .await
+                            .map_err(|e| {
+                                CdcError::generic(format!(
+                                    "SQL Server COMMIT TRANSACTION failed after bulk load: {e}"
+                                ))
+                            })?;
+
+                        Ok(())
+                    }
+                    Err(e) => {
+                        warn!(
+                            "TDS Bulk Load finalize failed, falling back to multi-value INSERT: {}",
+                            e
+                        );
+                        let _ = client.simple_query("ROLLBACK TRANSACTION").await;
+                        self.fallback_multi_value_insert(table, columns, rows, pre_commit_hook)
+                            .await
+                    }
+                }
+            }
+            Err(e) => {
+                warn!(
+                    "TDS Bulk Load init failed, falling back to multi-value INSERT: {}",
+                    e
+                );
+                let _ = client.simple_query("ROLLBACK TRANSACTION").await;
+                self.fallback_multi_value_insert(table, columns, rows, pre_commit_hook)
+                    .await
+            }
+        }
+    }
 }
 
 impl Default for SqlServerDestination {
     fn default() -> Self {
         Self::new()
     }
+}
+
+impl SqlServerDestination {
+    async fn fallback_multi_value_insert(
+        &mut self,
+        table: &str,
+        columns: &[String],
+        rows: &[Vec<String>],
+        pre_commit_hook: Option<PreCommitHook>,
+    ) -> Result<()> {
+        let sql = super::bulk_insert::build_multi_value_insert(table, columns, rows);
+        self.execute_sql_batch_with_hook(&[sql], pre_commit_hook)
+            .await
+    }
+}
+
+fn parse_sql_value(value: &str) -> ColumnData<'static> {
+    let trimmed = value.trim();
+
+    if trimmed.eq_ignore_ascii_case("NULL") {
+        return ColumnData::String(None);
+    }
+
+    if trimmed.starts_with('\'') && trimmed.ends_with('\'') {
+        let inner = &trimmed[1..trimmed.len() - 1];
+        let unescaped = inner.replace("''", "'");
+        return ColumnData::String(Some(Cow::Owned(unescaped)));
+    }
+
+    if let Ok(i) = trimmed.parse::<i64>() {
+        return ColumnData::I64(Some(i));
+    }
+
+    if let Ok(f) = trimmed.parse::<f64>() {
+        return ColumnData::F64(Some(f));
+    }
+
+    ColumnData::String(Some(Cow::Owned(trimmed.to_string())))
 }
 
 #[cfg(test)]
@@ -167,5 +314,60 @@ mod tests {
     fn test_sqlserver_destination_creation() {
         let destination = SqlServerDestination::new();
         assert!(destination.client.is_none());
+    }
+
+    #[test]
+    fn test_parse_sql_value_null() {
+        let result = parse_sql_value("NULL");
+        assert!(matches!(result, ColumnData::String(None)));
+    }
+
+    #[test]
+    fn test_parse_sql_value_integer() {
+        let result = parse_sql_value("42");
+        assert!(matches!(result, ColumnData::I64(Some(42))));
+    }
+
+    #[test]
+    fn test_parse_sql_value_negative_integer() {
+        let result = parse_sql_value("-123");
+        assert!(matches!(result, ColumnData::I64(Some(-123))));
+    }
+
+    #[test]
+    fn test_parse_sql_value_float() {
+        let result = parse_sql_value("3.14");
+        if let ColumnData::F64(Some(v)) = result {
+            assert!((v - 3.14).abs() < f64::EPSILON);
+        } else {
+            panic!("Expected F64");
+        }
+    }
+
+    #[test]
+    fn test_parse_sql_value_string() {
+        let result = parse_sql_value("'hello world'");
+        assert_eq!(
+            result,
+            ColumnData::String(Some(Cow::Owned("hello world".to_string())))
+        );
+    }
+
+    #[test]
+    fn test_parse_sql_value_escaped_string() {
+        let result = parse_sql_value("'it''s escaped'");
+        assert_eq!(
+            result,
+            ColumnData::String(Some(Cow::Owned("it's escaped".to_string())))
+        );
+    }
+
+    #[test]
+    fn test_parse_sql_value_unquoted_string() {
+        let result = parse_sql_value("some_value");
+        assert_eq!(
+            result,
+            ColumnData::String(Some(Cow::Owned("some_value".to_string())))
+        );
     }
 }

--- a/pg2any-lib/src/destinations/sqlserver.rs
+++ b/pg2any-lib/src/destinations/sqlserver.rs
@@ -295,14 +295,8 @@ fn parse_sql_value(value: &str) -> ColumnData<'static> {
         return ColumnData::String(Some(Cow::Owned(unescaped)));
     }
 
-    if let Ok(i) = trimmed.parse::<i64>() {
-        return ColumnData::I64(Some(i));
-    }
-
-    if let Ok(f) = trimmed.parse::<f64>() {
-        return ColumnData::F64(Some(f));
-    }
-
+    // Send all non-NULL values as strings — SQL Server handles implicit type conversion.
+    // Avoids f64 precision loss for large decimals in CDC data.
     ColumnData::String(Some(Cow::Owned(trimmed.to_string())))
 }
 
@@ -325,23 +319,28 @@ mod tests {
     #[test]
     fn test_parse_sql_value_integer() {
         let result = parse_sql_value("42");
-        assert!(matches!(result, ColumnData::I64(Some(42))));
+        assert_eq!(
+            result,
+            ColumnData::String(Some(Cow::Owned("42".to_string())))
+        );
     }
 
     #[test]
     fn test_parse_sql_value_negative_integer() {
         let result = parse_sql_value("-123");
-        assert!(matches!(result, ColumnData::I64(Some(-123))));
+        assert_eq!(
+            result,
+            ColumnData::String(Some(Cow::Owned("-123".to_string())))
+        );
     }
 
     #[test]
     fn test_parse_sql_value_float() {
         let result = parse_sql_value("3.14");
-        if let ColumnData::F64(Some(v)) = result {
-            assert!((v - 3.14).abs() < f64::EPSILON);
-        } else {
-            panic!("Expected F64");
-        }
+        assert_eq!(
+            result,
+            ColumnData::String(Some(Cow::Owned("3.14".to_string())))
+        );
     }
 
     #[test]

--- a/pg2any-lib/src/env.rs
+++ b/pg2any-lib/src/env.rs
@@ -103,6 +103,8 @@ pub fn load_config_from_env() -> Result<Config, CdcError> {
     let segment_size_mb = parse_usize_env("CDC_TRANSACTION_SEGMENT_SIZE_MB", 64)?;
     let segment_size_bytes = segment_size_mb.saturating_mul(1024 * 1024);
 
+    let bulk_insert_threshold = parse_usize_env("CDC_BULK_INSERT_THRESHOLD", 500)?;
+
     // Transaction file persistence configuration
     let transaction_file_base_path =
         std::env::var("CDC_TRANSACTION_FILE_BASE_PATH").unwrap_or_else(|_| ".".to_string());
@@ -156,6 +158,7 @@ pub fn load_config_from_env() -> Result<Config, CdcError> {
         .batch_size(batch_size)
         .transaction_file_base_path(transaction_file_base_path)
         .transaction_segment_size_bytes(segment_size_bytes)
+        .bulk_insert_threshold(bulk_insert_threshold)
         .build()?;
 
     tracing::info!("Configuration loaded successfully");

--- a/pg2any-lib/src/transaction_manager.rs
+++ b/pg2any-lib/src/transaction_manager.rs
@@ -263,6 +263,9 @@ pub struct TransactionManager {
     storage: Arc<dyn TransactionStorage>,
     /// When true, stores raw ChangeEvent JSON instead of generated SQL
     event_mode: bool,
+    /// Whether bulk insert optimization is enabled
+    /// Minimum INSERT count to trigger bulk insert path
+    bulk_insert_threshold: usize,
 }
 
 impl TransactionManager {
@@ -301,6 +304,7 @@ impl TransactionManager {
             segment_size_bytes,
             storage,
             event_mode: false,
+            bulk_insert_threshold: 500,
         })
     }
 
@@ -312,6 +316,11 @@ impl TransactionManager {
     /// Enable event-mode: stores raw ChangeEvent JSON instead of generated SQL
     pub fn set_event_mode(&mut self, enabled: bool) {
         self.event_mode = enabled;
+    }
+
+    /// Configure bulk insert optimization parameters
+    pub fn set_bulk_insert_config(&mut self, threshold: usize) {
+        self.bulk_insert_threshold = threshold;
     }
 
     /// Flush all pending buffered writes
@@ -1403,6 +1412,88 @@ impl TransactionManager {
 }
 
 impl TransactionManager {
+    async fn execute_batch_with_bulk_detection(
+        self: &Arc<Self>,
+        destination_handler: &mut Box<dyn DestinationHandler>,
+        metadata_path: &Path,
+        commands: &[String],
+        last_executed_index: usize,
+        batch_idx: usize,
+        metrics_collector: &Arc<MetricsCollector>,
+        bulk_insert_threshold: usize,
+    ) -> Result<()> {
+        #[cfg(any(feature = "mysql", feature = "sqlserver"))]
+        if commands.len() >= bulk_insert_threshold && destination_handler.supports_bulk_insert() {
+            if let Some(parsed) =
+                crate::destinations::bulk_insert::detect_bulk_insert_batch(commands)
+            {
+                debug!(
+                    "Bulk insert detected: {} rows into {} (batch {})",
+                    parsed.rows.len(),
+                    parsed.table,
+                    batch_idx
+                );
+
+                let batch_start_time = Instant::now();
+                let metadata_path_owned = metadata_path.to_path_buf();
+                let file_manager_for_hook = self.clone();
+                let staged_index = last_executed_index;
+
+                let pre_commit_hook: Option<PreCommitHook> = Some(Box::new(move || {
+                    let metadata_path = metadata_path_owned;
+                    let file_manager_for_hook = file_manager_for_hook;
+                    Box::pin(async move {
+                        file_manager_for_hook
+                            .stage_pending_metadata_progress(&metadata_path, staged_index)
+                            .await?;
+                        Ok(())
+                    })
+                }));
+
+                match destination_handler
+                    .execute_bulk_insert_with_hook(
+                        &parsed.table,
+                        &parsed.columns,
+                        &parsed.rows,
+                        pre_commit_hook,
+                    )
+                    .await
+                {
+                    Ok(()) => {
+                        let duration = batch_start_time.elapsed();
+                        debug!(
+                            "Bulk insert batch {} complete: {} rows in {:?}",
+                            batch_idx,
+                            parsed.rows.len(),
+                            duration
+                        );
+                        self.flush_staged_pending_progress().await?;
+                        return Ok(());
+                    }
+                    Err(e) => {
+                        warn!(
+                            "Bulk insert failed for batch {}, falling back to SQL batch: {}",
+                            batch_idx, e
+                        );
+                    }
+                }
+            }
+        }
+
+        #[cfg(not(any(feature = "mysql", feature = "sqlserver")))]
+        let _ = bulk_insert_threshold;
+
+        self.execute_sql_batch(
+            destination_handler,
+            metadata_path,
+            commands,
+            last_executed_index,
+            batch_idx,
+            metrics_collector,
+        )
+        .await
+    }
+
     async fn execute_sql_batch(
         self: &Arc<Self>,
         destination_handler: &mut Box<dyn DestinationHandler>,
@@ -1506,13 +1597,14 @@ impl TransactionManager {
                         let last_executed_index = next_command_index - 1;
                         *state.batch_count += 1;
 
-                        self.execute_sql_batch(
+                        self.execute_batch_with_bulk_detection(
                             destination_handler,
                             &pending_tx.file_path,
                             state.batch,
                             last_executed_index,
                             *state.batch_count,
                             metrics_collector,
+                            self.bulk_insert_threshold,
                         )
                         .await?;
 
@@ -1750,13 +1842,14 @@ impl TransactionManager {
             let last_executed_index = next_command_index - 1;
             batch_count += 1;
 
-            self.execute_sql_batch(
+            self.execute_batch_with_bulk_detection(
                 destination_handler,
                 &pending_tx.file_path,
                 &batch,
                 last_executed_index,
                 batch_count,
                 metrics_collector,
+                self.bulk_insert_threshold,
             )
             .await?;
 

--- a/pg2any-lib/tests/bulk_insert_tests.rs
+++ b/pg2any-lib/tests/bulk_insert_tests.rs
@@ -1,0 +1,78 @@
+//! Integration tests for bulk insert optimization
+
+#[cfg(feature = "mysql")]
+mod bulk_insert_integration {
+    use pg2any_lib::destinations::bulk_insert::{
+        build_multi_value_insert, detect_bulk_insert_batch,
+    };
+
+    #[test]
+    fn test_large_batch_detection() {
+        let stmts: Vec<String> = (0..1000)
+            .map(|i| {
+                format!(
+                    "INSERT INTO `cdc_db`.`t1` (`id`, `val`, `col1`) VALUES ({}, {}, 'value_{}');",
+                    i,
+                    i * 100,
+                    i
+                )
+            })
+            .collect();
+
+        let result = detect_bulk_insert_batch(&stmts);
+        assert!(
+            result.is_some(),
+            "Should detect 1000 INSERT statements as bulk batch"
+        );
+
+        let parsed = result.unwrap();
+        assert_eq!(parsed.table, "`cdc_db`.`t1`");
+        assert_eq!(parsed.columns.len(), 3);
+        assert_eq!(parsed.rows.len(), 1000);
+    }
+
+    #[test]
+    fn test_below_threshold_not_detected() {
+        let stmts = vec![
+            "INSERT INTO `t` (`id`) VALUES (1);".to_string(),
+            "INSERT INTO `t` (`id`) VALUES (2);".to_string(),
+        ];
+        let result = detect_bulk_insert_batch(&stmts);
+        assert!(result.is_some());
+    }
+
+    #[test]
+    fn test_multi_value_insert_generation() {
+        let table = "`cdc_db`.`t1`";
+        let columns = vec![
+            "`id`".to_string(),
+            "`name`".to_string(),
+            "`value`".to_string(),
+        ];
+        let rows: Vec<Vec<String>> = (0..5)
+            .map(|i| vec![i.to_string(), format!("'name_{}'", i), "NULL".to_string()])
+            .collect();
+
+        let sql = build_multi_value_insert(table, &columns, &rows);
+        assert!(sql.starts_with("INSERT INTO `cdc_db`.`t1` (`id`, `name`, `value`) VALUES "));
+        assert!(sql.contains("(0, 'name_0', NULL)"));
+        assert!(sql.contains("(4, 'name_4', NULL)"));
+        assert!(sql.ends_with(';'));
+    }
+
+    #[test]
+    fn test_empty_batch_returns_none() {
+        let stmts: Vec<String> = vec![];
+        let result = detect_bulk_insert_batch(&stmts);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_single_insert_detection() {
+        let stmts = vec!["INSERT INTO `db`.`t` (`a`, `b`) VALUES (1, 'x');".to_string()];
+        let result = detect_bulk_insert_batch(&stmts);
+        assert!(result.is_some());
+        let parsed = result.unwrap();
+        assert_eq!(parsed.rows.len(), 1);
+    }
+}

--- a/pg2any-lib/tests/sqlserver_bulk_insert_tests.rs
+++ b/pg2any-lib/tests/sqlserver_bulk_insert_tests.rs
@@ -1,0 +1,157 @@
+#[cfg(feature = "sqlserver")]
+mod sqlserver_bulk_insert {
+    use pg2any_lib::destinations::bulk_insert::{
+        build_multi_value_insert, detect_bulk_insert_batch,
+    };
+
+    #[test]
+    fn test_detect_bracket_quoted_inserts() {
+        let stmts = vec![
+            "INSERT INTO [dbo].[users] ([id], [name]) VALUES (1, 'alice');".to_string(),
+            "INSERT INTO [dbo].[users] ([id], [name]) VALUES (2, 'bob');".to_string(),
+            "INSERT INTO [dbo].[users] ([id], [name]) VALUES (3, 'carol');".to_string(),
+        ];
+        let result = detect_bulk_insert_batch(&stmts);
+        assert!(
+            result.is_some(),
+            "Should detect bracket-quoted INSERT batch"
+        );
+        let parsed = result.unwrap();
+        assert_eq!(parsed.table, "[dbo].[users]");
+        assert_eq!(parsed.columns, vec!["[id]", "[name]"]);
+        assert_eq!(parsed.rows.len(), 3);
+        assert_eq!(parsed.rows[0], vec!["1", "'alice'"]);
+    }
+
+    #[test]
+    fn test_detect_bracket_quoted_large_batch() {
+        let stmts: Vec<String> = (0..500)
+            .map(|i| {
+                format!(
+                    "INSERT INTO [cdc_db].[dbo].[orders] ([id], [amount], [status]) VALUES ({}, {}.50, 'pending');",
+                    i, i
+                )
+            })
+            .collect();
+
+        let result = detect_bulk_insert_batch(&stmts);
+        assert!(result.is_some());
+        let parsed = result.unwrap();
+        assert_eq!(parsed.table, "[cdc_db].[dbo].[orders]");
+        assert_eq!(parsed.columns.len(), 3);
+        assert_eq!(parsed.rows.len(), 500);
+    }
+
+    #[test]
+    fn test_detect_mixed_tables_returns_none() {
+        let stmts = vec![
+            "INSERT INTO [dbo].[t1] ([id]) VALUES (1);".to_string(),
+            "INSERT INTO [dbo].[t2] ([id]) VALUES (2);".to_string(),
+        ];
+        let result = detect_bulk_insert_batch(&stmts);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_build_multi_value_insert_brackets() {
+        let table = "[dbo].[users]";
+        let columns = vec!["[id]".to_string(), "[name]".to_string()];
+        let rows = vec![
+            vec!["1".to_string(), "'alice'".to_string()],
+            vec!["2".to_string(), "'bob'".to_string()],
+        ];
+        let sql = build_multi_value_insert(table, &columns, &rows);
+        assert_eq!(
+            sql,
+            "INSERT INTO [dbo].[users] ([id], [name]) VALUES (1, 'alice'), (2, 'bob');"
+        );
+    }
+
+    #[test]
+    fn test_null_values_in_batch() {
+        let stmts = vec![
+            "INSERT INTO [dbo].[t] ([id], [name], [age]) VALUES (1, NULL, 25);".to_string(),
+            "INSERT INTO [dbo].[t] ([id], [name], [age]) VALUES (2, 'bob', NULL);".to_string(),
+        ];
+        let result = detect_bulk_insert_batch(&stmts);
+        assert!(result.is_some());
+        let parsed = result.unwrap();
+        assert_eq!(parsed.rows[0], vec!["1", "NULL", "25"]);
+        assert_eq!(parsed.rows[1], vec!["2", "'bob'", "NULL"]);
+    }
+
+    #[test]
+    fn test_string_with_special_characters() {
+        let stmts = vec![
+            "INSERT INTO [dbo].[t] ([id], [val]) VALUES (1, 'it''s a test');".to_string(),
+            "INSERT INTO [dbo].[t] ([id], [val]) VALUES (2, 'hello, world');".to_string(),
+        ];
+        let result = detect_bulk_insert_batch(&stmts);
+        assert!(result.is_some());
+        let parsed = result.unwrap();
+        assert_eq!(parsed.rows[0][1], "'it''s a test'");
+        assert_eq!(parsed.rows[1][1], "'hello, world'");
+    }
+
+    #[test]
+    fn test_multi_value_insert_with_nulls() {
+        let table = "[dbo].[users]";
+        let columns = vec![
+            "[id]".to_string(),
+            "[name]".to_string(),
+            "[age]".to_string(),
+        ];
+        let rows = vec![
+            vec!["1".to_string(), "'alice'".to_string(), "30".to_string()],
+            vec!["2".to_string(), "NULL".to_string(), "25".to_string()],
+        ];
+        let sql = build_multi_value_insert(table, &columns, &rows);
+        assert_eq!(
+            sql,
+            "INSERT INTO [dbo].[users] ([id], [name], [age]) VALUES (1, 'alice', 30), (2, NULL, 25);"
+        );
+    }
+
+    #[test]
+    fn test_three_part_table_name() {
+        let stmts = vec![
+            "INSERT INTO [mydb].[dbo].[orders] ([id], [total]) VALUES (1, 99.99);".to_string(),
+            "INSERT INTO [mydb].[dbo].[orders] ([id], [total]) VALUES (2, 150.00);".to_string(),
+        ];
+        let result = detect_bulk_insert_batch(&stmts);
+        assert!(result.is_some());
+        let parsed = result.unwrap();
+        assert_eq!(parsed.table, "[mydb].[dbo].[orders]");
+    }
+
+    #[test]
+    fn test_large_batch_performance() {
+        let stmts: Vec<String> = (0..2000)
+            .map(|i| {
+                format!(
+                    "INSERT INTO [dbo].[perf_test] ([id], [value], [label]) VALUES ({}, {}.5, 'item_{}');",
+                    i, i, i
+                )
+            })
+            .collect();
+
+        let result = detect_bulk_insert_batch(&stmts);
+        assert!(result.is_some());
+        let parsed = result.unwrap();
+        assert_eq!(parsed.rows.len(), 2000);
+    }
+
+    #[test]
+    fn test_non_insert_statements_return_none() {
+        let stmts = vec!["UPDATE [dbo].[t] SET [name] = 'new' WHERE [id] = 1;".to_string()];
+        let result = detect_bulk_insert_batch(&stmts);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_empty_batch() {
+        let stmts: Vec<String> = vec![];
+        let result = detect_bulk_insert_batch(&stmts);
+        assert!(result.is_none());
+    }
+}


### PR DESCRIPTION
Provides the core utilities for bulk loading optimization:
- detect_bulk_insert_batch: identifies homogeneous INSERT batches
- generate_tsv_buffer: converts row data to MySQL LOAD DATA TSV format
- build_multi_value_insert: fallback multi-value INSERT builder

feat: extend DestinationHandler trait with execute_bulk_insert_with_hook

Adds supports_bulk_insert() and execute_bulk_insert_with_hook() with a default implementation that falls back to multi-value INSERT. MySQL destination will override this with LOAD DATA LOCAL INFILE.

feat: implement LOAD DATA LOCAL INFILE in MySQL destination

Adds mysql_async pool alongside sqlx for bulk loading via LOAD DATA LOCAL INFILE protocol. Falls back to multi-value INSERT when local_infile is disabled on the server. Session tuning applied during LOAD DATA ops.

feat: add bulk insert detection and routing in consumer

When a batch consists entirely of INSERTs to the same table and exceeds the threshold, route through execute_bulk_insert_with_hook for LOAD DATA optimization. Falls back to regular SQL batch on detection failure.