### PR TITLE
feat: add bulk_insert module with TSV generation and INSERT detection

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,6 +1,5 @@
 [advisories]
 ignore = [
-    "RUSTSEC-2023-0071",
-    "RUSTSEC-2026-0049"
+    "RUSTSEC-2023-0071"
 ]
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,12 +40,13 @@ pg2any/                          # Cargo workspace root
       transaction_manager.rs     # TransactionManager - file lifecycle (begin/append/commit/abort/process)
       destinations/
         destination_factory.rs   # DestinationHandler trait (core interface) + DestinationFactory
-        mysql.rs                 # MySQL impl via SQLx
+        mysql.rs                 # MySQL impl via SQLx + mysql_async (LOAD DATA LOCAL INFILE)
         sqlserver.rs             # SQL Server impl via Tiberius
         sqlite.rs                # SQLite impl via SQLx
         kafka.rs                 # Kafka impl via rdkafka (event mode - sends JSON, not SQL)
-        coalescing.rs            # DML batch coalescing (multi-row INSERT optimization)
-        common.rs                # Shared SQL generation helpers
+        bulk_insert.rs           # TSV generation, INSERT batch detection, multi-value INSERT fallback
+        coalescing.rs            # DML batch coalescing (multi-row INSERT, CASE-WHEN UPDATE)
+        common.rs                # Shared transaction execution with session tuning
       storage/
         traits.rs                # TransactionStorage trait
         compressed.rs            # Gzip storage impl
@@ -74,11 +75,15 @@ pub trait DestinationHandler: Send + Sync {
     async fn execute_sql_batch_with_hook(&mut self, commands: &[String], pre_commit_hook: Option<PreCommitHook>) -> Result<()>;
     async fn close(&mut self) -> Result<()>;
     fn supports_event_mode(&self) -> bool { false }
+    fn supports_bulk_insert(&self) -> bool { false }
+    async fn execute_bulk_insert_with_hook(&mut self, table: &str, columns: &[String], rows: &[Vec<String>], pre_commit_hook: Option<PreCommitHook>) -> Result<()> { ... }
     async fn execute_events_batch_with_hook(&mut self, events: &[ChangeEvent], ...) -> Result<()> { ... }
 }
 ```
 
 - SQL destinations (MySQL, SQLite, SQL Server) use `execute_sql_batch_with_hook`
+- MySQL additionally supports `execute_bulk_insert_with_hook` for LOAD DATA LOCAL INFILE
+- SQL Server supports `execute_bulk_insert_with_hook` for TDS Bulk Load (with multi-value INSERT fallback)
 - Kafka uses event mode (`supports_event_mode() = true`, `execute_events_batch_with_hook`)
 
 ### TransactionStorage (trait) - `storage/traits.rs`
@@ -93,6 +98,7 @@ Builder pattern. All fields have sensible defaults. Required: `source_connection
 
 ```
 default = ["mysql", "sqlserver", "sqlite"]
+mysql   = ["sqlx/mysql", "mysql_async"]
 kafka   = ["rdkafka", "futures-util", "base64"]
 metrics = ["hyper", "hyper-util", "http-body-util", "prometheus"]
 ```
@@ -120,6 +126,17 @@ Consumer uses exponential backoff (2^n seconds, capped at 30s) for transient fai
 - **pg_walstream** (by same author): Low-level PostgreSQL logical replication protocol implementation. Handles WAL parsing, replication state, connection management. [GitHub](https://github.com/isdaniel/pg-walstream)
 
 System dependencies for building: `libpq-dev`, `pkg-config`, `libssl-dev`, `cmake` (for rdkafka).
+
+## Performance Optimization (MySQL & SQL Server)
+
+The consumer-side uses a tiered optimization strategy for batch INSERT operations:
+
+1. **DML Coalescing** (always active) - Consecutive INSERT statements to same table are combined into multi-value INSERT
+2. **Bulk Insert Detection** (configurable) - When a batch is entirely INSERT statements to one table and exceeds threshold, routes to `execute_bulk_insert_with_hook`
+3. **LOAD DATA LOCAL INFILE** (when server supports it) - MySQL's fastest bulk loading protocol via mysql_async. Falls back to multi-value INSERT if `local_infile` is disabled.
+4. **TDS Bulk Load** (SQL Server, configurable) - Uses tiberius's native `bulk_insert()` API for streaming row insertion via TDS protocol. Falls back to multi-value INSERT if bulk load fails or table metadata retrieval fails.
+
+Config env vars: `CDC_BULK_INSERT_THRESHOLD`
 
 ## Common Patterns
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,15 +23,30 @@ pg2any is a Rust CDC (Change Data Capture) library that streams PostgreSQL WAL c
 - Shutdown coordination: `CancellationToken` + `oneshot` channel (producer -> consumer)
 - Destinations behind `DestinationHandler` trait; Kafka uses event mode, SQL destinations use SQL batch mode
 - `TransactionStorage` trait abstracts compressed vs uncompressed file I/O
+- MySQL uses dual pools: sqlx for normal SQL batches, mysql_async for LOAD DATA LOCAL INFILE
+- SQL Server uses TDS Bulk Load (tiberius `bulk_insert`) for homogeneous INSERT batches, falls back to multi-value INSERT
+- Consumer detects homogeneous INSERT batches and routes to bulk insert path when threshold met
+- Smart batching: consecutive INSERT-only transactions to the same table are merged and executed as a single bulk insert (controlled by `CDC_SMART_BATCH_MAX_TXNS`)
 
 ## Important Files
 
-- `pg2any-lib/src/client.rs` - Core orchestration logic (~1500 lines), producer/consumer tasks
-- `pg2any-lib/src/transaction_manager.rs` - File-based transaction lifecycle
+- `pg2any-lib/src/client.rs` - Core orchestration logic, producer/consumer tasks, smart batching (`try_smart_batch`)
+- `pg2any-lib/src/transaction_manager.rs` - File-based transaction lifecycle + bulk insert routing + `analyze_transaction_content`
 - `pg2any-lib/src/destinations/destination_factory.rs` - `DestinationHandler` trait definition
+- `pg2any-lib/src/destinations/mysql.rs` - MySQL destination (sqlx + mysql_async dual pool)
+- `pg2any-lib/src/destinations/sqlserver.rs` - SQL Server destination (tiberius TDS Bulk Load)
+- `pg2any-lib/src/destinations/common.rs` - Shared transaction helpers (`execute_with_hook_guard`, `commit_with_hook`)
+- `pg2any-lib/src/destinations/bulk_insert.rs` - INSERT detection (backtick + bracket), TSV generation, multi-value INSERT fallback
+- `pg2any-lib/src/destinations/coalescing.rs` - DML coalescing (multi-value INSERT, CASE-WHEN UPDATE)
 - `pg2any-lib/src/config.rs` - All configuration fields and builder
-- `pg2any-lib/src/env.rs` - Environment variable mapping
+- `pg2any-lib/src/env.rs` - Environment variable mapping (supports deprecated fallback names)
 - `pg2any-lib/src/error.rs` - Error types (transient vs permanent classification matters for retry logic)
+
+## Environment Variable Naming
+
+- New canonical names: `CDC_CHANNEL_CAPACITY`, `CDC_BATCH_SIZE`
+- Deprecated aliases (still work, emit warning): `CDC_BUFFER_SIZE`, `CDC_COMMIT_BATCH_SIZE`
+- Use `parse_usize_env_with_fallback` pattern for any future renames
 
 ## What NOT to Do
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,6 +239,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "btoi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd6407f73a9b8b6162d8a2ef999fe6afd7cc15902ebf42c5cd296addf17e0ad"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -491,6 +500,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.112",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.112",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -683,6 +727,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
@@ -897,7 +947,7 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -905,6 +955,11 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
@@ -1056,7 +1111,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-layer",
@@ -1177,6 +1232,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1239,6 +1300,15 @@ checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "keyed_priority_queue"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ee7893dab2e44ae5f9d0173f26ff4aa327c10b01b06a72b52dd9405b628640d"
+dependencies = [
+ "indexmap",
 ]
 
 [[package]]
@@ -1336,6 +1406,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1395,6 +1474,83 @@ dependencies = [
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "mysql-common-derive"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66f62cad7623a9cb6f8f64037f0c4f69c8db8e82914334a83c9788201c2c1bfa"
+dependencies = [
+ "darling",
+ "heck",
+ "num-bigint",
+ "proc-macro-crate",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.112",
+ "termcolor",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "mysql_async"
+version = "0.36.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1d9585dc9058886ff3a1f48a23024dd1d054264dee7c5ae0e4bd640c953bee5"
+dependencies = [
+ "bytes",
+ "crossbeam-queue",
+ "flate2",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "keyed_priority_queue",
+ "lru",
+ "mysql_common",
+ "pem",
+ "percent-encoding",
+ "rand 0.9.4",
+ "rustls",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "socket2 0.5.10",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "twox-hash",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "mysql_common"
+version = "0.35.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbb9f371618ce723f095c61fbcdc36e8936956d2b62832f9c7648689b338e052"
+dependencies = [
+ "base64",
+ "bitflags 2.11.0",
+ "btoi",
+ "byteorder",
+ "bytes",
+ "crc32fast",
+ "flate2",
+ "getrandom 0.3.4",
+ "mysql-common-derive",
+ "num-bigint",
+ "num-traits",
+ "regex",
+ "saturating",
+ "serde",
+ "serde_json",
+ "sha1",
+ "sha2 0.10.9",
+ "thiserror 2.0.18",
+ "uuid",
 ]
 
 [[package]]
@@ -1587,6 +1743,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
+]
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1626,12 +1792,14 @@ dependencies = [
  "hyper",
  "hyper-util",
  "lazy_static",
+ "mysql_async",
  "pg_walstream",
  "prometheus",
  "rdkafka",
  "serde",
  "serde_json",
  "sqlx",
+ "tempfile",
  "thiserror 2.0.18",
  "tiberius",
  "tokio",
@@ -1654,7 +1822,7 @@ dependencies = [
  "rustls",
  "serde",
  "smallvec",
- "socket2",
+ "socket2 0.6.3",
  "tokio",
  "tokio-rustls",
  "tokio-util",
@@ -1760,6 +1928,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
  "toml_edit",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.112",
 ]
 
 [[package]]
@@ -1903,6 +2093,16 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
@@ -1933,6 +2133,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1948,6 +2158,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.16",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -2012,6 +2231,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f3fe0889e69e2ae9e41f4d6c4c0181701d00e4697b356fb1f74173a5e0ee27"
 dependencies = [
  "bitflags 2.11.0",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -2162,6 +2393,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2193,6 +2433,12 @@ name = "ryu"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
+
+[[package]]
+name = "saturating"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ece8e78b2f38ec51c51f5d475df0a7187ba5111b2a28bdc761ee05b075d40a71"
 
 [[package]]
 name = "schannel"
@@ -2392,6 +2638,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2639,6 +2895,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2715,6 +2977,15 @@ dependencies = [
  "once_cell",
  "rustix 1.1.3",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -2853,7 +3124,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -3013,6 +3284,12 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "typenum"
@@ -3278,6 +3555,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 pg_walstream = { version = "0.6.3", default-features = false, features = ["rustls-tls"] }
 tiberius = { version = "0.12.3", features = ["tds73", "sql-browser-tokio", "bigdecimal", "rust_decimal", "time", "chrono"] }
 sqlx = { version = "0.8.6", features = ["runtime-tokio-rustls", "mysql", "sqlite", "chrono", "uuid"] }
+mysql_async = { version = "0.36.2", default-features = false, features = ["default-rustls"] }
 flate2 = "1.1.9"
 async-compression = { version = "0.4.42", features = ["tokio", "gzip"] }
 rdkafka = { version = "0.39", features = ["cmake-build", "tokio"] }

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A high-performance PostgreSQL Change Data Capture (CDC) tool that streams databa
 
 | Destination | Driver | Feature Flag |
 |-------------|--------|--------------|
-| MySQL | SQLx | `mysql` (default) |
+| MySQL | SQLx + mysql_async | `mysql` (default) |
 | SQL Server | Tiberius (TDS) | `sqlserver` (default) |
 | SQLite | SQLx | `sqlite` (default) |
 | Kafka | rdkafka (librdkafka) | `kafka` |
@@ -25,6 +25,9 @@ A high-performance PostgreSQL Change Data Capture (CDC) tool that streams databa
 - **Schema mapping** - Configurable PostgreSQL schema to destination database/schema translation
 - **Prometheus metrics** - Built-in HTTP metrics endpoint (feature: `metrics`)
 - **Graceful shutdown** - Coordinated producer-consumer shutdown with LSN persistence
+- **Bulk insert optimization** - LOAD DATA LOCAL INFILE for MySQL, TDS Bulk Load for SQL Server + session tuning for large batches
+- **DML coalescing** - Multi-value INSERT, CASE-WHEN UPDATE, OR-combined DELETE batching
+- **Smart batching** - Merges consecutive homogeneous INSERT-only transactions across boundaries for higher throughput
 
 ## Quick Start
 
@@ -237,14 +240,18 @@ All configuration is via environment variables (ideal for containers) or the `Co
 | `CDC_PROTOCOL_VERSION` | `1` | Replication protocol version (1-4) |
 | `CDC_STREAMING` | `true` | Stream in-progress transactions (requires protocol v2+) |
 | `CDC_SCHEMA_MAPPING` | | Schema translation, e.g. `public:cdc_db,sales:sales_db` |
-| `CDC_BUFFER_SIZE` | `500` | Transaction channel capacity |
+| `CDC_CHANNEL_CAPACITY` | `1000` | Transaction channel capacity between producer and consumer |
+| `CDC_BATCH_SIZE` | `1000` | SQL commands per batch execution |
 | `CDC_TRANSACTION_SEGMENT_SIZE_MB` | `64` | Max segment file size in MB |
 | `CDC_CONNECTION_TIMEOUT` | `30` | Connection timeout (seconds) |
 | `CDC_QUERY_TIMEOUT` | `10` | Query timeout (seconds) |
 | `CDC_LAST_LSN_FILE` | `./pg2any_last_lsn` | Base path for LSN metadata file |
 | `CDC_TRANSACTION_FILE_BASE_PATH` | `./` | Base directory for transaction files |
 | `PG2ANY_ENABLE_COMPRESSION` | `false` | Enable gzip compression for SQL files |
+| `CDC_BULK_INSERT_THRESHOLD` | `500` | Minimum INSERT statements to trigger bulk path |
+| `CDC_SMART_BATCH_MAX_TXNS` | `50` | Max consecutive INSERT-only transactions to merge |
 | `RUST_LOG` | `pg2any=debug` | Log level |
+
 
 ## Monitoring
 
@@ -289,7 +296,7 @@ make pgbench-test-mysql-full
 ```toml
 [features]
 default = ["mysql", "sqlserver", "sqlite"]
-mysql = ["sqlx/mysql"]
+mysql = ["sqlx/mysql", "mysql_async"]
 sqlserver = ["tiberius"]
 sqlite = ["sqlx/sqlite"]
 kafka = ["rdkafka", "futures-util", "base64"]
@@ -303,6 +310,7 @@ metrics = ["hyper", "hyper-util", "http-body-util", "prometheus"]
 | [pg_walstream](https://crates.io/crates/pg_walstream) | PostgreSQL logical replication protocol |
 | tokio | Async runtime |
 | sqlx | MySQL + SQLite async driver |
+| mysql_async | MySQL LOAD DATA LOCAL INFILE support |
 | tiberius | SQL Server TDS protocol |
 | rdkafka | Kafka producer (librdkafka wrapper) |
 | serde / serde_json | Serialization |

--- a/pg2any-lib/Cargo.toml
+++ b/pg2any-lib/Cargo.toml
@@ -28,6 +28,7 @@ flate2 = { workspace = true }
 async-compression = { workspace = true }
 tiberius = { workspace = true, optional = true }
 sqlx = { workspace = true, optional = true }
+mysql_async = { workspace = true, optional = true }
 rdkafka = { workspace = true, optional = true }
 futures-util = { workspace = true, optional = true }
 base64 = { workspace = true, optional = true }
@@ -39,9 +40,12 @@ http-body-util = { workspace = true, optional = true }
 
 [features]
 default = ["mysql", "sqlserver", "sqlite"]
-mysql = ["sqlx/mysql"]
+mysql = ["sqlx/mysql", "mysql_async", "futures-util"]
 sqlserver = ["tiberius"]
 sqlite = ["sqlx/sqlite"]
 kafka = ["rdkafka", "futures-util", "base64"]
 metrics = ["hyper", "hyper-util", "http-body-util", "prometheus"]
+
+[dev-dependencies]
+tempfile = "3"
 

--- a/pg2any-lib/src/client.rs
+++ b/pg2any-lib/src/client.rs
@@ -116,6 +116,7 @@ impl CdcClient {
         )
         .await?;
         manager.set_schema_mappings(config.schema_mappings.clone());
+        manager.set_bulk_insert_config(config.bulk_insert_threshold);
 
         if destination_handler.supports_event_mode() {
             info!(
@@ -311,6 +312,7 @@ impl CdcClient {
             lsn_tracker,
             shared_lsn_feedback_for_consumer,
             self.config.batch_size,
+            self.config.smart_batch_max_txns,
             rx_commit_notifier,
             producer_shutdown_rx,
         ));
@@ -935,6 +937,7 @@ impl CdcClient {
         lsn_tracker: Arc<LsnTracker>,
         shared_lsn_feedback: Arc<SharedLsnFeedback>,
         batch_size: usize,
+        smart_batch_max_txns: usize,
         mut commit_receiver: mpsc::Receiver<PendingTransactionFile>,
         mut producer_shutdown_rx: oneshot::Receiver<()>,
     ) -> Result<()> {
@@ -952,6 +955,11 @@ impl CdcClient {
         let mut retry_deadline: Option<tokio::time::Instant> = None;
         let mut retry_count: u32 = 0;
 
+        // Track queue size when smart batch last failed analysis, to avoid redundant re-analysis
+        // of the same candidates when new transactions arrive one at a time.
+        #[cfg(any(feature = "mysql", feature = "sqlserver"))]
+        let mut smart_batch_skip_until_size: usize = 0;
+
         loop {
             // If queue has pending work and we're in retry mode, wait for backoff to expire
             if !commit_queue.is_empty() {
@@ -963,21 +971,24 @@ impl CdcClient {
                             biased;
 
                             _ = &mut producer_shutdown_rx => {
-                                info!("Consumer: Received producer shutdown signal during retry wait, persisting position");
+                                info!("Consumer: Received producer shutdown signal during retry wait, draining queue");
 
                                 Self::drain_and_shutdown(
+                                    &mut commit_queue,
+                                    &mut commit_receiver,
                                     &transaction_file_manager,
+                                    &mut destination_handler,
                                     &lsn_tracker,
+                                    &metrics_collector,
+                                    batch_size,
                                     &shared_lsn_feedback,
                                 )
                                 .await;
-                                // Use a labeled block to break outer loop
                                 metrics_collector.update_destination_connection_status(&destination_type, false);
                                 info!("Consumer stopped gracefully");
                                 return Ok(());
                             }
 
-                            // Enqueue new notifications while waiting, but do NOT reset the timer
                             result = commit_receiver.recv() => {
                                 if let Some(notification) = result {
                                     commit_queue.push(std::cmp::Reverse(notification));
@@ -988,8 +999,13 @@ impl CdcClient {
                                     let _ = producer_shutdown_rx.await;
 
                                     Self::drain_and_shutdown(
+                                        &mut commit_queue,
+                                        &mut commit_receiver,
                                         &transaction_file_manager,
+                                        &mut destination_handler,
                                         &lsn_tracker,
+                                        &metrics_collector,
+                                        batch_size,
                                         &shared_lsn_feedback,
                                     )
                                     .await;
@@ -1008,7 +1024,7 @@ impl CdcClient {
                     retry_deadline = None;
 
                     // Backoff expired — process queue
-                    Self::process_commit_queue(
+                    let cancelled = Self::process_commit_queue(
                         &mut commit_queue,
                         &transaction_file_manager,
                         &mut destination_handler,
@@ -1016,11 +1032,33 @@ impl CdcClient {
                         &lsn_tracker,
                         &metrics_collector,
                         batch_size,
+                        smart_batch_max_txns,
                         &shared_lsn_feedback,
                         &mut retry_deadline,
                         &mut retry_count,
+                        #[cfg(any(feature = "mysql", feature = "sqlserver"))]
+                        &mut smart_batch_skip_until_size,
                     )
                     .await;
+
+                    if cancelled {
+                        info!("Consumer: cancellation detected during retry, draining remaining queue");
+                        Self::drain_and_shutdown(
+                            &mut commit_queue,
+                            &mut commit_receiver,
+                            &transaction_file_manager,
+                            &mut destination_handler,
+                            &lsn_tracker,
+                            &metrics_collector,
+                            batch_size,
+                            &shared_lsn_feedback,
+                        )
+                        .await;
+                        metrics_collector
+                            .update_destination_connection_status(&destination_type, false);
+                        info!("Consumer stopped gracefully");
+                        return Ok(());
+                    }
                     continue;
                 }
             }
@@ -1030,11 +1068,16 @@ impl CdcClient {
 
                 // Handle producer shutdown signal (producer stopped gracefully)
                 _ = &mut producer_shutdown_rx => {
-                    info!("Consumer: Received producer shutdown signal, persisting position");
+                    info!("Consumer: Received producer shutdown signal, draining queue");
 
                     Self::drain_and_shutdown(
+                        &mut commit_queue,
+                        &mut commit_receiver,
                         &transaction_file_manager,
+                        &mut destination_handler,
                         &lsn_tracker,
+                        &metrics_collector,
+                        batch_size,
                         &shared_lsn_feedback,
                     )
                     .await;
@@ -1055,7 +1098,7 @@ impl CdcClient {
                             commit_queue.push(std::cmp::Reverse(notification));
 
                             // Process all transactions that are ready (in commit_lsn order)
-                            Self::process_commit_queue(
+                            let cancelled = Self::process_commit_queue(
                                 &mut commit_queue,
                                 &transaction_file_manager,
                                 &mut destination_handler,
@@ -1063,11 +1106,30 @@ impl CdcClient {
                                 &lsn_tracker,
                                 &metrics_collector,
                                 batch_size,
+                                smart_batch_max_txns,
                                 &shared_lsn_feedback,
                                 &mut retry_deadline,
                                 &mut retry_count,
+                                #[cfg(any(feature = "mysql", feature = "sqlserver"))]
+                                &mut smart_batch_skip_until_size,
                             )
                             .await;
+
+                            if cancelled {
+                                info!("Consumer: cancellation detected, draining remaining queue");
+                                Self::drain_and_shutdown(
+                                    &mut commit_queue,
+                                    &mut commit_receiver,
+                                    &transaction_file_manager,
+                                    &mut destination_handler,
+                                    &lsn_tracker,
+                                    &metrics_collector,
+                                    batch_size,
+                                    &shared_lsn_feedback,
+                                )
+                                .await;
+                                break;
+                            }
                         }
                         None => {
                             // Channel closed - producer has dropped the sender
@@ -1076,8 +1138,13 @@ impl CdcClient {
                             let _ = producer_shutdown_rx.await;
 
                             Self::drain_and_shutdown(
+                                &mut commit_queue,
+                                &mut commit_receiver,
                                 &transaction_file_manager,
+                                &mut destination_handler,
                                 &lsn_tracker,
+                                &metrics_collector,
+                                batch_size,
                                 &shared_lsn_feedback,
                             )
                             .await;
@@ -1094,19 +1161,82 @@ impl CdcClient {
         Ok(())
     }
 
-    /// Persist current position and exit. Pending transaction files remain in
-    /// sql_pending_tx/ and will be recovered on the next restart.
+    /// Drain remaining channel messages, process all queued transactions, then
+    /// persist position and exit.
     ///
-    /// Does NOT attempt to process queued transactions — processing large
-    /// transactions during drain risks exceeding the docker stop grace period
-    /// and triggering SIGKILL before progress is persisted.
+    /// Uses a 90-second timeout to leave headroom within the Docker stop grace
+    /// period (typically 120s). If the timeout fires, processing stops and the
+    /// current position is persisted — unprocessed files remain in sql_pending_tx/
+    /// for recovery on the next restart.
     async fn drain_and_shutdown(
+        commit_queue: &mut BinaryHeap<std::cmp::Reverse<PendingTransactionFile>>,
+        commit_receiver: &mut mpsc::Receiver<PendingTransactionFile>,
         transaction_file_manager: &Arc<TransactionManager>,
+        destination_handler: &mut Box<dyn DestinationHandler>,
         lsn_tracker: &Arc<LsnTracker>,
+        metrics_collector: &Arc<MetricsCollector>,
+        batch_size: usize,
         shared_lsn_feedback: &Arc<SharedLsnFeedback>,
     ) {
-        Self::flush_and_persist_on_shutdown(transaction_file_manager, lsn_tracker).await;
+        // Drain any remaining messages from the channel into the queue
+        while let Ok(notification) = commit_receiver.try_recv() {
+            commit_queue.push(std::cmp::Reverse(notification));
+        }
 
+        if commit_queue.is_empty() {
+            Self::flush_and_persist_on_shutdown(transaction_file_manager, lsn_tracker).await;
+            info!("Consumer: Shutdown complete, no pending transactions, position persisted");
+            shared_lsn_feedback.log_state("Consumer shutdown - final LSN state");
+            return;
+        }
+
+        info!(
+            "Consumer: Processing {} queued transaction(s) before shutdown",
+            commit_queue.len()
+        );
+
+        let drain_deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(90);
+
+        while let Some(std::cmp::Reverse(next_tx)) = commit_queue.pop() {
+            if tokio::time::Instant::now() >= drain_deadline {
+                warn!(
+                    "Consumer: Drain timeout reached with {} transaction(s) remaining, persisting position",
+                    commit_queue.len() + 1
+                );
+                commit_queue.push(std::cmp::Reverse(next_tx));
+                break;
+            }
+
+            info!(
+                "Consumer drain: processing transaction {} (LSN: {:?})",
+                next_tx.metadata.transaction_id, next_tx.metadata.commit_lsn
+            );
+
+            // Use a no-op cancellation token — we don't want cancellation during drain
+            let drain_token = CancellationToken::new();
+
+            if let Err(e) = transaction_file_manager
+                .clone()
+                .process_transaction_file(
+                    &next_tx,
+                    destination_handler,
+                    &drain_token,
+                    lsn_tracker,
+                    metrics_collector,
+                    batch_size,
+                    shared_lsn_feedback,
+                )
+                .await
+            {
+                warn!(
+                    "Consumer drain: failed to process transaction {}: {}. File remains in sql_pending_tx/ for recovery.",
+                    next_tx.metadata.transaction_id, e
+                );
+                break;
+            }
+        }
+
+        Self::flush_and_persist_on_shutdown(transaction_file_manager, lsn_tracker).await;
         info!("Consumer: Shutdown complete, position persisted");
         shared_lsn_feedback.log_state("Consumer shutdown - final LSN state");
     }
@@ -1116,8 +1246,7 @@ impl CdcClient {
     /// On failure, re-inserts the failed transaction and sets a retry delay
     /// with exponential backoff (1s, 2s, 4s, ... up to 30s).
     ///
-    /// Returns `true` if a transaction was cancelled by shutdown signal,
-    /// indicating that drain_and_shutdown must NOT process additional transactions.
+    /// Returns `true` if a transaction was cancelled by shutdown signal.
     async fn process_commit_queue(
         commit_queue: &mut BinaryHeap<std::cmp::Reverse<PendingTransactionFile>>,
         transaction_file_manager: &Arc<TransactionManager>,
@@ -1126,10 +1255,42 @@ impl CdcClient {
         lsn_tracker: &Arc<LsnTracker>,
         metrics_collector: &Arc<MetricsCollector>,
         batch_size: usize,
+        smart_batch_max_txns: usize,
         shared_lsn_feedback: &Arc<SharedLsnFeedback>,
         retry_deadline: &mut Option<tokio::time::Instant>,
         retry_count: &mut u32,
+        #[cfg(any(feature = "mysql", feature = "sqlserver"))]
+        smart_batch_skip_until_size: &mut usize,
     ) -> bool {
+        #[cfg(any(feature = "mysql", feature = "sqlserver"))]
+        if !cancellation_token.is_cancelled()
+            && commit_queue.len() >= 2
+            && smart_batch_max_txns > 1
+            && commit_queue.len() > *smart_batch_skip_until_size
+        {
+            if Self::try_smart_batch(
+                commit_queue,
+                transaction_file_manager,
+                destination_handler,
+                lsn_tracker,
+                metrics_collector,
+                shared_lsn_feedback,
+                smart_batch_max_txns,
+            )
+            .await
+            {
+                *retry_deadline = None;
+                *retry_count = 0;
+                *smart_batch_skip_until_size = 0;
+                if commit_queue.is_empty() {
+                    return false;
+                }
+            } else {
+                // Analysis failed — skip re-analysis until queue grows
+                *smart_batch_skip_until_size = commit_queue.len();
+            }
+        }
+
         while let Some(std::cmp::Reverse(next_tx)) = commit_queue.pop() {
             info!(
                 "Consumer processing transaction {} in commit_lsn order (LSN: {:?})",
@@ -1154,7 +1315,11 @@ impl CdcClient {
                         "Consumer: transaction {} cancelled by shutdown, will be recovered on restart",
                         next_tx.metadata.transaction_id
                     );
-                    commit_queue.clear();
+                    // Push the cancelled transaction back — it wasn't committed to
+                    // the destination, so its sql_pending_tx/ file still exists for
+                    // recovery. Do NOT clear the queue: drain_and_shutdown will
+                    // process remaining items.
+                    commit_queue.push(std::cmp::Reverse(next_tx));
                     return true;
                 }
 
@@ -1186,6 +1351,159 @@ impl CdcClient {
             *retry_count = 0;
         }
         false
+    }
+
+    #[cfg(any(feature = "mysql", feature = "sqlserver"))]
+    async fn try_smart_batch(
+        commit_queue: &mut BinaryHeap<std::cmp::Reverse<PendingTransactionFile>>,
+        transaction_file_manager: &Arc<TransactionManager>,
+        destination_handler: &mut Box<dyn DestinationHandler>,
+        lsn_tracker: &Arc<LsnTracker>,
+        metrics_collector: &Arc<MetricsCollector>,
+        shared_lsn_feedback: &Arc<SharedLsnFeedback>,
+        smart_batch_max_txns: usize,
+    ) -> bool {
+        if commit_queue.len() < 2 || !destination_handler.supports_bulk_insert() {
+            return false;
+        }
+
+        // Pop candidates from the heap to guarantee commit_lsn ordering.
+        // BinaryHeap::iter() does NOT return elements in sorted order.
+        let take_count = smart_batch_max_txns.min(commit_queue.len());
+        let mut candidates: Vec<PendingTransactionFile> = Vec::with_capacity(take_count);
+        for _ in 0..take_count {
+            if let Some(std::cmp::Reverse(tx)) = commit_queue.pop() {
+                candidates.push(tx);
+            }
+        }
+
+        if candidates.len() < 2 {
+            // Push back and abort
+            for tx in candidates {
+                commit_queue.push(std::cmp::Reverse(tx));
+            }
+            return false;
+        }
+
+        let all_segments: Vec<_> = candidates
+            .iter()
+            .flat_map(|tx| tx.metadata.segments.iter().cloned())
+            .collect();
+
+        let (table, columns, all_rows) = match transaction_file_manager
+            .analyze_and_extract_rows(&all_segments)
+            .await
+        {
+            Ok(Some(result)) => result,
+            Ok(None) => {
+                for tx in candidates {
+                    commit_queue.push(std::cmp::Reverse(tx));
+                }
+                return false;
+            }
+            Err(e) => {
+                tracing::warn!("Smart batch analysis failed: {e}");
+                for tx in candidates {
+                    commit_queue.push(std::cmp::Reverse(tx));
+                }
+                return false;
+            }
+        };
+
+        if all_rows.is_empty() {
+            for tx in candidates {
+                commit_queue.push(std::cmp::Reverse(tx));
+            }
+            return false;
+        }
+
+        let total_rows = all_rows.len();
+        let batch_count = candidates.len();
+
+        info!(
+            "Smart batch: merging {} transactions ({} rows) into single bulk insert to {}",
+            batch_count, total_rows, table
+        );
+
+        let highest_lsn = candidates
+            .iter()
+            .filter_map(|tx| tx.metadata.commit_lsn)
+            .max();
+
+        let hook_lsn = highest_lsn;
+        let hook_feedback = Arc::clone(shared_lsn_feedback);
+
+        let pre_commit_hook: Option<crate::destinations::destination_factory::PreCommitHook> =
+            Some(Box::new(move || {
+                Box::pin(async move {
+                    if let Some(lsn) = hook_lsn {
+                        hook_feedback.update_applied_lsn(lsn.0);
+                        hook_feedback.update_flushed_lsn(lsn.0);
+                    }
+                    Ok(())
+                })
+            }));
+
+        match destination_handler
+            .execute_bulk_insert_with_hook(&table, &columns, &all_rows, pre_commit_hook)
+            .await
+        {
+            Ok(()) => {
+                info!(
+                    "Smart batch complete: {} transactions, {} rows merged",
+                    batch_count, total_rows
+                );
+
+                for candidate in &candidates {
+                    let mut tx = crate::types::Transaction::new(
+                        candidate.metadata.transaction_id,
+                        candidate.metadata.commit_timestamp,
+                    );
+                    tx.commit_lsn = candidate.metadata.commit_lsn;
+                    let dest_str = candidate.metadata.destination_type.to_string();
+                    metrics_collector.record_transaction_processed(&tx, &dest_str);
+                }
+
+                // Persist LSN BEFORE deleting files — if we crash between these,
+                // files remain and will be re-processed on restart (safe duplicate),
+                // rather than losing them with no position record.
+                if let Some(lsn) = highest_lsn {
+                    lsn_tracker.commit_lsn(lsn.0);
+                    if let Err(e) = lsn_tracker.persist_async().await {
+                        warn!("Failed to persist LSN after smart batch: {}", e);
+                    }
+                }
+
+                let all_paths: Vec<std::path::PathBuf> = candidates
+                    .iter()
+                    .flat_map(|tx| {
+                        let mut paths: Vec<std::path::PathBuf> = tx
+                            .metadata
+                            .segments
+                            .iter()
+                            .map(|s| s.path.clone())
+                            .collect();
+                        paths.push(tx.file_path.clone());
+                        paths
+                    })
+                    .collect();
+                transaction_file_manager
+                    .batch_delete_files(&all_paths)
+                    .await;
+
+                true
+            }
+            Err(e) => {
+                warn!(
+                    "Smart batch failed, falling back to individual processing: {}",
+                    e
+                );
+                for tx in candidates {
+                    commit_queue.push(std::cmp::Reverse(tx));
+                }
+                false
+            }
+        }
     }
 
     #[inline]

--- a/pg2any-lib/src/config.rs
+++ b/pg2any-lib/src/config.rs
@@ -93,6 +93,12 @@ pub struct Config {
 
     /// Additional configuration options
     pub extra_options: HashMap<String, String>,
+
+    /// Minimum number of INSERT statements to trigger bulk insert mode
+    pub bulk_insert_threshold: usize,
+
+    /// Maximum number of consecutive INSERT-only transactions to merge in smart batching
+    pub smart_batch_max_txns: usize,
 }
 
 /// Origin filtering options
@@ -193,6 +199,8 @@ impl Default for Config {
             transaction_file_base_path: ".".to_string(),
             transaction_segment_size_bytes: 64 * 1024 * 1024,
             extra_options: HashMap::new(),
+            bulk_insert_threshold: 500,
+            smart_batch_max_txns: 50,
         }
     }
 }
@@ -389,6 +397,16 @@ impl ConfigBuilder {
         V: Into<String>,
     {
         self.config.extra_options.insert(key.into(), value.into());
+        self
+    }
+
+    pub fn bulk_insert_threshold(mut self, threshold: usize) -> Self {
+        self.config.bulk_insert_threshold = threshold;
+        self
+    }
+
+    pub fn smart_batch_max_txns(mut self, max: usize) -> Self {
+        self.config.smart_batch_max_txns = max.max(1);
         self
     }
 

--- a/pg2any-lib/src/destinations/bulk_insert.rs
+++ b/pg2any-lib/src/destinations/bulk_insert.rs
@@ -1,0 +1,421 @@
+//! Shared bulk insert utilities: INSERT batch detection and multi-value INSERT generation.
+//!
+//! This module is conditionally compiled when either `mysql` or `sqlserver` feature is enabled.
+//! Destination-specific bulk load logic lives in each destination's own module.
+
+#[derive(Debug, Clone)]
+pub struct ParsedBulkInsert {
+    pub table: String,
+    pub columns: Vec<String>,
+    pub rows: Vec<Vec<String>>,
+}
+
+/// Parse the INSERT prefix from a single SQL statement.
+/// Returns `(prefix_str, columns, table)` if the statement is a valid INSERT.
+pub fn extract_insert_prefix(sql: &str) -> Option<(String, Vec<String>, String)> {
+    parse_insert_prefix(sql)
+}
+
+/// Extract just the VALUES tuple from a statement whose prefix is already known.
+/// `values_suffix` should be the part of the statement after the prefix (e.g., "(1, 'hello');").
+pub fn extract_values_from_suffix(values_suffix: &str) -> Option<Vec<String>> {
+    parse_values_tuple(values_suffix)
+}
+
+pub fn detect_bulk_insert_batch(statements: &[String]) -> Option<ParsedBulkInsert> {
+    if statements.is_empty() {
+        return None;
+    }
+
+    let first = parse_insert_prefix(&statements[0])?;
+    let expected_prefix = &first.0;
+    let columns = first.1.clone();
+    let table = first.2.clone();
+
+    let mut rows: Vec<Vec<String>> = Vec::with_capacity(statements.len());
+
+    let first_trimmed = statements[0].trim();
+    let values = parse_values_tuple(&first_trimmed[expected_prefix.len()..])?;
+    rows.push(values);
+
+    for stmt in &statements[1..] {
+        let trimmed_stmt = stmt.trim();
+        if !trimmed_stmt.starts_with(expected_prefix.as_str()) {
+            return None;
+        }
+        let values = parse_values_tuple(&trimmed_stmt[expected_prefix.len()..])?;
+        rows.push(values);
+    }
+
+    Some(ParsedBulkInsert {
+        table,
+        columns,
+        rows,
+    })
+}
+
+pub fn build_multi_value_insert(table: &str, columns: &[String], rows: &[Vec<String>]) -> String {
+    let col_list = columns.join(", ");
+    let prefix = format!("INSERT INTO {} ({}) VALUES ", table, col_list);
+    let mut sql = String::with_capacity(prefix.len() + rows.len() * 64);
+    sql.push_str(&prefix);
+    for (i, row) in rows.iter().enumerate() {
+        if i > 0 {
+            sql.push_str(", ");
+        }
+        sql.push('(');
+        for (j, val) in row.iter().enumerate() {
+            if j > 0 {
+                sql.push_str(", ");
+            }
+            sql.push_str(val);
+        }
+        sql.push(')');
+    }
+    sql.push(';');
+    sql
+}
+
+/// Builds chunked multi-value INSERT statements that respect a maximum byte size per statement.
+/// MySQL's default `max_allowed_packet` is 64MB but can be as low as 4MB in some configurations.
+/// We use 4MB as a safe default to avoid exceeding the limit.
+const DEFAULT_MAX_STATEMENT_BYTES: usize = 4 * 1024 * 1024;
+
+pub fn build_chunked_multi_value_inserts(
+    table: &str,
+    columns: &[String],
+    rows: &[Vec<String>],
+    max_bytes: Option<usize>,
+) -> Vec<String> {
+    let max = max_bytes.unwrap_or(DEFAULT_MAX_STATEMENT_BYTES);
+    let col_list = columns.join(", ");
+    let prefix = format!("INSERT INTO {} ({}) VALUES ", table, col_list);
+
+    let mut statements = Vec::new();
+    let mut current = prefix.clone();
+    let mut row_count = 0;
+
+    for row in rows {
+        let mut tuple = String::from("(");
+        for (j, val) in row.iter().enumerate() {
+            if j > 0 {
+                tuple.push_str(", ");
+            }
+            tuple.push_str(val);
+        }
+        tuple.push(')');
+
+        let addition_len = if row_count == 0 {
+            tuple.len()
+        } else {
+            2 + tuple.len() // ", " + tuple
+        };
+
+        if row_count > 0 && current.len() + addition_len + 1 > max {
+            current.push(';');
+            statements.push(current);
+            current = prefix.clone();
+            row_count = 0;
+        }
+
+        if row_count > 0 {
+            current.push_str(", ");
+        }
+        current.push_str(&tuple);
+        row_count += 1;
+    }
+
+    if row_count > 0 {
+        current.push(';');
+        statements.push(current);
+    }
+
+    statements
+}
+
+fn parse_insert_prefix(sql: &str) -> Option<(String, Vec<String>, String)> {
+    let trimmed = sql.trim();
+    if !trimmed
+        .get(..7)
+        .map(|s| s.eq_ignore_ascii_case("INSERT "))
+        .unwrap_or(false)
+    {
+        return None;
+    }
+
+    let values_pos = find_case_insensitive(trimmed, " VALUES ")?;
+    let prefix = &trimmed[..values_pos + 8];
+
+    let into_pos = find_case_insensitive(trimmed, "INTO ")?;
+    let after_into = &trimmed[into_pos + 5..];
+
+    let col_paren_pos = after_into.find('(')?;
+    let table = after_into[..col_paren_pos].trim().to_string();
+
+    let col_section = &after_into[col_paren_pos..];
+    let close_paren = col_section.find(')')?;
+    let col_list = &col_section[1..close_paren];
+    let columns = split_quoted_identifiers(col_list);
+
+    Some((prefix.to_string(), columns, table))
+}
+
+/// Split a column list respecting quoted identifiers (backticks, brackets, double-quotes).
+/// Handles escaped quotes: `]]` in brackets, `` `` `` in backticks, `""` in double-quotes.
+fn split_quoted_identifiers(col_list: &str) -> Vec<String> {
+    let mut columns = Vec::new();
+    let mut current = String::new();
+    let mut in_quote = false;
+    let mut quote_char = ' ';
+    let mut chars = col_list.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        match ch {
+            '`' | '"' if !in_quote => {
+                in_quote = true;
+                quote_char = ch;
+                current.push(ch);
+            }
+            '[' if !in_quote => {
+                in_quote = true;
+                quote_char = ']';
+                current.push(ch);
+            }
+            ']' if in_quote && quote_char == ']' => {
+                current.push(ch);
+                if chars.peek() == Some(&']') {
+                    current.push(chars.next().unwrap());
+                } else {
+                    in_quote = false;
+                }
+            }
+            c if in_quote && c == quote_char => {
+                current.push(c);
+                if chars.peek() == Some(&quote_char) {
+                    current.push(chars.next().unwrap());
+                } else {
+                    in_quote = false;
+                }
+            }
+            ',' if !in_quote => {
+                columns.push(current.trim().to_string());
+                current.clear();
+            }
+            _ => current.push(ch),
+        }
+    }
+    if !current.trim().is_empty() {
+        columns.push(current.trim().to_string());
+    }
+    columns
+}
+
+fn find_case_insensitive(haystack: &str, needle: &str) -> Option<usize> {
+    let h = haystack.as_bytes();
+    let n = needle.as_bytes();
+    let n_len = n.len();
+    if h.len() < n_len {
+        return None;
+    }
+    for i in 0..=(h.len() - n_len) {
+        if h[i..i + n_len].eq_ignore_ascii_case(n) {
+            return Some(i);
+        }
+    }
+    None
+}
+
+fn parse_values_tuple(values_part: &str) -> Option<Vec<String>> {
+    let trimmed = values_part
+        .trim()
+        .strip_suffix(';')
+        .unwrap_or(values_part.trim())
+        .trim();
+    if !trimmed.starts_with('(') || !trimmed.ends_with(')') {
+        return None;
+    }
+    let inner = &trimmed[1..trimmed.len() - 1];
+
+    let mut values = Vec::new();
+    let mut current = String::new();
+    let mut in_quotes = false;
+    let mut chars = inner.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        match ch {
+            '\\' if in_quotes => {
+                current.push(ch);
+                if let Some(next) = chars.next() {
+                    current.push(next);
+                }
+            }
+            '\'' if !in_quotes => {
+                in_quotes = true;
+                current.push(ch);
+            }
+            '\'' if in_quotes => {
+                current.push(ch);
+                if chars.peek() == Some(&'\'') {
+                    current.push(chars.next().unwrap());
+                } else {
+                    in_quotes = false;
+                }
+            }
+            ',' if !in_quotes => {
+                values.push(current.trim().to_string());
+                current.clear();
+            }
+            _ => current.push(ch),
+        }
+    }
+    if !current.is_empty() || !values.is_empty() {
+        values.push(current.trim().to_string());
+    }
+
+    Some(values)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_detect_bulk_insert_same_table() {
+        let stmts = vec![
+            "INSERT INTO `cdc_db`.`t1` (`id`, `name`) VALUES (1, 'hello');".to_string(),
+            "INSERT INTO `cdc_db`.`t1` (`id`, `name`) VALUES (2, 'world');".to_string(),
+            "INSERT INTO `cdc_db`.`t1` (`id`, `name`) VALUES (3, 'foo');".to_string(),
+        ];
+        let result = detect_bulk_insert_batch(&stmts);
+        assert!(result.is_some());
+        let parsed = result.unwrap();
+        assert_eq!(parsed.table, "`cdc_db`.`t1`");
+        assert_eq!(parsed.columns, vec!["`id`", "`name`"]);
+        assert_eq!(parsed.rows.len(), 3);
+        assert_eq!(parsed.rows[0], vec!["1", "'hello'"]);
+    }
+
+    #[test]
+    fn test_detect_bulk_insert_backslash_escaped_quotes() {
+        let stmts = vec![
+            "INSERT INTO `db`.`t1` (`id`, `name`) VALUES (1, 'it\\'s here');".to_string(),
+            "INSERT INTO `db`.`t1` (`id`, `name`) VALUES (2, 'she\\'s there');".to_string(),
+        ];
+        let result = detect_bulk_insert_batch(&stmts);
+        assert!(result.is_some());
+        let parsed = result.unwrap();
+        assert_eq!(parsed.rows.len(), 2);
+        assert_eq!(parsed.rows[0], vec!["1", "'it\\'s here'"]);
+        assert_eq!(parsed.rows[1], vec!["2", "'she\\'s there'"]);
+    }
+
+    #[test]
+    fn test_detect_bulk_insert_mixed_tables_returns_none() {
+        let stmts = vec![
+            "INSERT INTO `cdc_db`.`t1` (`id`) VALUES (1);".to_string(),
+            "INSERT INTO `cdc_db`.`t2` (`id`) VALUES (2);".to_string(),
+        ];
+        let result = detect_bulk_insert_batch(&stmts);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_detect_bulk_insert_with_update_returns_none() {
+        let stmts = vec![
+            "INSERT INTO `cdc_db`.`t1` (`id`) VALUES (1);".to_string(),
+            "UPDATE `cdc_db`.`t1` SET `id` = 2 WHERE `id` = 1;".to_string(),
+        ];
+        let result = detect_bulk_insert_batch(&stmts);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_build_multi_value_insert() {
+        let table = "`cdc_db`.`t1`";
+        let columns = vec!["`id`".to_string(), "`name`".to_string()];
+        let rows = vec![
+            vec!["1".to_string(), "'hello'".to_string()],
+            vec!["2".to_string(), "'world'".to_string()],
+        ];
+        let sql = build_multi_value_insert(table, &columns, &rows);
+        assert_eq!(
+            sql,
+            "INSERT INTO `cdc_db`.`t1` (`id`, `name`) VALUES (1, 'hello'), (2, 'world');"
+        );
+    }
+
+    #[test]
+    fn test_split_quoted_identifiers_with_comma() {
+        let cols = split_quoted_identifiers("`normal`, `has,comma`, `another`");
+        assert_eq!(cols, vec!["`normal`", "`has,comma`", "`another`"]);
+    }
+
+    #[test]
+    fn test_split_bracket_identifiers_with_comma() {
+        let cols = split_quoted_identifiers("[normal], [has,comma], [another]");
+        assert_eq!(cols, vec!["[normal]", "[has,comma]", "[another]"]);
+    }
+
+    #[test]
+    fn test_split_bracket_identifiers_with_escaped_bracket() {
+        let cols = split_quoted_identifiers("[normal], [has]]bracket], [another]");
+        assert_eq!(cols, vec!["[normal]", "[has]]bracket]", "[another]"]);
+    }
+
+    #[test]
+    fn test_split_backtick_identifiers_with_escaped_backtick() {
+        let cols = split_quoted_identifiers("`normal`, `has``tick`, `another`");
+        assert_eq!(cols, vec!["`normal`", "`has``tick`", "`another`"]);
+    }
+
+    #[test]
+    fn test_split_double_quote_identifiers_with_escaped_quote() {
+        let cols = split_quoted_identifiers("\"normal\", \"has\"\"quote\", \"another\"");
+        assert_eq!(cols, vec!["\"normal\"", "\"has\"\"quote\"", "\"another\""]);
+    }
+
+    #[test]
+    fn test_detect_bulk_insert_with_leading_whitespace() {
+        let stmts = vec![
+            "  INSERT INTO `db`.`t` (`id`) VALUES (1);  ".to_string(),
+            "  INSERT INTO `db`.`t` (`id`) VALUES (2);  ".to_string(),
+        ];
+        let result = detect_bulk_insert_batch(&stmts);
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().rows.len(), 2);
+    }
+
+    #[test]
+    fn test_build_chunked_multi_value_inserts_single_chunk() {
+        let table = "`db`.`t`";
+        let columns = vec!["`id`".to_string(), "`name`".to_string()];
+        let rows = vec![
+            vec!["1".to_string(), "'a'".to_string()],
+            vec!["2".to_string(), "'b'".to_string()],
+        ];
+        let result = build_chunked_multi_value_inserts(table, &columns, &rows, Some(1024));
+        assert_eq!(result.len(), 1);
+        assert_eq!(
+            result[0],
+            "INSERT INTO `db`.`t` (`id`, `name`) VALUES (1, 'a'), (2, 'b');"
+        );
+    }
+
+    #[test]
+    fn test_build_chunked_multi_value_inserts_splits_on_size() {
+        let table = "`db`.`t`";
+        let columns = vec!["`id`".to_string()];
+        let rows = vec![
+            vec!["1".to_string()],
+            vec!["2".to_string()],
+            vec!["3".to_string()],
+        ];
+        // Set max to just above prefix + one row to force splitting
+        let prefix_len = "INSERT INTO `db`.`t` (`id`) VALUES ".len();
+        let max = prefix_len + "(1), (2);".len(); // fits 2 rows
+        let result = build_chunked_multi_value_inserts(table, &columns, &rows, Some(max));
+        assert_eq!(result.len(), 2);
+        assert!(result[0].contains("(1), (2)"));
+        assert!(result[1].contains("(3)"));
+    }
+}

--- a/pg2any-lib/src/destinations/common.rs
+++ b/pg2any-lib/src/destinations/common.rs
@@ -1,4 +1,71 @@
 /// Common utilities and traits for destination implementations
+use crate::error::{CdcError, Result};
+use std::future::Future;
+
+/// Shared transaction lifecycle: operation → hook → commit, with rollback on any failure.
+///
+/// Encapsulates the repeated BEGIN/execute/hook/COMMIT/ROLLBACK pattern used
+/// by MySQL and SQL Server destinations.
+pub(crate) async fn execute_with_hook_guard<OpFut, RbFut, CmFut>(
+    operation: OpFut,
+    pre_commit_hook: Option<super::PreCommitHook>,
+    rollback: RbFut,
+    commit: CmFut,
+    context: &str,
+) -> Result<()>
+where
+    OpFut: Future<Output = std::result::Result<(), CdcError>>,
+    RbFut: Future<Output = ()>,
+    CmFut: Future<Output = std::result::Result<(), CdcError>>,
+{
+    tokio::pin!(rollback);
+    tokio::pin!(commit);
+
+    if let Err(e) = operation.await {
+        tracing::debug!("{context} operation failed, rolling back: {e}");
+        rollback.await;
+        return Err(e);
+    }
+
+    if let Some(hook) = pre_commit_hook {
+        if let Err(e) = hook().await {
+            tracing::debug!("{context} pre-commit hook failed, rolling back: {e}");
+            rollback.await;
+            return Err(CdcError::generic(format!(
+                "{context} pre-commit hook failed, transaction rolled back: {e}"
+            )));
+        }
+    }
+
+    commit.await
+}
+
+/// Run pre-commit hook then commit. Rolls back on hook failure.
+/// Call this after the main operation has already succeeded within an active transaction.
+pub(crate) async fn commit_with_hook<CmFut, RbFut>(
+    pre_commit_hook: Option<super::PreCommitHook>,
+    commit: CmFut,
+    rollback: RbFut,
+    context: &str,
+) -> Result<()>
+where
+    CmFut: Future<Output = std::result::Result<(), CdcError>>,
+    RbFut: Future<Output = ()>,
+{
+    tokio::pin!(commit);
+    tokio::pin!(rollback);
+
+    if let Some(hook) = pre_commit_hook {
+        if let Err(e) = hook().await {
+            rollback.await;
+            return Err(CdcError::generic(format!(
+                "{context} pre-commit hook failed, rolled back: {e}"
+            )));
+        }
+    }
+
+    commit.await
+}
 
 /// Execute a batch of SQL commands within a single sqlx transaction with optional pre-commit hook.
 ///
@@ -69,4 +136,88 @@ where
     })?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn test_hook_guard_success_path() {
+        let committed = Arc::new(AtomicBool::new(false));
+        let committed_clone = committed.clone();
+
+        let result = execute_with_hook_guard(
+            async { Ok::<(), CdcError>(()) },
+            None,
+            async {},
+            async move {
+                committed_clone.store(true, Ordering::SeqCst);
+                Ok::<(), CdcError>(())
+            },
+            "test",
+        )
+        .await;
+
+        assert!(result.is_ok());
+        assert!(committed.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn test_hook_guard_operation_failure_triggers_rollback() {
+        let rolled_back = Arc::new(AtomicBool::new(false));
+        let rolled_back_clone = rolled_back.clone();
+        let committed = Arc::new(AtomicBool::new(false));
+        let committed_clone = committed.clone();
+
+        let result = execute_with_hook_guard(
+            async { Err::<(), CdcError>(CdcError::generic("op failed")) },
+            None,
+            async move {
+                rolled_back_clone.store(true, Ordering::SeqCst);
+            },
+            async move {
+                committed_clone.store(true, Ordering::SeqCst);
+                Ok::<(), CdcError>(())
+            },
+            "test",
+        )
+        .await;
+
+        assert!(result.is_err());
+        assert!(rolled_back.load(Ordering::SeqCst));
+        assert!(!committed.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn test_hook_guard_hook_failure_triggers_rollback() {
+        let rolled_back = Arc::new(AtomicBool::new(false));
+        let rolled_back_clone = rolled_back.clone();
+        let committed = Arc::new(AtomicBool::new(false));
+        let committed_clone = committed.clone();
+
+        let hook: Option<crate::destinations::PreCommitHook> = Some(Box::new(|| {
+            Box::pin(async { Err(CdcError::generic("hook failed")) })
+        }));
+
+        let result = execute_with_hook_guard(
+            async { Ok::<(), CdcError>(()) },
+            hook,
+            async move {
+                rolled_back_clone.store(true, Ordering::SeqCst);
+            },
+            async move {
+                committed_clone.store(true, Ordering::SeqCst);
+                Ok::<(), CdcError>(())
+            },
+            "test",
+        )
+        .await;
+
+        assert!(result.is_err());
+        assert!(rolled_back.load(Ordering::SeqCst));
+        assert!(!committed.load(Ordering::SeqCst));
+    }
 }

--- a/pg2any-lib/src/destinations/destination_factory.rs
+++ b/pg2any-lib/src/destinations/destination_factory.rs
@@ -95,6 +95,38 @@ pub trait DestinationHandler: Send + Sync {
             "Event mode not supported by this destination",
         ))
     }
+
+    fn supports_bulk_insert(&self) -> bool {
+        false
+    }
+
+    async fn execute_bulk_insert_with_hook(
+        &mut self,
+        table: &str,
+        columns: &[String],
+        rows: &[Vec<String>],
+        pre_commit_hook: Option<PreCommitHook>,
+    ) -> Result<()> {
+        if rows.is_empty() {
+            return Ok(());
+        }
+        #[cfg(any(feature = "mysql", feature = "sqlserver"))]
+        {
+            let sqls = crate::destinations::bulk_insert::build_chunked_multi_value_inserts(
+                table, columns, rows, None,
+            );
+            return self
+                .execute_sql_batch_with_hook(&sqls, pre_commit_hook)
+                .await;
+        }
+        #[cfg(not(any(feature = "mysql", feature = "sqlserver")))]
+        {
+            let _ = (table, columns, rows, pre_commit_hook);
+            Err(CdcError::unsupported(
+                "Bulk insert not available without mysql or sqlserver feature",
+            ))
+        }
+    }
 }
 
 /// Factory for creating destination handlers

--- a/pg2any-lib/src/destinations/mod.rs
+++ b/pg2any-lib/src/destinations/mod.rs
@@ -1,6 +1,10 @@
 pub mod coalescing;
 pub mod common;
 
+/// Bulk insert utilities (TSV generation, INSERT detection)
+#[cfg(any(feature = "mysql", feature = "sqlserver"))]
+pub mod bulk_insert;
+
 /// MySQL destination implementation
 #[cfg(feature = "mysql")]
 pub mod mysql;

--- a/pg2any-lib/src/destinations/mysql.rs
+++ b/pg2any-lib/src/destinations/mysql.rs
@@ -3,29 +3,29 @@ use crate::error::{CdcError, Result};
 use async_trait::async_trait;
 use sqlx::MySqlPool;
 use std::collections::HashMap;
-use tracing::{debug, info};
+use std::sync::{Arc, Mutex};
+use tracing::{debug, info, warn};
 
 use super::coalescing::{coalesce_commands, QuoteStyle};
 
-// ============================================================================
-// MySQL Destination Implementation
-// ============================================================================
-
 pub struct MySQLDestination {
     pool: Option<MySqlPool>,
-    /// Schema mappings: maps source schema to destination database
+    bulk_pool: Option<mysql_async::Pool>,
+    infile_data: Arc<Mutex<Option<bytes::Bytes>>>,
     schema_mappings: HashMap<String, String>,
-    /// MySQL max_allowed_packet value in bytes (default 64MB, max 1GB), Used to calculate safe batch sizes dynamically
     max_allowed_packet: u64,
+    load_data_available: bool,
 }
 
 impl MySQLDestination {
-    /// Create a new MySQL destination instance
     pub fn new() -> Self {
         Self {
             pool: None,
+            bulk_pool: None,
+            infile_data: Arc::new(Mutex::new(None)),
             schema_mappings: HashMap::new(),
-            max_allowed_packet: 67108864, // Default 64MB
+            max_allowed_packet: 67108864,
+            load_data_available: false,
         }
     }
 }
@@ -41,14 +41,12 @@ impl DestinationHandler for MySQLDestination {
     async fn connect(&mut self, connection_string: &str) -> Result<()> {
         let pool = MySqlPool::connect(connection_string).await?;
 
-        // Query max_allowed_packet to calculate optimal batch sizes
         let row: (String, String) = sqlx::query_as("SHOW VARIABLES LIKE 'max_allowed_packet'")
             .fetch_one(&pool)
             .await
             .map_err(|e| CdcError::generic(format!("Failed to query max_allowed_packet: {e}")))?;
 
-        // Parse the string value to u64
-        self.max_allowed_packet = row.1.parse::<u64>().unwrap_or(67108864); // Default to 64MB if parse fails
+        self.max_allowed_packet = row.1.parse::<u64>().unwrap_or(67108864);
 
         info!(
             "MySQL max_allowed_packet: {} bytes ({:.2} MB)",
@@ -57,6 +55,53 @@ impl DestinationHandler for MySQLDestination {
         );
 
         self.pool = Some(pool);
+
+        let opts = mysql_async::Opts::from_url(connection_string).map_err(|e| {
+            CdcError::generic(format!("Failed to parse MySQL URL for bulk pool: {e}"))
+        })?;
+
+        let infile_data = self.infile_data.clone();
+        let opts = mysql_async::OptsBuilder::from_opts(opts).local_infile_handler(Some(
+            move |_file_name: &[u8]| {
+                let data = infile_data.clone();
+                Box::pin(async move {
+                    let bytes = data
+                        .lock()
+                        .unwrap()
+                        .take()
+                        .unwrap_or_else(|| bytes::Bytes::new());
+                    let stream =
+                        futures_util::stream::once(async move { Ok::<_, std::io::Error>(bytes) });
+                    Ok(Box::pin(stream) as mysql_async::InfileData)
+                })
+                    as futures_util::future::BoxFuture<
+                        'static,
+                        std::result::Result<mysql_async::InfileData, mysql_async::LocalInfileError>,
+                    >
+            },
+        ));
+
+        let bulk_pool = mysql_async::Pool::new(opts);
+        self.bulk_pool = Some(bulk_pool);
+
+        match self.check_load_data_available().await {
+            Ok(available) => {
+                self.load_data_available = available;
+                if available {
+                    info!("MySQL LOAD DATA LOCAL INFILE: available");
+                } else {
+                    warn!("MySQL LOAD DATA LOCAL INFILE: not available, falling back to multi-value INSERT");
+                }
+            }
+            Err(e) => {
+                warn!(
+                    "Failed to check LOAD DATA availability: {}, falling back to multi-value INSERT",
+                    e
+                );
+                self.load_data_available = false;
+            }
+        }
+
         Ok(())
     }
 
@@ -84,10 +129,6 @@ impl DestinationHandler for MySQLDestination {
             .as_ref()
             .ok_or_else(|| CdcError::generic("MySQL pool not initialized"))?;
 
-        // Coalesce consecutive DML statements before executing:
-        // - INSERT → multi-value INSERT
-        // - UPDATE → CASE-WHEN batch UPDATE
-        // - DELETE → OR-combined WHERE clause
         let coalesced = coalesce_commands(commands, self.max_allowed_packet, QuoteStyle::Backtick);
 
         if coalesced.len() < commands.len() {
@@ -103,13 +144,255 @@ impl DestinationHandler for MySQLDestination {
             .await
     }
 
+    fn supports_bulk_insert(&self) -> bool {
+        self.load_data_available
+    }
+
+    async fn execute_bulk_insert_with_hook(
+        &mut self,
+        table: &str,
+        columns: &[String],
+        rows: &[Vec<String>],
+        pre_commit_hook: Option<PreCommitHook>,
+    ) -> Result<()> {
+        if rows.is_empty() {
+            return Ok(());
+        }
+
+        if !self.load_data_available {
+            let sqls = super::bulk_insert::build_chunked_multi_value_inserts(
+                table,
+                columns,
+                rows,
+                Some(self.max_allowed_packet as usize),
+            );
+            return self
+                .execute_sql_batch_with_hook(&sqls, pre_commit_hook)
+                .await;
+        }
+
+        self.execute_load_data(table, columns, rows, pre_commit_hook)
+            .await
+    }
+
     async fn close(&mut self) -> Result<()> {
         if let Some(pool) = &self.pool {
             pool.close().await;
         }
         self.pool = None;
+
+        if let Some(pool) = self.bulk_pool.take() {
+            pool.disconnect().await.map_err(|e| {
+                CdcError::generic(format!("Failed to disconnect mysql_async pool: {e}"))
+            })?;
+        }
+
         info!("MySQL connection closed successfully");
         Ok(())
+    }
+}
+
+impl MySQLDestination {
+    async fn check_load_data_available(&self) -> Result<bool> {
+        use mysql_async::prelude::*;
+
+        let pool = self
+            .bulk_pool
+            .as_ref()
+            .ok_or_else(|| CdcError::generic("Bulk pool not initialized"))?;
+
+        let mut conn = pool
+            .get_conn()
+            .await
+            .map_err(|e| CdcError::generic(format!("Failed to get bulk connection: {e}")))?;
+
+        let result: Option<(String, String)> = conn
+            .query_first("SHOW VARIABLES LIKE 'local_infile'")
+            .await
+            .map_err(|e| CdcError::generic(format!("Failed to check local_infile: {e}")))?;
+
+        drop(conn);
+
+        match result {
+            Some((_, value)) => Ok(value.eq_ignore_ascii_case("ON")),
+            None => Ok(false),
+        }
+    }
+
+    async fn execute_load_data(
+        &mut self,
+        table: &str,
+        columns: &[String],
+        rows: &[Vec<String>],
+        pre_commit_hook: Option<PreCommitHook>,
+    ) -> Result<()> {
+        use mysql_async::prelude::*;
+
+        let pool = self
+            .bulk_pool
+            .as_ref()
+            .ok_or_else(|| CdcError::generic("Bulk pool not initialized"))?;
+
+        let tsv_data = generate_tsv_buffer(rows);
+        let row_count = rows.len();
+
+        debug!(
+            "Executing LOAD DATA LOCAL INFILE for {} rows ({} bytes TSV) into {}",
+            row_count,
+            tsv_data.len(),
+            table
+        );
+
+        let mut tx = pool
+            .start_transaction(mysql_async::TxOpts::default())
+            .await
+            .map_err(|e| CdcError::generic(format!("MySQL START TRANSACTION failed: {e}")))?;
+
+        let col_spec = columns.join(", ");
+        let load_sql = format!(
+            "LOAD DATA LOCAL INFILE 'data.tsv' INTO TABLE {} \
+             FIELDS TERMINATED BY '\\t' LINES TERMINATED BY '\\n' ({})",
+            table, col_spec
+        );
+
+        *self.infile_data.lock().unwrap() = Some(bytes::Bytes::from(tsv_data));
+
+        let result = tx.query_drop(&load_sql).await;
+
+        if let Err(e) = result {
+            *self.infile_data.lock().unwrap() = None;
+            debug!("LOAD DATA LOCAL INFILE failed, falling back to multi-value INSERT: {e}");
+            let _ = tx.rollback().await;
+
+            let sqls = super::bulk_insert::build_chunked_multi_value_inserts(
+                table,
+                columns,
+                rows,
+                Some(self.max_allowed_packet as usize),
+            );
+            return self
+                .execute_sql_batch_with_hook(&sqls, pre_commit_hook)
+                .await;
+        }
+
+        if let Some(hook) = pre_commit_hook {
+            if let Err(e) = hook().await {
+                let _ = tx.rollback().await;
+                return Err(CdcError::generic(format!(
+                    "MySQL bulk insert pre-commit hook failed, rolled back: {e}"
+                )));
+            }
+        }
+
+        tx.commit()
+            .await
+            .map_err(|e| CdcError::generic(format!("MySQL COMMIT failed after LOAD DATA: {e}")))?;
+
+        info!(
+            "LOAD DATA complete: {} rows loaded into {}",
+            row_count, table
+        );
+
+        Ok(())
+    }
+}
+
+fn generate_tsv_buffer(rows: &[Vec<String>]) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(rows.len() * 128);
+
+    for row in rows {
+        for (col_idx, value) in row.iter().enumerate() {
+            if col_idx > 0 {
+                buf.push(b'\t');
+            }
+            let trimmed = value.trim();
+            if trimmed.eq_ignore_ascii_case("NULL") {
+                buf.extend_from_slice(b"\\N");
+            } else if trimmed.len() >= 2 && trimmed.starts_with('\'') && trimmed.ends_with('\'') {
+                let unquoted = &trimmed[1..trimmed.len() - 1];
+                tsv_escape_string(unquoted, &mut buf);
+            } else if let Some(decoded) = decode_hex_literal(trimmed) {
+                tsv_escape_raw(&decoded, &mut buf);
+            } else {
+                tsv_escape_raw(trimmed.as_bytes(), &mut buf);
+            }
+        }
+        buf.push(b'\n');
+    }
+
+    buf
+}
+
+/// Decode MySQL hex literal (X'aabb' or x'aabb') into raw bytes.
+fn decode_hex_literal(s: &str) -> Option<Vec<u8>> {
+    if s.len() < 3 {
+        return None;
+    }
+    if !(s.starts_with("X'") || s.starts_with("x'")) || !s.ends_with('\'') {
+        return None;
+    }
+    let hex_str = &s[2..s.len() - 1];
+    if hex_str.len() % 2 != 0 || !hex_str.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return None;
+    }
+    let bytes: Vec<u8> = (0..hex_str.len())
+        .step_by(2)
+        .map(|i| u8::from_str_radix(&hex_str[i..i + 2], 16).unwrap())
+        .collect();
+    Some(bytes)
+}
+
+/// Unescape MySQL SQL literal content and re-encode for TSV format.
+/// Input is the content between single quotes from a MySQL SQL literal.
+/// MySQL SQL literals use backslash escaping: \\ → \, \n → newline, \t → tab, etc.
+/// TSV format uses: \\ → \, \n → newline, \t → tab, \N → NULL.
+fn tsv_escape_string(s: &str, buf: &mut Vec<u8>) {
+    let mut chars = s.chars().peekable();
+    while let Some(ch) = chars.next() {
+        match ch {
+            '\'' => {
+                if chars.peek() == Some(&'\'') {
+                    chars.next();
+                }
+                buf.push(b'\'');
+            }
+            '\\' => {
+                match chars.next() {
+                    Some('\\') => buf.extend_from_slice(b"\\\\"), // SQL \\ → literal \ → TSV \\
+                    Some('n') => buf.extend_from_slice(b"\\n"),   // SQL \n → newline → TSV \n
+                    Some('t') => buf.extend_from_slice(b"\\t"),   // SQL \t → tab → TSV \t
+                    Some('r') => buf.extend_from_slice(b"\\r"),   // SQL \r → CR → TSV \r
+                    Some('0') => buf.extend_from_slice(b"\\0"),   // SQL \0 → null → TSV \0
+                    Some(other) => {
+                        // MySQL: \x → x for any unrecognized escape
+                        let mut bytes = [0u8; 4];
+                        buf.extend_from_slice(other.encode_utf8(&mut bytes).as_bytes());
+                    }
+                    None => buf.extend_from_slice(b"\\\\"), // trailing backslash
+                }
+            }
+            '\t' => buf.extend_from_slice(b"\\t"),
+            '\n' => buf.extend_from_slice(b"\\n"),
+            '\r' => buf.extend_from_slice(b"\\r"),
+            '\0' => buf.extend_from_slice(b"\\0"),
+            _ => {
+                let mut bytes = [0u8; 4];
+                buf.extend_from_slice(ch.encode_utf8(&mut bytes).as_bytes());
+            }
+        }
+    }
+}
+
+fn tsv_escape_raw(data: &[u8], buf: &mut Vec<u8>) {
+    for &b in data {
+        match b {
+            b'\\' => buf.extend_from_slice(b"\\\\"),
+            b'\t' => buf.extend_from_slice(b"\\t"),
+            b'\n' => buf.extend_from_slice(b"\\n"),
+            b'\r' => buf.extend_from_slice(b"\\r"),
+            0 => buf.extend_from_slice(b"\\0"),
+            _ => buf.push(b),
+        }
     }
 }
 
@@ -121,5 +404,93 @@ mod tests {
     fn test_mysql_destination_creation() {
         let destination = MySQLDestination::new();
         assert!(destination.pool.is_none());
+        assert!(destination.bulk_pool.is_none());
+        assert!(destination.infile_data.lock().unwrap().is_none());
+        assert!(!destination.load_data_available);
+    }
+
+    #[test]
+    fn test_tsv_generation_basic() {
+        let rows = vec![
+            vec!["1".to_string(), "'hello'".to_string(), "NULL".to_string()],
+            vec!["2".to_string(), "'world'".to_string(), "42".to_string()],
+        ];
+        let tsv = generate_tsv_buffer(&rows);
+        let output = String::from_utf8(tsv).unwrap();
+        assert_eq!(output, "1\thello\t\\N\n2\tworld\t42\n");
+    }
+
+    #[test]
+    fn test_tsv_generation_escaping() {
+        let rows = vec![vec!["3".to_string(), "'it''s escaped'".to_string()]];
+        let tsv = generate_tsv_buffer(&rows);
+        let output = String::from_utf8(tsv).unwrap();
+        assert!(output.contains("it's escaped"));
+    }
+
+    #[test]
+    fn test_tsv_null_handling() {
+        let rows = vec![
+            vec!["1".to_string(), "NULL".to_string(), "'text'".to_string()],
+            vec!["2".to_string(), "'value'".to_string(), "NULL".to_string()],
+        ];
+        let tsv = generate_tsv_buffer(&rows);
+        let output = String::from_utf8(tsv).unwrap();
+        assert!(output.contains("\\N"));
+        assert!(output.contains("text"));
+        assert!(output.contains("value"));
+    }
+
+    #[test]
+    fn test_tsv_special_characters() {
+        let rows = vec![
+            vec!["1".to_string(), "'hello\\tworld'".to_string()],
+            vec!["2".to_string(), "'line1\\nline2'".to_string()],
+            // SQL literal '\\' means one backslash; TSV should produce \\
+            vec!["3".to_string(), "'back\\\\slash'".to_string()],
+        ];
+        let tsv = generate_tsv_buffer(&rows);
+        let output = String::from_utf8(tsv).unwrap();
+        let lines: Vec<&str> = output.lines().collect();
+        // SQL \t → literal tab → TSV \t
+        assert_eq!(lines[0], "1\thello\\tworld");
+        // SQL \n → literal newline → TSV \n
+        assert_eq!(lines[1], "2\tline1\\nline2");
+        // SQL \\ → literal backslash → TSV \\
+        assert_eq!(lines[2], "3\tback\\\\slash");
+    }
+
+    #[test]
+    fn test_tsv_hex_literal_decoding() {
+        let rows = vec![vec![
+            "1".to_string(),
+            "X'deadbeef'".to_string(),
+            "'text'".to_string(),
+        ]];
+        let tsv = generate_tsv_buffer(&rows);
+        assert_eq!(tsv, b"1\t\xde\xad\xbe\xef\ttext\n");
+    }
+
+    #[test]
+    fn test_tsv_hex_literal_lowercase() {
+        let rows = vec![vec!["1".to_string(), "x'cafe'".to_string()]];
+        let tsv = generate_tsv_buffer(&rows);
+        assert_eq!(tsv, b"1\t\xca\xfe\n");
+    }
+
+    #[test]
+    fn test_tsv_hex_literal_with_special_bytes() {
+        // Hex containing tab, newline, backslash bytes should be TSV-escaped
+        let rows = vec![vec!["1".to_string(), "X'090a5c00'".to_string()]];
+        let tsv = generate_tsv_buffer(&rows);
+        assert_eq!(tsv, b"1\t\\t\\n\\\\\\0\n");
+    }
+
+    #[test]
+    fn test_decode_hex_literal_invalid() {
+        assert!(decode_hex_literal("hello").is_none());
+        assert!(decode_hex_literal("X'zz'").is_none());
+        assert!(decode_hex_literal("X'abc'").is_none()); // odd length
+        assert!(decode_hex_literal("0xdead").is_none()); // 0x prefix is SQL Server style
     }
 }

--- a/pg2any-lib/src/destinations/sqlserver.rs
+++ b/pg2any-lib/src/destinations/sqlserver.rs
@@ -2,11 +2,12 @@ use super::coalescing::{coalesce_commands, QuoteStyle};
 use super::destination_factory::{DestinationHandler, PreCommitHook};
 use crate::error::{CdcError, Result};
 use async_trait::async_trait;
+use std::borrow::Cow;
 use std::collections::HashMap;
-use tiberius::{Client, Config};
+use tiberius::{Client, ColumnData, Config, TokenRow};
 use tokio::net::TcpStream;
 use tokio_util::compat::{Compat, TokioAsyncWriteCompatExt};
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 /// SQL Server destination implementation
 pub struct SqlServerDestination {
@@ -151,12 +152,173 @@ impl DestinationHandler for SqlServerDestination {
         info!("SQL Server connection closed successfully");
         Ok(())
     }
+
+    fn supports_bulk_insert(&self) -> bool {
+        true
+    }
+
+    async fn execute_bulk_insert_with_hook(
+        &mut self,
+        table: &str,
+        columns: &[String],
+        rows: &[Vec<String>],
+        pre_commit_hook: Option<PreCommitHook>,
+    ) -> Result<()> {
+        if rows.is_empty() {
+            return Ok(());
+        }
+
+        let row_count = rows.len();
+        let bulk_table = table.trim();
+
+        debug!(
+            "Attempting TDS Bulk Load: {} rows into {}",
+            row_count, bulk_table
+        );
+
+        let client = self
+            .client
+            .as_mut()
+            .ok_or_else(|| CdcError::generic("SQL Server client not initialized"))?;
+
+        client
+            .simple_query("BEGIN TRANSACTION")
+            .await
+            .map_err(|e| {
+                CdcError::generic(format!(
+                    "SQL Server BEGIN TRANSACTION failed for bulk load: {e}"
+                ))
+            })?;
+
+        match client.bulk_insert(bulk_table).await {
+            Ok(mut req) => {
+                for row_values in rows {
+                    let mut token_row = TokenRow::new();
+                    for value in row_values {
+                        token_row.push(parse_sql_value(value));
+                    }
+                    if let Err(e) = req.send(token_row).await {
+                        warn!(
+                            "TDS Bulk Load send failed, falling back to multi-value INSERT: {}",
+                            e
+                        );
+                        let _ = client.simple_query("ROLLBACK TRANSACTION").await;
+                        return self
+                            .fallback_multi_value_insert(table, columns, rows, pre_commit_hook)
+                            .await;
+                    }
+                }
+
+                match req.finalize().await {
+                    Ok(result) => {
+                        info!(
+                            "TDS Bulk Load complete: {} rows loaded into {}",
+                            result.total(),
+                            bulk_table
+                        );
+
+                        if let Some(hook) = pre_commit_hook {
+                            if let Err(e) = hook().await {
+                                let _ = client.simple_query("ROLLBACK TRANSACTION").await;
+                                return Err(CdcError::generic(format!(
+                                    "SQL Server bulk insert pre-commit hook failed, rolled back: {}",
+                                    e
+                                )));
+                            }
+                        }
+
+                        client
+                            .simple_query("COMMIT TRANSACTION")
+                            .await
+                            .map_err(|e| {
+                                CdcError::generic(format!(
+                                    "SQL Server COMMIT TRANSACTION failed after bulk load: {e}"
+                                ))
+                            })?;
+
+                        Ok(())
+                    }
+                    Err(e) => {
+                        warn!(
+                            "TDS Bulk Load finalize failed, falling back to multi-value INSERT: {}",
+                            e
+                        );
+                        let _ = client.simple_query("ROLLBACK TRANSACTION").await;
+                        self.fallback_multi_value_insert(table, columns, rows, pre_commit_hook)
+                            .await
+                    }
+                }
+            }
+            Err(e) => {
+                warn!(
+                    "TDS Bulk Load init failed, falling back to multi-value INSERT: {}",
+                    e
+                );
+                let _ = client.simple_query("ROLLBACK TRANSACTION").await;
+                self.fallback_multi_value_insert(table, columns, rows, pre_commit_hook)
+                    .await
+            }
+        }
+    }
 }
 
 impl Default for SqlServerDestination {
     fn default() -> Self {
         Self::new()
     }
+}
+
+impl SqlServerDestination {
+    async fn fallback_multi_value_insert(
+        &mut self,
+        table: &str,
+        columns: &[String],
+        rows: &[Vec<String>],
+        pre_commit_hook: Option<PreCommitHook>,
+    ) -> Result<()> {
+        let sqls =
+            super::bulk_insert::build_chunked_multi_value_inserts(table, columns, rows, None);
+        self.execute_sql_batch_with_hook(&sqls, pre_commit_hook)
+            .await
+    }
+}
+
+fn parse_sql_value(value: &str) -> ColumnData<'static> {
+    let trimmed = value.trim();
+
+    if trimmed.eq_ignore_ascii_case("NULL") {
+        return ColumnData::String(None);
+    }
+
+    if trimmed.starts_with('\'') && trimmed.ends_with('\'') {
+        let inner = &trimmed[1..trimmed.len() - 1];
+        let unescaped = inner.replace("''", "'");
+        return ColumnData::String(Some(Cow::Owned(unescaped)));
+    }
+
+    if let Some(bytes) = decode_hex_0x(trimmed) {
+        return ColumnData::Binary(Some(Cow::Owned(bytes)));
+    }
+
+    // Send remaining values as strings — SQL Server handles implicit type conversion.
+    // Avoids f64 precision loss for large decimals in CDC data.
+    ColumnData::String(Some(Cow::Owned(trimmed.to_string())))
+}
+
+/// Decode SQL Server hex literal (0xDEADBEEF) into raw bytes.
+fn decode_hex_0x(s: &str) -> Option<Vec<u8>> {
+    if s.len() < 4 || !s.starts_with("0x") && !s.starts_with("0X") {
+        return None;
+    }
+    let hex_str = &s[2..];
+    if hex_str.len() % 2 != 0 || !hex_str.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return None;
+    }
+    let bytes: Vec<u8> = (0..hex_str.len())
+        .step_by(2)
+        .map(|i| u8::from_str_radix(&hex_str[i..i + 2], 16).unwrap())
+        .collect();
+    Some(bytes)
 }
 
 #[cfg(test)]
@@ -167,5 +329,91 @@ mod tests {
     fn test_sqlserver_destination_creation() {
         let destination = SqlServerDestination::new();
         assert!(destination.client.is_none());
+    }
+
+    #[test]
+    fn test_parse_sql_value_null() {
+        let result = parse_sql_value("NULL");
+        assert!(matches!(result, ColumnData::String(None)));
+    }
+
+    #[test]
+    fn test_parse_sql_value_integer() {
+        let result = parse_sql_value("42");
+        assert_eq!(
+            result,
+            ColumnData::String(Some(Cow::Owned("42".to_string())))
+        );
+    }
+
+    #[test]
+    fn test_parse_sql_value_negative_integer() {
+        let result = parse_sql_value("-123");
+        assert_eq!(
+            result,
+            ColumnData::String(Some(Cow::Owned("-123".to_string())))
+        );
+    }
+
+    #[test]
+    fn test_parse_sql_value_float() {
+        let result = parse_sql_value("3.14");
+        assert_eq!(
+            result,
+            ColumnData::String(Some(Cow::Owned("3.14".to_string())))
+        );
+    }
+
+    #[test]
+    fn test_parse_sql_value_string() {
+        let result = parse_sql_value("'hello world'");
+        assert_eq!(
+            result,
+            ColumnData::String(Some(Cow::Owned("hello world".to_string())))
+        );
+    }
+
+    #[test]
+    fn test_parse_sql_value_escaped_string() {
+        let result = parse_sql_value("'it''s escaped'");
+        assert_eq!(
+            result,
+            ColumnData::String(Some(Cow::Owned("it's escaped".to_string())))
+        );
+    }
+
+    #[test]
+    fn test_parse_sql_value_unquoted_string() {
+        let result = parse_sql_value("some_value");
+        assert_eq!(
+            result,
+            ColumnData::String(Some(Cow::Owned("some_value".to_string())))
+        );
+    }
+
+    #[test]
+    fn test_parse_sql_value_hex_binary() {
+        let result = parse_sql_value("0xDEADBEEF");
+        assert_eq!(
+            result,
+            ColumnData::Binary(Some(Cow::Owned(vec![0xDE, 0xAD, 0xBE, 0xEF])))
+        );
+    }
+
+    #[test]
+    fn test_parse_sql_value_hex_binary_lowercase() {
+        let result = parse_sql_value("0xcafe");
+        assert_eq!(
+            result,
+            ColumnData::Binary(Some(Cow::Owned(vec![0xCA, 0xFE])))
+        );
+    }
+
+    #[test]
+    fn test_decode_hex_0x_invalid() {
+        assert!(decode_hex_0x("hello").is_none());
+        assert!(decode_hex_0x("0x").is_none());
+        assert!(decode_hex_0x("0xZZ").is_none());
+        assert!(decode_hex_0x("0xABC").is_none()); // odd length
     }
 }

--- a/pg2any-lib/src/env.rs
+++ b/pg2any-lib/src/env.rs
@@ -42,12 +42,14 @@ use std::time::Duration;
 /// - `CDC_QUERY_TIMEOUT`: Query timeout in seconds (default: "10")
 ///
 /// ## Performance Configuration
-/// - `CDC_BUFFER_SIZE`: Capacity of the transaction channel between producer and consumer (default: "1000")
+/// - `CDC_CHANNEL_CAPACITY`: Capacity of the transaction channel between producer and consumer (default: "1000")
 ///   Controls how many complete transactions can be queued. Larger values handle burst traffic better but use more memory.
 ///   Recommended: 1000-5000 for typical workloads, 10000+ for high-throughput scenarios.
-/// - `CDC_COMMIT_BATCH_SIZE`: Number of rows per batch INSERT statement (default: "1000")
+///   (Deprecated alias: `CDC_BUFFER_SIZE`)
+/// - `CDC_BATCH_SIZE`: Number of rows per batch INSERT statement (default: "1000")
 ///   Higher values improve throughput for large streaming transactions (e.g., 400k+ inserts).
 ///   Recommended: 1000-5000 for typical workloads, adjust based on MySQL max_allowed_packet.
+///   (Deprecated alias: `CDC_COMMIT_BATCH_SIZE`)
 ///
 /// # Errors
 ///
@@ -98,10 +100,15 @@ pub fn load_config_from_env() -> Result<Config, CdcError> {
     // Timeout configurations
     let connection_timeout_secs = parse_u64_env("CDC_CONNECTION_TIMEOUT", 30)?;
     let query_timeout_secs = parse_u64_env("CDC_QUERY_TIMEOUT", 10)?;
-    let buffer_size = parse_usize_env("CDC_BUFFER_SIZE", 1000)?;
-    let batch_size = parse_usize_env("CDC_COMMIT_BATCH_SIZE", 1000)?;
+    let buffer_size =
+        parse_usize_env_with_fallback("CDC_CHANNEL_CAPACITY", "CDC_BUFFER_SIZE", 1000)?;
+    let batch_size =
+        parse_usize_env_with_fallback("CDC_BATCH_SIZE", "CDC_COMMIT_BATCH_SIZE", 1000)?;
     let segment_size_mb = parse_usize_env("CDC_TRANSACTION_SEGMENT_SIZE_MB", 64)?;
     let segment_size_bytes = segment_size_mb.saturating_mul(1024 * 1024);
+
+    let bulk_insert_threshold = parse_usize_env("CDC_BULK_INSERT_THRESHOLD", 500)?;
+    let smart_batch_max_txns = parse_usize_env("CDC_SMART_BATCH_MAX_TXNS", 50)?;
 
     // Transaction file persistence configuration
     let transaction_file_base_path =
@@ -156,6 +163,8 @@ pub fn load_config_from_env() -> Result<Config, CdcError> {
         .batch_size(batch_size)
         .transaction_file_base_path(transaction_file_base_path)
         .transaction_segment_size_bytes(segment_size_bytes)
+        .bulk_insert_threshold(bulk_insert_threshold)
+        .smart_batch_max_txns(smart_batch_max_txns)
         .build()?;
 
     tracing::info!("Configuration loaded successfully");
@@ -235,4 +244,25 @@ fn parse_usize_env(key: &str, default: usize) -> Result<usize, CdcError> {
             .map_err(|e| CdcError::config(format!("Invalid usize value for {key}: {value} ({e})"))),
         Err(_) => Ok(default),
     }
+}
+
+/// Parse a usize env var with a deprecated fallback name.
+/// Prefers `new_key`; if absent, checks `old_key` and logs a deprecation warning.
+fn parse_usize_env_with_fallback(
+    new_key: &str,
+    old_key: &str,
+    default: usize,
+) -> Result<usize, CdcError> {
+    if let Ok(value) = std::env::var(new_key) {
+        return value.parse::<usize>().map_err(|e| {
+            CdcError::config(format!("Invalid usize value for {new_key}: {value} ({e})"))
+        });
+    }
+    if let Ok(value) = std::env::var(old_key) {
+        tracing::warn!("Environment variable {old_key} is deprecated, use {new_key} instead");
+        return value.parse::<usize>().map_err(|e| {
+            CdcError::config(format!("Invalid usize value for {old_key}: {value} ({e})"))
+        });
+    }
+    Ok(default)
 }

--- a/pg2any-lib/src/lib.rs
+++ b/pg2any-lib/src/lib.rs
@@ -70,7 +70,7 @@ pub mod lsn_tracker;
 pub mod client;
 
 // Transaction file persistence
-mod transaction_manager;
+pub mod transaction_manager;
 
 // Storage abstraction for transaction files
 pub mod storage;

--- a/pg2any-lib/src/transaction_manager.rs
+++ b/pg2any-lib/src/transaction_manager.rs
@@ -263,6 +263,9 @@ pub struct TransactionManager {
     storage: Arc<dyn TransactionStorage>,
     /// When true, stores raw ChangeEvent JSON instead of generated SQL
     event_mode: bool,
+    /// Whether bulk insert optimization is enabled
+    /// Minimum INSERT count to trigger bulk insert path
+    bulk_insert_threshold: usize,
 }
 
 impl TransactionManager {
@@ -301,6 +304,7 @@ impl TransactionManager {
             segment_size_bytes,
             storage,
             event_mode: false,
+            bulk_insert_threshold: 500,
         })
     }
 
@@ -312,6 +316,11 @@ impl TransactionManager {
     /// Enable event-mode: stores raw ChangeEvent JSON instead of generated SQL
     pub fn set_event_mode(&mut self, enabled: bool) {
         self.event_mode = enabled;
+    }
+
+    /// Configure bulk insert optimization parameters
+    pub fn set_bulk_insert_config(&mut self, threshold: usize) {
+        self.bulk_insert_threshold = threshold;
     }
 
     /// Flush all pending buffered writes
@@ -1403,6 +1412,88 @@ impl TransactionManager {
 }
 
 impl TransactionManager {
+    async fn execute_batch_with_bulk_detection(
+        self: &Arc<Self>,
+        destination_handler: &mut Box<dyn DestinationHandler>,
+        metadata_path: &Path,
+        commands: &[String],
+        last_executed_index: usize,
+        batch_idx: usize,
+        metrics_collector: &Arc<MetricsCollector>,
+        bulk_insert_threshold: usize,
+    ) -> Result<()> {
+        #[cfg(any(feature = "mysql", feature = "sqlserver"))]
+        if commands.len() >= bulk_insert_threshold && destination_handler.supports_bulk_insert() {
+            if let Some(parsed) =
+                crate::destinations::bulk_insert::detect_bulk_insert_batch(commands)
+            {
+                debug!(
+                    "Bulk insert detected: {} rows into {} (batch {})",
+                    parsed.rows.len(),
+                    parsed.table,
+                    batch_idx
+                );
+
+                let batch_start_time = Instant::now();
+                let metadata_path_owned = metadata_path.to_path_buf();
+                let file_manager_for_hook = self.clone();
+                let staged_index = last_executed_index;
+
+                let pre_commit_hook: Option<PreCommitHook> = Some(Box::new(move || {
+                    let metadata_path = metadata_path_owned;
+                    let file_manager_for_hook = file_manager_for_hook;
+                    Box::pin(async move {
+                        file_manager_for_hook
+                            .stage_pending_metadata_progress(&metadata_path, staged_index)
+                            .await?;
+                        Ok(())
+                    })
+                }));
+
+                match destination_handler
+                    .execute_bulk_insert_with_hook(
+                        &parsed.table,
+                        &parsed.columns,
+                        &parsed.rows,
+                        pre_commit_hook,
+                    )
+                    .await
+                {
+                    Ok(()) => {
+                        let duration = batch_start_time.elapsed();
+                        debug!(
+                            "Bulk insert batch {} complete: {} rows in {:?}",
+                            batch_idx,
+                            parsed.rows.len(),
+                            duration
+                        );
+                        self.flush_staged_pending_progress().await?;
+                        return Ok(());
+                    }
+                    Err(e) => {
+                        warn!(
+                            "Bulk insert failed for batch {}, falling back to SQL batch: {}",
+                            batch_idx, e
+                        );
+                    }
+                }
+            }
+        }
+
+        #[cfg(not(any(feature = "mysql", feature = "sqlserver")))]
+        let _ = bulk_insert_threshold;
+
+        self.execute_sql_batch(
+            destination_handler,
+            metadata_path,
+            commands,
+            last_executed_index,
+            batch_idx,
+            metrics_collector,
+        )
+        .await
+    }
+
     async fn execute_sql_batch(
         self: &Arc<Self>,
         destination_handler: &mut Box<dyn DestinationHandler>,
@@ -1506,13 +1597,14 @@ impl TransactionManager {
                         let last_executed_index = next_command_index - 1;
                         *state.batch_count += 1;
 
-                        self.execute_sql_batch(
+                        self.execute_batch_with_bulk_detection(
                             destination_handler,
                             &pending_tx.file_path,
                             state.batch,
                             last_executed_index,
                             *state.batch_count,
                             metrics_collector,
+                            self.bulk_insert_threshold,
                         )
                         .await?;
 
@@ -1636,23 +1728,6 @@ impl TransactionManager {
         batch_size: usize,
         shared_lsn_feedback: &Arc<SharedLsnFeedback>,
     ) -> Result<()> {
-        // Skip transactions already applied (position-tracking based deduplication)
-        if let Some(commit_lsn) = pending_tx.metadata.commit_lsn {
-            let current_flush_lsn = lsn_tracker.get();
-            if commit_lsn.0 <= current_flush_lsn && current_flush_lsn > 0 {
-                info!(
-                    "Skipping already-applied transaction {} (commit_lsn {} <= flush_lsn {})",
-                    pending_tx.metadata.transaction_id,
-                    commit_lsn,
-                    pg_walstream::format_lsn(current_flush_lsn)
-                );
-                if let Err(e) = self.delete_pending_transaction(&pending_tx.file_path).await {
-                    warn!("Failed to delete duplicate pending file: {}", e);
-                }
-                return Ok(());
-            }
-        }
-
         if self.event_mode {
             return self
                 .process_transaction_file_event_mode(
@@ -1750,13 +1825,14 @@ impl TransactionManager {
             let last_executed_index = next_command_index - 1;
             batch_count += 1;
 
-            self.execute_sql_batch(
+            self.execute_batch_with_bulk_detection(
                 destination_handler,
                 &pending_tx.file_path,
                 &batch,
                 last_executed_index,
                 batch_count,
                 metrics_collector,
+                self.bulk_insert_threshold,
             )
             .await?;
 
@@ -2133,6 +2209,164 @@ impl TransactionManager {
         }
 
         Ok(())
+    }
+
+    /// Analyzes AND extracts rows from transaction segments in a single pass.
+    /// Returns `Some((table, columns, rows))` if ALL statements are homogeneous INSERTs
+    /// targeting the same table with the same columns. Returns `None` otherwise.
+    ///
+    /// This combines what was previously two separate passes (analyze + extract) into one,
+    /// eliminating redundant I/O for large transactions.
+    #[cfg(any(feature = "mysql", feature = "sqlserver"))]
+    pub async fn analyze_and_extract_rows(
+        &self,
+        segments: &[TransactionSegment],
+    ) -> Result<Option<(String, Vec<String>, Vec<Vec<String>>)>> {
+        use tokio::io::AsyncBufReadExt;
+
+        let total_statements: usize = segments.iter().map(|s| s.statement_count).sum();
+        let mut expected_prefix: Option<String> = None;
+        let mut expected_table: Option<String> = None;
+        let mut expected_columns: Option<Vec<String>> = None;
+        let mut all_rows: Vec<Vec<String>> = Vec::with_capacity(total_statements);
+
+        for segment in segments {
+            let is_compressed = segment
+                .path
+                .extension()
+                .and_then(|ext| ext.to_str())
+                .map(|ext| ext.eq_ignore_ascii_case("gz"))
+                .unwrap_or(false);
+
+            let file = tokio::fs::File::open(&segment.path).await.map_err(|e| {
+                CdcError::generic(format!(
+                    "Failed to open segment {:?} for analysis: {e}",
+                    segment.path
+                ))
+            })?;
+
+            let reader: Box<dyn tokio::io::AsyncBufRead + Unpin + Send> = if is_compressed {
+                let buf = tokio::io::BufReader::new(file);
+                let mut decoder = GzipDecoder::new(buf);
+                decoder.multiple_members(true);
+                Box::new(tokio::io::BufReader::new(decoder))
+            } else {
+                Box::new(tokio::io::BufReader::new(file))
+            };
+
+            let mut lines = reader.lines();
+            let mut parser = SqlStreamParser::new();
+            let mut line_stmts: Vec<String> = Vec::new();
+
+            while let Some(line) = lines.next_line().await.map_err(|e| {
+                CdcError::generic(format!(
+                    "Failed to read segment {:?} for analysis: {e}",
+                    segment.path
+                ))
+            })? {
+                line_stmts.clear();
+                parser.parse_line(&line, &mut line_stmts)?;
+
+                for stmt in line_stmts.drain(..) {
+                    let trimmed = stmt.trim();
+                    if trimmed.is_empty() {
+                        continue;
+                    }
+                    if !self.check_and_extract_row(
+                        trimmed,
+                        &mut expected_prefix,
+                        &mut expected_table,
+                        &mut expected_columns,
+                        &mut all_rows,
+                    ) {
+                        return Ok(None);
+                    }
+                }
+            }
+
+            if let Some(stmt) = parser.finish_statement() {
+                let trimmed = stmt.trim();
+                if !trimmed.is_empty()
+                    && !self.check_and_extract_row(
+                        trimmed,
+                        &mut expected_prefix,
+                        &mut expected_table,
+                        &mut expected_columns,
+                        &mut all_rows,
+                    )
+                {
+                    return Ok(None);
+                }
+            }
+        }
+
+        match (expected_table, expected_columns) {
+            (Some(t), Some(c)) => Ok(Some((t, c, all_rows))),
+            _ => Ok(None),
+        }
+    }
+
+    /// Helper: validates a statement matches the expected INSERT prefix and extracts its row.
+    /// On first call, establishes the prefix. Returns false if statement doesn't match.
+    #[cfg(any(feature = "mysql", feature = "sqlserver"))]
+    fn check_and_extract_row(
+        &self,
+        stmt: &str,
+        expected_prefix: &mut Option<String>,
+        expected_table: &mut Option<String>,
+        expected_columns: &mut Option<Vec<String>>,
+        rows: &mut Vec<Vec<String>>,
+    ) -> bool {
+        use crate::destinations::bulk_insert::{extract_insert_prefix, extract_values_from_suffix};
+
+        match expected_prefix {
+            None => {
+                // First statement: parse fully to establish prefix
+                let (prefix, columns, table) = match extract_insert_prefix(stmt) {
+                    Some(p) => p,
+                    None => return false,
+                };
+                let values_suffix = &stmt[prefix.len()..];
+                let values = match extract_values_from_suffix(values_suffix) {
+                    Some(v) => v,
+                    None => return false,
+                };
+                *expected_prefix = Some(prefix);
+                *expected_table = Some(table);
+                *expected_columns = Some(columns);
+                rows.push(values);
+                true
+            }
+            Some(prefix) => {
+                // Subsequent statements: fast prefix check then extract values
+                if !stmt.starts_with(prefix.as_str()) {
+                    return false;
+                }
+                let values_suffix = &stmt[prefix.len()..];
+                match extract_values_from_suffix(values_suffix) {
+                    Some(values) => {
+                        rows.push(values);
+                        true
+                    }
+                    None => false,
+                }
+            }
+        }
+    }
+
+    /// Delete multiple files in batch. Logs warnings for individual failures
+    /// but does not fail the entire operation.
+    pub async fn batch_delete_files(&self, paths: &[PathBuf]) {
+        for path in paths {
+            if let Err(e) = tokio::fs::remove_file(path).await {
+                if e.kind() != std::io::ErrorKind::NotFound {
+                    warn!("Failed to delete file {:?}: {}", path, e);
+                }
+            }
+        }
+        if !paths.is_empty() {
+            debug!("Batch deleted {} files", paths.len());
+        }
     }
 }
 

--- a/pg2any-lib/src/transaction_manager.rs
+++ b/pg2any-lib/src/transaction_manager.rs
@@ -2212,7 +2212,7 @@ impl TransactionManager {
     }
 
     /// Analyzes AND extracts rows from transaction segments in a single pass.
-    /// Returns `Some((table, columns, rows))` if ALL statements are homogeneous INSERTs
+    /// Returns `Some((table, columns, rows))` if ALL statements are homogeneous insert
     /// targeting the same table with the same columns. Returns `None` otherwise.
     ///
     /// This combines what was previously two separate passes (analyze + extract) into one,

--- a/pg2any-lib/tests/bulk_insert_tests.rs
+++ b/pg2any-lib/tests/bulk_insert_tests.rs
@@ -1,0 +1,78 @@
+//! Integration tests for bulk insert optimization
+
+#[cfg(feature = "mysql")]
+mod bulk_insert_integration {
+    use pg2any_lib::destinations::bulk_insert::{
+        build_multi_value_insert, detect_bulk_insert_batch,
+    };
+
+    #[test]
+    fn test_large_batch_detection() {
+        let stmts: Vec<String> = (0..1000)
+            .map(|i| {
+                format!(
+                    "INSERT INTO `cdc_db`.`t1` (`id`, `val`, `col1`) VALUES ({}, {}, 'value_{}');",
+                    i,
+                    i * 100,
+                    i
+                )
+            })
+            .collect();
+
+        let result = detect_bulk_insert_batch(&stmts);
+        assert!(
+            result.is_some(),
+            "Should detect 1000 INSERT statements as bulk batch"
+        );
+
+        let parsed = result.unwrap();
+        assert_eq!(parsed.table, "`cdc_db`.`t1`");
+        assert_eq!(parsed.columns.len(), 3);
+        assert_eq!(parsed.rows.len(), 1000);
+    }
+
+    #[test]
+    fn test_below_threshold_not_detected() {
+        let stmts = vec![
+            "INSERT INTO `t` (`id`) VALUES (1);".to_string(),
+            "INSERT INTO `t` (`id`) VALUES (2);".to_string(),
+        ];
+        let result = detect_bulk_insert_batch(&stmts);
+        assert!(result.is_some());
+    }
+
+    #[test]
+    fn test_multi_value_insert_generation() {
+        let table = "`cdc_db`.`t1`";
+        let columns = vec![
+            "`id`".to_string(),
+            "`name`".to_string(),
+            "`value`".to_string(),
+        ];
+        let rows: Vec<Vec<String>> = (0..5)
+            .map(|i| vec![i.to_string(), format!("'name_{}'", i), "NULL".to_string()])
+            .collect();
+
+        let sql = build_multi_value_insert(table, &columns, &rows);
+        assert!(sql.starts_with("INSERT INTO `cdc_db`.`t1` (`id`, `name`, `value`) VALUES "));
+        assert!(sql.contains("(0, 'name_0', NULL)"));
+        assert!(sql.contains("(4, 'name_4', NULL)"));
+        assert!(sql.ends_with(';'));
+    }
+
+    #[test]
+    fn test_empty_batch_returns_none() {
+        let stmts: Vec<String> = vec![];
+        let result = detect_bulk_insert_batch(&stmts);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_single_insert_detection() {
+        let stmts = vec!["INSERT INTO `db`.`t` (`a`, `b`) VALUES (1, 'x');".to_string()];
+        let result = detect_bulk_insert_batch(&stmts);
+        assert!(result.is_some());
+        let parsed = result.unwrap();
+        assert_eq!(parsed.rows.len(), 1);
+    }
+}

--- a/pg2any-lib/tests/env_parsing_tests.rs
+++ b/pg2any-lib/tests/env_parsing_tests.rs
@@ -1,0 +1,141 @@
+use std::env;
+use std::sync::Mutex;
+
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+fn clear_env_vars() {
+    for key in &[
+        "CDC_SOURCE_CONNECTION_STRING",
+        "CDC_DEST_TYPE",
+        "CDC_DEST_URI",
+        "CDC_SCHEMA_MAPPING",
+        "CDC_REPLICATION_SLOT",
+        "CDC_PUBLICATION",
+        "CDC_PROTOCOL_VERSION",
+        "CDC_BINARY_FORMAT",
+        "CDC_STREAMING",
+        "CDC_CONNECTION_TIMEOUT",
+        "CDC_QUERY_TIMEOUT",
+        "CDC_BUFFER_SIZE",
+        "CDC_COMMIT_BATCH_SIZE",
+        "CDC_CHANNEL_CAPACITY",
+        "CDC_BATCH_SIZE",
+        "CDC_TRANSACTION_SEGMENT_SIZE_MB",
+        "CDC_BULK_INSERT_THRESHOLD",
+        "CDC_SMART_BATCH_MAX_TXNS",
+        "CDC_TRANSACTION_FILE_BASE_PATH",
+    ] {
+        env::remove_var(key);
+    }
+}
+
+fn set_required_env() {
+    env::set_var(
+        "CDC_SOURCE_CONNECTION_STRING",
+        "postgresql://user:pass@localhost:5432/db?replication=database",
+    );
+    env::set_var("CDC_DEST_URI", "mysql://user:pass@localhost:3306/testdb");
+    env::set_var("CDC_PROTOCOL_VERSION", "2");
+}
+
+#[test]
+fn test_new_env_names_preferred() {
+    let _lock = ENV_LOCK.lock().unwrap();
+    clear_env_vars();
+    set_required_env();
+    env::set_var("CDC_CHANNEL_CAPACITY", "2000");
+    env::set_var("CDC_BATCH_SIZE", "3000");
+
+    let config = pg2any_lib::load_config_from_env().unwrap();
+    assert_eq!(config.buffer_size, 2000);
+    assert_eq!(config.batch_size, 3000);
+
+    clear_env_vars();
+}
+
+#[test]
+fn test_deprecated_env_names_still_work() {
+    let _lock = ENV_LOCK.lock().unwrap();
+    clear_env_vars();
+    set_required_env();
+    env::set_var("CDC_BUFFER_SIZE", "4000");
+    env::set_var("CDC_COMMIT_BATCH_SIZE", "5000");
+
+    let config = pg2any_lib::load_config_from_env().unwrap();
+    assert_eq!(config.buffer_size, 4000);
+    assert_eq!(config.batch_size, 5000);
+
+    clear_env_vars();
+}
+
+#[test]
+fn test_new_name_takes_precedence_over_deprecated() {
+    let _lock = ENV_LOCK.lock().unwrap();
+    clear_env_vars();
+    set_required_env();
+    env::set_var("CDC_CHANNEL_CAPACITY", "6000");
+    env::set_var("CDC_BUFFER_SIZE", "9999");
+    env::set_var("CDC_BATCH_SIZE", "7000");
+    env::set_var("CDC_COMMIT_BATCH_SIZE", "9999");
+
+    let config = pg2any_lib::load_config_from_env().unwrap();
+    assert_eq!(config.buffer_size, 6000);
+    assert_eq!(config.batch_size, 7000);
+
+    clear_env_vars();
+}
+
+#[test]
+fn test_defaults_when_no_env_set() {
+    let _lock = ENV_LOCK.lock().unwrap();
+    clear_env_vars();
+    set_required_env();
+
+    let config = pg2any_lib::load_config_from_env().unwrap();
+    assert_eq!(config.buffer_size, 1000);
+    assert_eq!(config.batch_size, 1000);
+    assert_eq!(config.bulk_insert_threshold, 500);
+    assert_eq!(config.smart_batch_max_txns, 50);
+
+    clear_env_vars();
+}
+
+#[test]
+fn test_smart_batch_max_txns_env() {
+    let _lock = ENV_LOCK.lock().unwrap();
+    clear_env_vars();
+    set_required_env();
+    env::set_var("CDC_SMART_BATCH_MAX_TXNS", "100");
+
+    let config = pg2any_lib::load_config_from_env().unwrap();
+    assert_eq!(config.smart_batch_max_txns, 100);
+
+    clear_env_vars();
+}
+
+#[test]
+fn test_schema_mapping_parsing() {
+    let _lock = ENV_LOCK.lock().unwrap();
+    clear_env_vars();
+    set_required_env();
+    env::set_var("CDC_SCHEMA_MAPPING", "public:cdc_db,sales:sales_db");
+
+    let config = pg2any_lib::load_config_from_env().unwrap();
+    assert_eq!(config.schema_mappings.get("public").unwrap(), "cdc_db");
+    assert_eq!(config.schema_mappings.get("sales").unwrap(), "sales_db");
+
+    clear_env_vars();
+}
+
+#[test]
+fn test_invalid_schema_mapping_returns_error() {
+    let _lock = ENV_LOCK.lock().unwrap();
+    clear_env_vars();
+    set_required_env();
+    env::set_var("CDC_SCHEMA_MAPPING", "invalid_no_colon");
+
+    let result = pg2any_lib::load_config_from_env();
+    assert!(result.is_err());
+
+    clear_env_vars();
+}

--- a/pg2any-lib/tests/graceful_shutdown_tests.rs
+++ b/pg2any-lib/tests/graceful_shutdown_tests.rs
@@ -1,0 +1,95 @@
+use pg2any_lib::lsn_tracker::LsnTracker;
+use pg2any_lib::transaction_manager::TransactionManager;
+use pg2any_lib::types::DestinationType;
+use std::sync::Arc;
+use tempfile::TempDir;
+
+#[tokio::test]
+async fn test_lsn_persists_and_recovers() {
+    let temp_dir = TempDir::new().unwrap();
+    let lsn_file = temp_dir.path().join("test_lsn.metadata");
+    let lsn_path = lsn_file.to_str().unwrap();
+
+    // Create tracker, commit an LSN, persist
+    let tracker = LsnTracker::new(Some(lsn_path)).await;
+    tracker.commit_lsn(12345);
+    tracker.persist_async().await.unwrap();
+
+    assert_eq!(tracker.get(), 12345);
+
+    // Simulate restart: create new tracker from same file
+    let (tracker2, loaded_lsn) = LsnTracker::new_with_load(Some(lsn_path)).await;
+    assert_eq!(tracker2.get(), 12345);
+    assert!(loaded_lsn.is_some());
+    assert_eq!(loaded_lsn.unwrap().0, 12345);
+}
+
+#[tokio::test]
+async fn test_lsn_only_advances_forward() {
+    let temp_dir = TempDir::new().unwrap();
+    let lsn_file = temp_dir.path().join("test_lsn.metadata");
+    let lsn_path = lsn_file.to_str().unwrap();
+
+    let tracker = LsnTracker::new(Some(lsn_path)).await;
+
+    tracker.commit_lsn(100);
+    assert_eq!(tracker.get(), 100);
+
+    // Trying to go backwards should be ignored
+    tracker.commit_lsn(50);
+    assert_eq!(tracker.get(), 100);
+
+    // Going forward works
+    tracker.commit_lsn(200);
+    assert_eq!(tracker.get(), 200);
+}
+
+#[tokio::test]
+async fn test_lsn_zero_is_ignored() {
+    let temp_dir = TempDir::new().unwrap();
+    let lsn_file = temp_dir.path().join("test_lsn.metadata");
+    let lsn_path = lsn_file.to_str().unwrap();
+
+    let tracker = LsnTracker::new(Some(lsn_path)).await;
+    tracker.commit_lsn(0);
+    assert_eq!(tracker.get(), 0);
+}
+
+#[tokio::test]
+async fn test_transaction_file_lifecycle() {
+    let temp_dir = TempDir::new().unwrap();
+    let manager = Arc::new(
+        TransactionManager::new(temp_dir.path(), DestinationType::MySQL, 64 * 1024 * 1024)
+            .await
+            .unwrap(),
+    );
+
+    // Directories should have been created
+    assert!(temp_dir.path().join("sql_received_tx").exists());
+    assert!(temp_dir.path().join("sql_pending_tx").exists());
+    assert!(temp_dir.path().join("sql_data_tx").exists());
+
+    // Verify no pending transactions at start
+    let pending = manager.list_pending_transactions().await.unwrap();
+    assert!(pending.is_empty());
+}
+
+#[tokio::test]
+async fn test_multiple_lsn_persists_latest_wins() {
+    let temp_dir = TempDir::new().unwrap();
+    let lsn_file = temp_dir.path().join("test_lsn.metadata");
+    let lsn_path = lsn_file.to_str().unwrap();
+
+    let tracker = LsnTracker::new(Some(lsn_path)).await;
+    tracker.commit_lsn(100);
+    tracker.persist_async().await.unwrap();
+    tracker.commit_lsn(500);
+    tracker.persist_async().await.unwrap();
+    tracker.commit_lsn(1000);
+    tracker.persist_async().await.unwrap();
+
+    // Reload and verify latest value
+    let (tracker2, loaded_lsn) = LsnTracker::new_with_load(Some(lsn_path)).await;
+    assert_eq!(tracker2.get(), 1000);
+    assert_eq!(loaded_lsn.unwrap().0, 1000);
+}

--- a/pg2any-lib/tests/smart_batching_tests.rs
+++ b/pg2any-lib/tests/smart_batching_tests.rs
@@ -1,0 +1,144 @@
+use pg2any_lib::transaction_manager::{TransactionManager, TransactionSegment};
+use pg2any_lib::types::DestinationType;
+use std::path::PathBuf;
+use tempfile::TempDir;
+
+async fn create_test_manager(temp_dir: &TempDir) -> std::sync::Arc<TransactionManager> {
+    std::sync::Arc::new(
+        TransactionManager::new(temp_dir.path(), DestinationType::MySQL, 64 * 1024 * 1024)
+            .await
+            .unwrap(),
+    )
+}
+
+fn write_segment(dir: &std::path::Path, name: &str, content: &str) -> TransactionSegment {
+    let path = dir.join(name);
+    std::fs::write(&path, content).unwrap();
+    TransactionSegment {
+        path,
+        statement_count: content.lines().filter(|l| !l.trim().is_empty()).count(),
+    }
+}
+
+#[tokio::test]
+async fn test_analyze_homogeneous_inserts_single_segment() {
+    let temp_dir = TempDir::new().unwrap();
+    let manager = create_test_manager(&temp_dir).await;
+
+    let content = "INSERT INTO `mydb`.`users` (`id`, `name`) VALUES (1, 'Alice');\n\
+                   INSERT INTO `mydb`.`users` (`id`, `name`) VALUES (2, 'Bob');\n";
+    let segment = write_segment(temp_dir.path(), "seg1.sql", content);
+
+    let result = manager.analyze_and_extract_rows(&[segment]).await.unwrap();
+    assert!(result.is_some());
+    let (table, columns, rows) = result.unwrap();
+    assert_eq!(table, "`mydb`.`users`");
+    assert_eq!(columns, vec!["`id`", "`name`"]);
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0], vec!["1", "'Alice'"]);
+    assert_eq!(rows[1], vec!["2", "'Bob'"]);
+}
+
+#[tokio::test]
+async fn test_analyze_homogeneous_inserts_multiple_segments() {
+    let temp_dir = TempDir::new().unwrap();
+    let manager = create_test_manager(&temp_dir).await;
+
+    let seg1 = write_segment(
+        temp_dir.path(),
+        "seg1.sql",
+        "INSERT INTO `mydb`.`users` (`id`, `name`) VALUES (1, 'Alice');\n",
+    );
+    let seg2 = write_segment(
+        temp_dir.path(),
+        "seg2.sql",
+        "INSERT INTO `mydb`.`users` (`id`, `name`) VALUES (2, 'Bob');\n",
+    );
+
+    let result = manager
+        .analyze_and_extract_rows(&[seg1, seg2])
+        .await
+        .unwrap();
+    assert!(result.is_some());
+    let (_, _, rows) = result.unwrap();
+    assert_eq!(rows.len(), 2);
+}
+
+#[tokio::test]
+async fn test_analyze_mixed_operations_returns_none() {
+    let temp_dir = TempDir::new().unwrap();
+    let manager = create_test_manager(&temp_dir).await;
+
+    let content = "INSERT INTO `mydb`.`users` (`id`, `name`) VALUES (1, 'Alice');\n\
+                   DELETE FROM `mydb`.`users` WHERE `id` = 2;\n";
+    let segment = write_segment(temp_dir.path(), "seg1.sql", content);
+
+    let result = manager.analyze_and_extract_rows(&[segment]).await.unwrap();
+    assert!(result.is_none());
+}
+
+#[tokio::test]
+async fn test_analyze_different_tables_returns_none() {
+    let temp_dir = TempDir::new().unwrap();
+    let manager = create_test_manager(&temp_dir).await;
+
+    let content = "INSERT INTO `mydb`.`users` (`id`, `name`) VALUES (1, 'Alice');\n\
+                   INSERT INTO `mydb`.`orders` (`id`, `total`) VALUES (1, 100);\n";
+    let segment = write_segment(temp_dir.path(), "seg1.sql", content);
+
+    let result = manager.analyze_and_extract_rows(&[segment]).await.unwrap();
+    assert!(result.is_none());
+}
+
+#[tokio::test]
+async fn test_analyze_empty_segments() {
+    let temp_dir = TempDir::new().unwrap();
+    let manager = create_test_manager(&temp_dir).await;
+
+    let segment = write_segment(temp_dir.path(), "seg1.sql", "\n\n");
+    let result = manager.analyze_and_extract_rows(&[segment]).await.unwrap();
+    assert!(result.is_none());
+}
+
+#[tokio::test]
+async fn test_batch_delete_files() {
+    let temp_dir = TempDir::new().unwrap();
+    let manager = create_test_manager(&temp_dir).await;
+
+    let f1 = temp_dir.path().join("file1.sql");
+    let f2 = temp_dir.path().join("file2.sql");
+    let f3 = temp_dir.path().join("nonexistent.sql");
+    std::fs::write(&f1, "data1").unwrap();
+    std::fs::write(&f2, "data2").unwrap();
+
+    let paths: Vec<PathBuf> = vec![f1.clone(), f2.clone(), f3];
+    manager.batch_delete_files(&paths).await;
+
+    assert!(!f1.exists());
+    assert!(!f2.exists());
+}
+
+#[tokio::test]
+async fn test_analyze_sqlserver_bracket_inserts() {
+    let temp_dir = TempDir::new().unwrap();
+    let manager = std::sync::Arc::new(
+        TransactionManager::new(
+            temp_dir.path(),
+            DestinationType::SqlServer,
+            64 * 1024 * 1024,
+        )
+        .await
+        .unwrap(),
+    );
+
+    let content = "INSERT INTO [dbo].[users] ([id], [name]) VALUES (1, 'Alice');\n\
+                   INSERT INTO [dbo].[users] ([id], [name]) VALUES (2, 'Bob');\n";
+    let segment = write_segment(temp_dir.path(), "seg1.sql", content);
+
+    let result = manager.analyze_and_extract_rows(&[segment]).await.unwrap();
+    assert!(result.is_some());
+    let (table, columns, rows) = result.unwrap();
+    assert_eq!(table, "[dbo].[users]");
+    assert_eq!(columns, vec!["[id]", "[name]"]);
+    assert_eq!(rows.len(), 2);
+}

--- a/pg2any-lib/tests/sqlserver_bulk_insert_tests.rs
+++ b/pg2any-lib/tests/sqlserver_bulk_insert_tests.rs
@@ -1,0 +1,157 @@
+#[cfg(feature = "sqlserver")]
+mod sqlserver_bulk_insert {
+    use pg2any_lib::destinations::bulk_insert::{
+        build_multi_value_insert, detect_bulk_insert_batch,
+    };
+
+    #[test]
+    fn test_detect_bracket_quoted_inserts() {
+        let stmts = vec![
+            "INSERT INTO [dbo].[users] ([id], [name]) VALUES (1, 'alice');".to_string(),
+            "INSERT INTO [dbo].[users] ([id], [name]) VALUES (2, 'bob');".to_string(),
+            "INSERT INTO [dbo].[users] ([id], [name]) VALUES (3, 'carol');".to_string(),
+        ];
+        let result = detect_bulk_insert_batch(&stmts);
+        assert!(
+            result.is_some(),
+            "Should detect bracket-quoted INSERT batch"
+        );
+        let parsed = result.unwrap();
+        assert_eq!(parsed.table, "[dbo].[users]");
+        assert_eq!(parsed.columns, vec!["[id]", "[name]"]);
+        assert_eq!(parsed.rows.len(), 3);
+        assert_eq!(parsed.rows[0], vec!["1", "'alice'"]);
+    }
+
+    #[test]
+    fn test_detect_bracket_quoted_large_batch() {
+        let stmts: Vec<String> = (0..500)
+            .map(|i| {
+                format!(
+                    "INSERT INTO [cdc_db].[dbo].[orders] ([id], [amount], [status]) VALUES ({}, {}.50, 'pending');",
+                    i, i
+                )
+            })
+            .collect();
+
+        let result = detect_bulk_insert_batch(&stmts);
+        assert!(result.is_some());
+        let parsed = result.unwrap();
+        assert_eq!(parsed.table, "[cdc_db].[dbo].[orders]");
+        assert_eq!(parsed.columns.len(), 3);
+        assert_eq!(parsed.rows.len(), 500);
+    }
+
+    #[test]
+    fn test_detect_mixed_tables_returns_none() {
+        let stmts = vec![
+            "INSERT INTO [dbo].[t1] ([id]) VALUES (1);".to_string(),
+            "INSERT INTO [dbo].[t2] ([id]) VALUES (2);".to_string(),
+        ];
+        let result = detect_bulk_insert_batch(&stmts);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_build_multi_value_insert_brackets() {
+        let table = "[dbo].[users]";
+        let columns = vec!["[id]".to_string(), "[name]".to_string()];
+        let rows = vec![
+            vec!["1".to_string(), "'alice'".to_string()],
+            vec!["2".to_string(), "'bob'".to_string()],
+        ];
+        let sql = build_multi_value_insert(table, &columns, &rows);
+        assert_eq!(
+            sql,
+            "INSERT INTO [dbo].[users] ([id], [name]) VALUES (1, 'alice'), (2, 'bob');"
+        );
+    }
+
+    #[test]
+    fn test_null_values_in_batch() {
+        let stmts = vec![
+            "INSERT INTO [dbo].[t] ([id], [name], [age]) VALUES (1, NULL, 25);".to_string(),
+            "INSERT INTO [dbo].[t] ([id], [name], [age]) VALUES (2, 'bob', NULL);".to_string(),
+        ];
+        let result = detect_bulk_insert_batch(&stmts);
+        assert!(result.is_some());
+        let parsed = result.unwrap();
+        assert_eq!(parsed.rows[0], vec!["1", "NULL", "25"]);
+        assert_eq!(parsed.rows[1], vec!["2", "'bob'", "NULL"]);
+    }
+
+    #[test]
+    fn test_string_with_special_characters() {
+        let stmts = vec![
+            "INSERT INTO [dbo].[t] ([id], [val]) VALUES (1, 'it''s a test');".to_string(),
+            "INSERT INTO [dbo].[t] ([id], [val]) VALUES (2, 'hello, world');".to_string(),
+        ];
+        let result = detect_bulk_insert_batch(&stmts);
+        assert!(result.is_some());
+        let parsed = result.unwrap();
+        assert_eq!(parsed.rows[0][1], "'it''s a test'");
+        assert_eq!(parsed.rows[1][1], "'hello, world'");
+    }
+
+    #[test]
+    fn test_multi_value_insert_with_nulls() {
+        let table = "[dbo].[users]";
+        let columns = vec![
+            "[id]".to_string(),
+            "[name]".to_string(),
+            "[age]".to_string(),
+        ];
+        let rows = vec![
+            vec!["1".to_string(), "'alice'".to_string(), "30".to_string()],
+            vec!["2".to_string(), "NULL".to_string(), "25".to_string()],
+        ];
+        let sql = build_multi_value_insert(table, &columns, &rows);
+        assert_eq!(
+            sql,
+            "INSERT INTO [dbo].[users] ([id], [name], [age]) VALUES (1, 'alice', 30), (2, NULL, 25);"
+        );
+    }
+
+    #[test]
+    fn test_three_part_table_name() {
+        let stmts = vec![
+            "INSERT INTO [mydb].[dbo].[orders] ([id], [total]) VALUES (1, 99.99);".to_string(),
+            "INSERT INTO [mydb].[dbo].[orders] ([id], [total]) VALUES (2, 150.00);".to_string(),
+        ];
+        let result = detect_bulk_insert_batch(&stmts);
+        assert!(result.is_some());
+        let parsed = result.unwrap();
+        assert_eq!(parsed.table, "[mydb].[dbo].[orders]");
+    }
+
+    #[test]
+    fn test_large_batch_performance() {
+        let stmts: Vec<String> = (0..2000)
+            .map(|i| {
+                format!(
+                    "INSERT INTO [dbo].[perf_test] ([id], [value], [label]) VALUES ({}, {}.5, 'item_{}');",
+                    i, i, i
+                )
+            })
+            .collect();
+
+        let result = detect_bulk_insert_batch(&stmts);
+        assert!(result.is_some());
+        let parsed = result.unwrap();
+        assert_eq!(parsed.rows.len(), 2000);
+    }
+
+    #[test]
+    fn test_non_insert_statements_return_none() {
+        let stmts = vec!["UPDATE [dbo].[t] SET [name] = 'new' WHERE [id] = 1;".to_string()];
+        let result = detect_bulk_insert_batch(&stmts);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_empty_batch() {
+        let stmts: Vec<String> = vec![];
+        let result = detect_bulk_insert_batch(&stmts);
+        assert!(result.is_none());
+    }
+}


### PR DESCRIPTION
Provides the core utilities for bulk loading optimization:
- detect_bulk_insert_batch: identifies homogeneous INSERT batches
- generate_tsv_buffer: converts row data to MySQL LOAD DATA TSV format
- build_multi_value_insert: fallback multi-value INSERT builder

feat: extend DestinationHandler trait with execute_bulk_insert_with_hook

Adds supports_bulk_insert() and execute_bulk_insert_with_hook() with a default implementation that falls back to multi-value INSERT. MySQL destination will override this with LOAD DATA LOCAL INFILE.

feat: implement LOAD DATA LOCAL INFILE in MySQL destination

Adds mysql_async pool alongside sqlx for bulk loading via LOAD DATA LOCAL INFILE protocol. Falls back to multi-value INSERT when local_infile is disabled on the server. Session tuning applied during LOAD DATA ops.

feat: add bulk insert detection and routing in consumer

When a batch consists entirely of INSERTs to the same table and exceeds the threshold, route through execute_bulk_insert_with_hook for LOAD DATA optimization. Falls back to regular SQL batch on detection failure.

feat: add execute_with_hook_guard shared transaction helper
feat: add CDC_SMART_BATCH_MAX_TXNS config (default: 50)
feat: add analyze_transaction_content and batch_delete_files for smart batching