### PR TITLE
refactor: clean up code formatting in graceful shutdown

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,39 @@ Destinations are conditionally compiled via `#[cfg(feature = "...")]`.
 - **Graceful shutdown**: `CancellationToken` + `oneshot` channel coordination between producer and consumer
 - All async, Tokio-based. No blocking I/O on the hot path.
 
+## Graceful Shutdown
+
+pg2any implements coordinated producer-consumer shutdown with zero data loss:
+
+### Sequence
+
+1. **Signal** (SIGINT/SIGTERM) → `CancellationToken` cancelled
+2. **Producer** exits WAL read loop → flushes buffers → drops mpsc sender → sends oneshot
+3. **Consumer** receives oneshot → breaks main loop → calls `drain_and_shutdown()`
+4. **Drain** uses a fresh (uncancellable) token → processes ALL remaining queued transactions
+5. **Finalize** each transaction: commit to destination → update `flush_lsn` → persist to disk → delete file
+6. **Client.stop()** joins handles → sends final ACK to PostgreSQL → closes destination → final persist
+
+### Invariant
+
+The on-disk LSN metadata represents the last transaction **fully applied** to the destination. On restart, any transaction with `commit_lsn <= flush_lsn` is skipped (position-tracking deduplication). Files in `sql_pending_tx/` with `commit_lsn > flush_lsn` are replayed.
+
+### Why NOT duplicate-key ignore
+
+Position-tracking (not `ON CONFLICT DO NOTHING` / `INSERT IGNORE`) is the correct approach because:
+- It handles UPDATE and DELETE (not just INSERT)
+- It avoids masking legitimate duplicate-key bugs in the source
+- It works identically across all destination types (MySQL, SQL Server, SQLite, Kafka)
+
+### Recovery scenarios
+
+| Scenario | What's on disk | What happens on restart |
+|----------|---------------|------------------------|
+| Clean shutdown | No pending files, LSN persisted | Resume from `flush_lsn` |
+| Crash mid-transaction | Files in `sql_received_tx/` | Incomplete transactions cleaned up |
+| Crash after commit, before execute | Files in `sql_pending_tx/` | Replayed from start (or `last_executed_command_index`) |
+| Crash after partial execution | File in `sql_pending_tx/` with progress | Resumed from checkpoint |
+
 ## Error Handling
 
 `CdcError` in `error.rs` classifies errors as:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,8 @@ pg2any is a Rust CDC (Change Data Capture) library that streams PostgreSQL WAL c
 - MySQL uses dual pools: sqlx for normal SQL batches, mysql_async for LOAD DATA LOCAL INFILE
 - SQL Server uses TDS Bulk Load (tiberius `bulk_insert`) for homogeneous INSERT batches, falls back to multi-value INSERT
 - Consumer detects homogeneous INSERT batches and routes to bulk insert path when threshold met
+- Graceful shutdown invariant: `drain_and_shutdown` completes all queued transactions using an uncancellable token before persisting final LSN. The on-disk LSN represents the last FULLY APPLIED transaction. Recovery skips files with `commit_lsn <= flush_lsn`.
+- Never pass the main `CancellationToken` to `drain_and_shutdown` — it must use its own fresh (never-cancelled) token
 
 ## Important Files
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1050,9 +1050,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "eb92f162bf56536459fc83c79b974bb12837acfed43d6bc370a7916d0ae15ecc"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ base64 = "0.22.1"
 
 # Monitoring and metrics
 prometheus = { version = "0.14.0", features = ["process"] }
-hyper = { version = "1.9.0", features = ["full"] }
+hyper = { version = "1.10.0", features = ["full"] }
 hyper-util = { version = "0.1.20", features = ["full"] }
 http-body-util = "0.1.3"
 

--- a/README.md
+++ b/README.md
@@ -122,11 +122,13 @@ pg2any implements coordinated producer-consumer shutdown to prevent data loss or
 
 1. **Signal received** (SIGINT/SIGTERM) — cancels the `CancellationToken`
 2. **Producer exits** — flushes buffers, drops mpsc sender, sends oneshot signal to consumer
-3. **Consumer drains** — processes all queued transactions within a 90-second deadline
-4. **Position persisted** — `flush_lsn` written to disk via atomic temp-file rename
+3. **Consumer drains** — processes ALL queued transactions using an uncancellable token (no timeout)
+4. **Position persisted** — `flush_lsn` written to disk via atomic temp-file rename after each transaction
 5. **Final ACK** — sends confirmed position to PostgreSQL so the WAL slot advances
 
 On next startup, any transaction with `commit_lsn <= flush_lsn` is skipped automatically (position-tracking deduplication). No `ON CONFLICT DO NOTHING` or `INSERT IGNORE` is used — correctness relies on tracking the exact position.
+
+If the final ACK to PostgreSQL fails (network issue), the local position is still safe — PostgreSQL will re-send from its slot's `confirmed_flush_lsn`, and local position-tracking skips already-applied transactions.
 
 ### Workflow Diagrams
 

--- a/pg2any-lib/src/client.rs
+++ b/pg2any-lib/src/client.rs
@@ -282,7 +282,7 @@ impl CdcClient {
 
     /// Process pending transaction files on startup (recovery).
     ///
-    /// Processes all committed files from `sql_pending_tx/` in commit timestamp order
+    /// Processes all committed files from `sql_pending_tx/` in commit_lsn (WAL) order
     /// before starting normal replication. Respects cancellation token.
     async fn process_pending_transaction_files(
         file_mgr: &Arc<TransactionManager>,
@@ -357,6 +357,13 @@ impl CdcClient {
     }
 
     /// Stop the CDC replication process gracefully.
+    ///
+    /// Shutdown ordering (each step depends on the previous):
+    /// 1. Cancel token → producer and consumer detect shutdown
+    /// 2. Join handles → wait for both tasks to complete (consumer drains queue)
+    /// 3. Final ACK → send confirmed_flush_lsn to PostgreSQL so WAL slot advances
+    /// 4. Close destination → release connection pool
+    /// 5. Persist LSN → final atomic write to disk (idempotent, consumer already persisted)
     pub async fn stop(&mut self) -> Result<()> {
         info!("Initiating graceful shutdown of CDC replication");
 

--- a/pg2any-lib/src/consumer.rs
+++ b/pg2any-lib/src/consumer.rs
@@ -125,9 +125,15 @@ pub(crate) async fn run_consumer_loop(
 /// Drain remaining channel messages, process all queued transactions, then
 /// persist position and exit.
 ///
-/// Waits for all queued transactions to complete without any timeout,
-/// ensuring the final LSN is persisted and no replay occurs on restart.
-async fn drain_and_shutdown(
+/// **Shutdown correctness guarantee:** This function uses an uncancellable
+/// `CancellationToken` (one that is never cancelled) when processing queued
+/// transactions. This ensures all in-progress work completes to maintain
+/// position-tracking correctness — if a transaction is partially applied
+/// without LSN advancement, the next restart would replay it.
+///
+/// On error, processing stops and the failing transaction's file remains in
+/// `sql_pending_tx/` for recovery on the next restart.
+pub async fn drain_and_shutdown(
     commit_queue: &mut BinaryHeap<std::cmp::Reverse<PendingTransactionFile>>,
     commit_receiver: &mut mpsc::Receiver<PendingTransactionFile>,
     transaction_file_manager: &Arc<TransactionManager>,
@@ -166,14 +172,14 @@ async fn drain_and_shutdown(
             next_tx.metadata.transaction_id, next_tx.metadata.commit_lsn
         );
 
-        let drain_token = CancellationToken::new();
+        let uncancellable_token = CancellationToken::new();
 
         if let Err(e) = transaction_file_manager
             .clone()
             .process_transaction_file(
                 &next_tx,
                 destination_handler,
-                &drain_token,
+                &uncancellable_token,
                 lsn_tracker,
                 metrics_collector,
                 batch_size,

--- a/pg2any-lib/src/lib.rs
+++ b/pg2any-lib/src/lib.rs
@@ -84,6 +84,7 @@ pub mod monitoring;
 pub use app::{run_cdc_app, CdcApp, CdcAppConfig};
 pub use client::CdcClient;
 pub use config::{Config, ConfigBuilder};
+pub use consumer::drain_and_shutdown;
 pub use env::load_config_from_env;
 pub use error::CdcError;
 pub use lsn_tracker::{create_lsn_tracker_with_load, LsnTracker};

--- a/pg2any-lib/src/transaction_manager.rs
+++ b/pg2any-lib/src/transaction_manager.rs
@@ -847,8 +847,9 @@ impl TransactionManager {
             }
         }
 
-        // Sort by commit timestamp
-        files.sort_by_key(|f| f.metadata.commit_timestamp);
+        // Sort using the custom Ord impl: commit_lsn ascending (None treated as
+        // infinity) with transaction_id tiebreaker for deterministic WAL-order recovery.
+        files.sort_unstable();
 
         Ok(files)
     }

--- a/pg2any-lib/tests/graceful_shutdown_integration_tests.rs
+++ b/pg2any-lib/tests/graceful_shutdown_integration_tests.rs
@@ -324,3 +324,260 @@ async fn test_cancellation_prevents_lsn_advance() {
     assert!(result.unwrap_err().is_cancelled());
     assert_eq!(lsn_tracker.get(), 0);
 }
+
+#[tokio::test]
+async fn test_mid_batch_cancellation_completes_drain() {
+    let temp_dir = TempDir::new().unwrap();
+    let lsn_file = temp_dir.path().join("test_lsn_drain");
+    let lsn_path = lsn_file.to_str().unwrap();
+
+    let manager = Arc::new(
+        TransactionManager::new(temp_dir.path(), DestinationType::MySQL, 64 * 1024 * 1024)
+            .await
+            .unwrap(),
+    );
+
+    let mut pending_txs = Vec::new();
+    for (i, lsn) in [(1u32, 10000u64), (2, 20000), (3, 30000)].iter() {
+        let timestamp = Utc::now();
+        manager
+            .begin_transaction(*i, timestamp, "normal")
+            .await
+            .unwrap();
+        let event = create_insert_event(*lsn);
+        manager.append_event(*i, &event).await.unwrap();
+        manager.flush_all_buffers().await.unwrap();
+        let pending_path = manager
+            .commit_transaction(*i, Some(Lsn(*lsn)))
+            .await
+            .unwrap();
+        let content = tokio::fs::read_to_string(&pending_path).await.unwrap();
+        let metadata = serde_json::from_str(&content).unwrap();
+        pending_txs.push(PendingTransactionFile {
+            file_path: pending_path,
+            metadata,
+        });
+    }
+
+    let mut commit_queue: std::collections::BinaryHeap<std::cmp::Reverse<PendingTransactionFile>> =
+        std::collections::BinaryHeap::new();
+    for tx in pending_txs {
+        commit_queue.push(std::cmp::Reverse(tx));
+    }
+
+    let (_tx_sender, mut rx_receiver) = tokio::sync::mpsc::channel::<PendingTransactionFile>(10);
+    drop(_tx_sender);
+
+    let mock = MockDestination::new();
+    let executed = mock.executed_batches.clone();
+    let mut dest: Box<dyn DestinationHandler> = Box::new(mock);
+    let lsn_tracker = LsnTracker::new(Some(lsn_path)).await;
+    let metrics = Arc::new(pg2any_lib::MetricsCollector::new());
+    let shared_feedback = SharedLsnFeedback::new_shared();
+
+    pg2any_lib::drain_and_shutdown(
+        &mut commit_queue,
+        &mut rx_receiver,
+        &manager,
+        &mut dest,
+        &lsn_tracker,
+        &metrics,
+        100,
+        &shared_feedback,
+    )
+    .await;
+
+    assert_eq!(executed.load(Ordering::SeqCst), 3);
+    assert_eq!(lsn_tracker.get(), 30000);
+    let (_, loaded_lsn) = LsnTracker::new_with_load(Some(lsn_path)).await;
+    assert_eq!(loaded_lsn, Some(Lsn(30000)));
+}
+
+#[tokio::test]
+async fn test_committed_but_undelivered_recovered_on_restart() {
+    let temp_dir = TempDir::new().unwrap();
+    let lsn_file = temp_dir.path().join("test_lsn_undelivered");
+    let lsn_path = lsn_file.to_str().unwrap();
+
+    let manager = Arc::new(
+        TransactionManager::new(temp_dir.path(), DestinationType::MySQL, 64 * 1024 * 1024)
+            .await
+            .unwrap(),
+    );
+
+    let timestamp = Utc::now();
+    manager
+        .begin_transaction(42, timestamp, "normal")
+        .await
+        .unwrap();
+    let event = create_insert_event(55000);
+    manager.append_event(42, &event).await.unwrap();
+    manager.flush_all_buffers().await.unwrap();
+    let _pending_path = manager
+        .commit_transaction(42, Some(Lsn(55000)))
+        .await
+        .unwrap();
+
+    let pending_txs = manager.list_pending_transactions().await.unwrap();
+    assert_eq!(pending_txs.len(), 1);
+    assert_eq!(pending_txs[0].metadata.transaction_id, 42);
+
+    let mock = MockDestination::new();
+    let executed = mock.executed_batches.clone();
+    let mut dest: Box<dyn DestinationHandler> = Box::new(mock);
+    let token = CancellationToken::new();
+    let lsn_tracker = LsnTracker::new(Some(lsn_path)).await;
+    let metrics = Arc::new(pg2any_lib::MetricsCollector::new());
+    let shared_feedback = SharedLsnFeedback::new_shared();
+
+    for pending_tx in &pending_txs {
+        manager
+            .clone()
+            .process_transaction_file(
+                pending_tx,
+                &mut dest,
+                &token,
+                &lsn_tracker,
+                &metrics,
+                100,
+                &shared_feedback,
+            )
+            .await
+            .unwrap();
+    }
+
+    assert!(executed.load(Ordering::SeqCst) >= 1);
+    assert_eq!(lsn_tracker.get(), 55000);
+    let remaining = manager.list_pending_transactions().await.unwrap();
+    assert!(remaining.is_empty());
+}
+
+#[tokio::test]
+async fn test_final_ack_failure_still_persists_local_lsn() {
+    let temp_dir = TempDir::new().unwrap();
+    let lsn_file = temp_dir.path().join("test_lsn_ack_fail");
+    let lsn_path = lsn_file.to_str().unwrap();
+
+    let (manager, pending_tx) =
+        setup_pending_transaction_with_events(&temp_dir, 600, 90000, 3).await;
+
+    let mut dest: Box<dyn DestinationHandler> = Box::new(MockDestination::new());
+    let token = CancellationToken::new();
+    let lsn_tracker = LsnTracker::new(Some(lsn_path)).await;
+    let metrics = Arc::new(pg2any_lib::MetricsCollector::new());
+    let shared_feedback = SharedLsnFeedback::new_shared();
+
+    manager
+        .clone()
+        .process_transaction_file(
+            &pending_tx,
+            &mut dest,
+            &token,
+            &lsn_tracker,
+            &metrics,
+            100,
+            &shared_feedback,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(lsn_tracker.get(), 90000);
+
+    let (tracker_after_restart, loaded_lsn) = LsnTracker::new_with_load(Some(lsn_path)).await;
+    assert_eq!(loaded_lsn, Some(Lsn(90000)));
+
+    let temp_dir2 = TempDir::new().unwrap();
+    let (manager2, pending_tx_replay) =
+        setup_pending_transaction_with_events(&temp_dir2, 601, 90000, 2).await;
+
+    let mock2 = MockDestination::new();
+    let executed2 = mock2.executed_batches.clone();
+    let mut dest2: Box<dyn DestinationHandler> = Box::new(mock2);
+
+    manager2
+        .clone()
+        .process_transaction_file(
+            &pending_tx_replay,
+            &mut dest2,
+            &token,
+            &tracker_after_restart,
+            &metrics,
+            100,
+            &shared_feedback,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(executed2.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn test_drain_on_error_preserves_file_for_recovery() {
+    let temp_dir = TempDir::new().unwrap();
+    let lsn_file = temp_dir.path().join("test_lsn_drain_err");
+    let lsn_path = lsn_file.to_str().unwrap();
+
+    let manager = Arc::new(
+        TransactionManager::new(temp_dir.path(), DestinationType::MySQL, 64 * 1024 * 1024)
+            .await
+            .unwrap(),
+    );
+
+    let mut pending_txs = Vec::new();
+    for (i, lsn) in [(10u32, 40000u64), (11, 50000)].iter() {
+        let timestamp = Utc::now();
+        manager
+            .begin_transaction(*i, timestamp, "normal")
+            .await
+            .unwrap();
+        let event = create_insert_event(*lsn);
+        manager.append_event(*i, &event).await.unwrap();
+        manager.flush_all_buffers().await.unwrap();
+        let pending_path = manager
+            .commit_transaction(*i, Some(Lsn(*lsn)))
+            .await
+            .unwrap();
+        let content = tokio::fs::read_to_string(&pending_path).await.unwrap();
+        let metadata = serde_json::from_str(&content).unwrap();
+        pending_txs.push(PendingTransactionFile {
+            file_path: pending_path,
+            metadata,
+        });
+    }
+
+    let mut commit_queue: std::collections::BinaryHeap<std::cmp::Reverse<PendingTransactionFile>> =
+        std::collections::BinaryHeap::new();
+    for tx in pending_txs {
+        commit_queue.push(std::cmp::Reverse(tx));
+    }
+
+    let (_tx_sender, mut rx_receiver) = tokio::sync::mpsc::channel::<PendingTransactionFile>(10);
+    drop(_tx_sender);
+
+    let mut dest: Box<dyn DestinationHandler> = Box::new(MockDestination::new_failing_at(2));
+    let lsn_tracker = LsnTracker::new(Some(lsn_path)).await;
+    let metrics = Arc::new(pg2any_lib::MetricsCollector::new());
+    let shared_feedback = SharedLsnFeedback::new_shared();
+
+    pg2any_lib::drain_and_shutdown(
+        &mut commit_queue,
+        &mut rx_receiver,
+        &manager,
+        &mut dest,
+        &lsn_tracker,
+        &metrics,
+        100,
+        &shared_feedback,
+    )
+    .await;
+
+    assert_eq!(lsn_tracker.get(), 40000);
+
+    let remaining = manager.list_pending_transactions().await.unwrap();
+    assert_eq!(remaining.len(), 1);
+    assert_eq!(remaining[0].metadata.transaction_id, 11);
+
+    let (tracker_restart, loaded_lsn) = LsnTracker::new_with_load(Some(lsn_path)).await;
+    assert_eq!(loaded_lsn, Some(Lsn(40000)));
+    assert!(50000 > tracker_restart.get());
+}


### PR DESCRIPTION
1. refactor: clean up code formatting in graceful shutdown integration tests
2. fix: sort transaction files by commit_lsn for correct recovery order