### PR TITLE
feat: expose DestinationHandler to Config for custom destination support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ pg2any/                          # Cargo workspace root
       lsn_tracker.rs             # LsnTracker - flush_lsn persistence to disk
       transaction_manager.rs     # TransactionManager - file lifecycle (begin/append/commit/abort/process)
       destinations/
-        destination_factory.rs   # DestinationHandler trait (core interface) + DestinationFactory
+        destination_factory.rs   # DestinationHandler trait + DestinationFactoryFn type alias
         mysql.rs                 # MySQL impl via SQLx + mysql_async (LOAD DATA LOCAL INFILE)
         sqlserver.rs             # SQL Server impl via Tiberius
         sqlite.rs                # SQLite impl via SQLx
@@ -87,6 +87,7 @@ pub trait DestinationHandler: Send + Sync {
 - MySQL additionally supports `execute_bulk_insert_with_hook` for LOAD DATA LOCAL INFILE
 - SQL Server supports `execute_bulk_insert_with_hook` for TDS Bulk Load (with multi-value INSERT fallback)
 - Kafka uses event mode (`supports_event_mode() = true`, `execute_events_batch_with_hook`)
+- Destinations are constructed via the per-Config registry (`Config::create_destination`). Built-ins self-register in `Config::default()`; external users add their own via `ConfigBuilder::register_destination` / `custom_destination`.
 
 ### TransactionStorage (trait) - `storage/traits.rs`
 
@@ -185,6 +186,6 @@ Config env vars: `CDC_BULK_INSERT_THRESHOLD`
 1. Create `pg2any-lib/src/destinations/your_dest.rs`
 2. Implement `DestinationHandler` trait
 3. Add feature flag to `pg2any-lib/Cargo.toml`
-4. Register in `destination_factory.rs` `DestinationFactory::create()` match arm
+4. Register in `Config::default()` (config.rs) under the appropriate registry key, gated by feature flag
 5. Add variant to `DestinationType` enum in `types.rs`
 6. Add `#[cfg(feature = "your_dest")]` guards in `destinations/mod.rs` and `lib.rs`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@ pg2any is a Rust CDC (Change Data Capture) library that streams PostgreSQL WAL c
 - LSN tracking: `flush_lsn` = last WAL position committed to destination. Updated by consumer only.
 - Shutdown coordination: `CancellationToken` + `oneshot` channel (producer -> consumer)
 - Destinations behind `DestinationHandler` trait; Kafka uses event mode, SQL destinations use SQL batch mode
+- Destinations are constructed via the per-Config registry (`Config::create_destination`). Built-ins self-register in `Config::default()`; external users add their own via `ConfigBuilder::register_destination` / `custom_destination`.
 - `TransactionStorage` trait abstracts compressed vs uncompressed file I/O
 - MySQL uses dual pools: sqlx for normal SQL batches, mysql_async for LOAD DATA LOCAL INFILE
 - SQL Server uses TDS Bulk Load (tiberius `bulk_insert`) for homogeneous INSERT batches, falls back to multi-value INSERT

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,9 +322,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -1050,9 +1050,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb92f162bf56536459fc83c79b974bb12837acfed43d6bc370a7916d0ae15ecc"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1670,7 +1670,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 name = "pg2any"
 version = "0.0.0"
 dependencies = [
+ "async-trait",
  "pg2any_lib",
+ "pg_walstream",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ tokio = { version = "1.52.3", features = ["full"] }
 tokio-util = { version = "0.7.18", features = ["compat", "io-util"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
-chrono = { version = "0.4.44", features = ["serde"] }
+chrono = { version = "0.4.45", features = ["serde"] }
 bytes = "1.11.1"
 async-trait = "0.1.89"
 thiserror = "2.0.18"
@@ -41,7 +41,7 @@ base64 = "0.22.1"
 
 # Monitoring and metrics
 prometheus = { version = "0.14.0", features = ["process"] }
-hyper = { version = "1.10.0", features = ["full"] }
+hyper = { version = "1.10.1", features = ["full"] }
 hyper-util = { version = "0.1.20", features = ["full"] }
 http-body-util = "0.1.3"
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,59 @@ A high-performance PostgreSQL Change Data Capture (CDC) tool that streams databa
 | SQLite | SQLx | `sqlite` (default) |
 | Kafka | rdkafka (librdkafka) | `kafka` |
 
+## Custom Destinations
+
+Built-in destinations self-register in `Config::default()`. External users can plug in their own `DestinationHandler` implementations through the per-`Config` registry — no fork required.
+
+Three ergonomic forms (pick the shortest that fits):
+
+```rust,ignore
+// 1) Type implements Default — zero arguments
+Config::builder()
+    .use_destination::<MyDest>()
+    .destination_connection_string("...")
+    .build()?;
+
+// 2) Construction takes args — supply a factory closure (no Box, no Result)
+Config::builder()
+    .custom_destination(|| MyDest::with_options(opts.clone()))
+    .destination_connection_string("...")
+    .build()?;
+
+// 3) Multi-key / runtime selection — register under a named key
+Config::builder()
+    .register_destination("my-dest", || MyDest::new())
+    .destination_type(DestinationType::Custom("my-dest".into()))
+    .build()?;
+```
+
+Minimal handler:
+
+```rust,ignore
+use async_trait::async_trait;
+use pg2any_lib::destinations::{DestinationHandler, PreCommitHook};
+use pg2any_lib::CdcResult;
+use std::collections::HashMap;
+
+#[derive(Default)]
+struct MyDest;
+
+#[async_trait]
+impl DestinationHandler for MyDest {
+    async fn connect(&mut self, _conn: &str) -> CdcResult<()> { Ok(()) }
+    fn set_schema_mappings(&mut self, _m: HashMap<String, String>) {}
+    async fn execute_sql_batch_with_hook(
+        &mut self, _cmds: &[String], hook: Option<PreCommitHook>,
+    ) -> CdcResult<()> {
+        if let Some(h) = hook { h().await?; }
+        Ok(())
+    }
+    async fn close(&mut self) -> CdcResult<()> { Ok(()) }
+}
+```
+
+The factory closure must return a fresh handler each call (it is invoked once for the main pipeline and once for the consumer). See the [`DestinationHandler`](pg2any-lib/src/destinations/destination_factory.rs) trait for the full surface (event mode, bulk insert hooks, pre-commit checkpoint integration). 
+
 ## Key Features
 
 - **Crash-safe persistence** - File-based producer-consumer with automatic crash recovery

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -20,6 +20,8 @@ metrics = ["pg2any_lib/metrics"]
 
 [dependencies]
 pg2any_lib = { path = "../pg2any-lib", default-features = false }
+pg_walstream = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+async-trait = { workspace = true }

--- a/examples/examples/custom_destination.rs
+++ b/examples/examples/custom_destination.rs
@@ -1,0 +1,130 @@
+//! End-to-end example: registering a custom DestinationHandler with a custom SqlDialect.
+//!
+//! This program is compile-checked only — it does not connect to a real destination.
+//! It demonstrates the third integration pattern from `pg2any_lib::destinations::dialect`:
+//! a fully custom `SqlDialect` plugged into a custom `DestinationHandler` via
+//! `ConfigBuilder::custom_destination`.
+//!
+//! Run: `cargo run -p pg2any --bin custom_destination`
+
+use async_trait::async_trait;
+use pg2any_lib::{AnsiDialect, CdcResult, Config, DestinationHandler, PreCommitHook, SqlDialect};
+use pg_walstream::ColumnValue;
+use std::collections::HashMap;
+
+// === A custom dialect mimicking ClickHouse: backtick identifiers, unhex() hex, generic TRUNCATE. ===
+
+#[derive(Default, Debug, Clone, Copy)]
+struct ClickHouseDialect;
+
+impl SqlDialect for ClickHouseDialect {
+    fn quote_identifier(&self, ident: &str, out: &mut String) {
+        out.push('`');
+        for ch in ident.chars() {
+            if ch == '`' {
+                out.push('`');
+            }
+            out.push(ch);
+        }
+        out.push('`');
+    }
+
+    fn qualify_table(&self, schema: &str, table: &str, out: &mut String) {
+        self.quote_identifier(schema, out);
+        out.push('.');
+        self.quote_identifier(table, out);
+    }
+
+    fn render_hex_literal(&self, bytes: &[u8], out: &mut String) {
+        out.push_str("unhex('");
+        for b in bytes {
+            out.push_str(&format!("{:02x}", b));
+        }
+        out.push_str("')");
+    }
+
+    fn render_value(&self, value: &ColumnValue, out: &mut String) {
+        match value {
+            ColumnValue::Null => out.push_str("NULL"),
+            ColumnValue::Text(_) => match value.as_str() {
+                Some(s) => {
+                    out.push('\'');
+                    for ch in s.chars() {
+                        if ch == '\'' {
+                            out.push_str("''");
+                        } else {
+                            out.push(ch);
+                        }
+                    }
+                    out.push('\'');
+                }
+                None => self.render_hex_literal(value.as_bytes(), out),
+            },
+            ColumnValue::Binary(_) => self.render_hex_literal(value.as_bytes(), out),
+        }
+    }
+
+    fn truncate_table_sql(&self, schema: &str, table: &str) -> Option<String> {
+        let mut s = String::from("TRUNCATE TABLE ");
+        self.qualify_table(schema, table, &mut s);
+        s.push(';');
+        Some(s)
+    }
+}
+
+// === A custom DestinationHandler that uses our ClickHouseDialect. ===
+
+#[derive(Default)]
+struct ClickHouseDest;
+
+#[async_trait]
+impl DestinationHandler for ClickHouseDest {
+    async fn connect(&mut self, _connection_string: &str) -> CdcResult<()> {
+        Ok(())
+    }
+
+    fn set_schema_mappings(&mut self, _mappings: HashMap<String, String>) {}
+
+    async fn execute_sql_batch_with_hook(
+        &mut self,
+        commands: &[String],
+        pre_commit_hook: Option<PreCommitHook>,
+    ) -> CdcResult<()> {
+        for cmd in commands {
+            println!("[clickhouse] {}", cmd);
+        }
+        if let Some(hook) = pre_commit_hook {
+            hook().await?;
+        }
+        Ok(())
+    }
+
+    async fn close(&mut self) -> CdcResult<()> {
+        Ok(())
+    }
+
+    fn dialect(&self) -> &'static dyn SqlDialect {
+        static D: ClickHouseDialect = ClickHouseDialect;
+        &D
+    }
+}
+
+#[tokio::main]
+async fn main() -> CdcResult<()> {
+    // The example only compile-checks the public API — it never connects.
+    // `custom_destination` switches `destination_type` to `DestinationType::Custom`
+    // and registers the factory under a sentinel key.
+    let _config = Config::builder()
+        .source_connection_string("postgres://localhost/source_db")
+        .destination_connection_string("clickhouse://localhost:9000/dest_db")
+        .custom_destination(ClickHouseDest::default)
+        .build()?;
+
+    println!("Config built with custom ClickHouse destination + dialect.");
+
+    // Pattern 2 (AnsiDialect default) — demonstrate the fallback type is reachable
+    // from the crate root, even though `ClickHouseDest` overrides it above.
+    let _ansi_demo: &dyn SqlDialect = &AnsiDialect;
+
+    Ok(())
+}

--- a/pg2any-lib/src/client.rs
+++ b/pg2any-lib/src/client.rs
@@ -1,6 +1,6 @@
 use crate::config::Config;
 use crate::consumer;
-use crate::destinations::{DestinationFactory, DestinationHandler};
+use crate::destinations::DestinationHandler;
 use crate::error::{CdcError, Result};
 use crate::lsn_tracker::{LsnTracker, SharedLsnFeedback};
 use crate::monitoring::{MetricsCollector, MetricsCollectorTrait};
@@ -54,7 +54,9 @@ impl CdcClient {
     pub async fn new(config: Config, lsn_file_path: Option<&str>) -> Result<(Self, Option<Lsn>)> {
         info!("Creating CDC client");
 
-        let destination_handler = DestinationFactory::create(&config.destination_type)?;
+        let destination_handler = config.create_destination()?;
+
+        let dialect_override = Some(destination_handler.dialect());
 
         info!(
             "Transaction file persistence enabled at: {}",
@@ -63,6 +65,7 @@ impl CdcClient {
         let mut manager = TransactionManager::new(
             &config.transaction_file_base_path,
             config.destination_type.clone(),
+            dialect_override,
             config.transaction_segment_size_bytes,
         )
         .await?;
@@ -224,7 +227,7 @@ impl CdcClient {
 
         info!("Starting file-based consumer for transaction processing");
 
-        let mut consumer_destination = DestinationFactory::create(dest_type)?;
+        let mut consumer_destination = self.config.create_destination()?;
         consumer_destination
             .connect(&self.config.destination_connection_string)
             .await?;

--- a/pg2any-lib/src/config.rs
+++ b/pg2any-lib/src/config.rs
@@ -1,12 +1,14 @@
 use pg_walstream::RetryConfig;
 
+use crate::destinations::{DestinationFactoryFn, DestinationHandler};
 use crate::error::{CdcError, Result};
 use crate::types::DestinationType;
 use std::collections::HashMap;
+use std::sync::Arc;
 use std::time::Duration;
 
 /// Configuration for the CDC client
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Config {
     /// Source PostgreSQL connection string
     pub source_connection_string: String,
@@ -101,6 +103,125 @@ pub struct Config {
     /// SQL Server enforces a hard limit of 1000 rows per INSERT VALUES.
     /// Set to 0 for no limit (e.g., MySQL/SQLite have no row count limit).
     pub max_rows_per_insert: usize,
+
+    /// Per-Config registry of destination factories keyed by `DestinationType::registry_key()`.
+    /// Built-ins self-register in `Config::default()`; external users add their own via
+    /// `ConfigBuilder::register_destination` / `custom_destination`.
+    pub(crate) destination_registry: HashMap<String, DestinationFactoryFn>,
+}
+
+/// Masks credentials in a connection string for safe logging.
+///
+/// Handles two formats:
+/// - URI style: `scheme://user:password@host/...` → password replaced with `********`
+/// - Key/value style (e.g. SQL Server ADO.NET): `key=value;...` → values for
+///   `password`/`pwd` (case-insensitive) replaced with `********`
+fn sanitize_connection_string(s: &str) -> String {
+    if let Some(scheme_end) = s.find("://") {
+        let after_scheme = scheme_end + 3;
+        let authority_end = s[after_scheme..]
+            .find(|c| c == '/' || c == '?' || c == '#')
+            .map(|idx| after_scheme + idx)
+            .unwrap_or(s.len());
+        if let Some(rel_at) = s[after_scheme..authority_end].rfind('@') {
+            let at_pos = after_scheme + rel_at;
+            let userinfo = &s[after_scheme..at_pos];
+            if let Some(colon) = userinfo.find(':') {
+                let user = &userinfo[..colon];
+                return format!(
+                    "{}://{}:********@{}",
+                    &s[..scheme_end],
+                    user,
+                    &s[at_pos + 1..]
+                );
+            }
+        }
+        return s.to_string();
+    }
+    // Walk the byte stream tracking quote state so that semicolons inside a
+    // quoted value (e.g. ADO.NET `Password="my;pwd"`) are not treated as
+    // delimiters — otherwise the second half of the password would leak.
+    let bytes = s.as_bytes();
+    let mut result = String::with_capacity(s.len());
+    let mut start = 0;
+    let mut in_quote: Option<u8> = None;
+    for (i, &b) in bytes.iter().enumerate() {
+        match in_quote {
+            Some(q) if b == q => in_quote = None,
+            Some(_) => {}
+            None => match b {
+                b'"' | b'\'' => in_quote = Some(b),
+                b';' => {
+                    append_sanitized_kv(&mut result, &s[start..i]);
+                    result.push(';');
+                    start = i + 1;
+                }
+                _ => {}
+            },
+        }
+    }
+    append_sanitized_kv(&mut result, &s[start..]);
+    result
+}
+
+fn append_sanitized_kv(out: &mut String, part: &str) {
+    if let Some(eq) = part.find('=') {
+        let key = part[..eq].trim();
+        if key.eq_ignore_ascii_case("password") || key.eq_ignore_ascii_case("pwd") {
+            out.push_str(&part[..eq]);
+            out.push_str("=********");
+            return;
+        }
+    }
+    out.push_str(part);
+}
+
+impl std::fmt::Debug for Config {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let sanitized_source = sanitize_connection_string(&self.source_connection_string);
+        let sanitized_dest = sanitize_connection_string(&self.destination_connection_string);
+        f.debug_struct("Config")
+            .field("source_connection_string", &sanitized_source)
+            .field("destination_type", &self.destination_type)
+            .field("destination_connection_string", &sanitized_dest)
+            .field("replication_slot_name", &self.replication_slot_name)
+            .field("publication_name", &self.publication_name)
+            .field("protocol_version", &self.protocol_version)
+            .field("binary_format", &self.binary_format)
+            .field("streaming", &self.streaming)
+            .field("include_messages", &self.include_messages)
+            .field("two_phase", &self.two_phase)
+            .field("origin", &self.origin)
+            .field("connection_timeout", &self.connection_timeout)
+            .field("query_timeout", &self.query_timeout)
+            .field("heartbeat_interval", &self.heartbeat_interval)
+            .field("max_retry_attempts", &self.max_retry_attempts)
+            .field("initial_retry_delay", &self.initial_retry_delay)
+            .field("max_retry_delay", &self.max_retry_delay)
+            .field("retry_multiplier", &self.retry_multiplier)
+            .field("max_retry_duration", &self.max_retry_duration)
+            .field("retry_jitter", &self.retry_jitter)
+            .field("buffer_size", &self.buffer_size)
+            .field("table_mappings", &self.table_mappings)
+            .field("schema_mappings", &self.schema_mappings)
+            .field("batch_size", &self.batch_size)
+            .field(
+                "transaction_file_base_path",
+                &self.transaction_file_base_path,
+            )
+            .field(
+                "transaction_segment_size_bytes",
+                &self.transaction_segment_size_bytes,
+            )
+            .field("extra_options", &self.extra_options)
+            .field("bulk_insert_threshold", &self.bulk_insert_threshold)
+            .field("max_rows_per_insert", &self.max_rows_per_insert)
+            .field(
+                "destination_registry",
+                &format_args!("<{} entries>", self.destination_registry.len()),
+            )
+            .finish()
+    }
 }
 
 /// Origin filtering options
@@ -173,6 +294,44 @@ pub enum TransformationType {
 
 impl Default for Config {
     fn default() -> Self {
+        let mut destination_registry: HashMap<String, DestinationFactoryFn> = HashMap::new();
+
+        #[cfg(feature = "mysql")]
+        destination_registry.insert(
+            "mysql".to_string(),
+            Arc::new(|| {
+                Ok(Box::new(crate::destinations::MySQLDestination::new())
+                    as Box<dyn DestinationHandler>)
+            }),
+        );
+
+        #[cfg(feature = "sqlserver")]
+        destination_registry.insert(
+            "sqlserver".to_string(),
+            Arc::new(|| {
+                Ok(Box::new(crate::destinations::SqlServerDestination::new())
+                    as Box<dyn DestinationHandler>)
+            }),
+        );
+
+        #[cfg(feature = "sqlite")]
+        destination_registry.insert(
+            "sqlite".to_string(),
+            Arc::new(|| {
+                Ok(Box::new(crate::destinations::SQLiteDestination::new())
+                    as Box<dyn DestinationHandler>)
+            }),
+        );
+
+        #[cfg(feature = "kafka")]
+        destination_registry.insert(
+            "kafka".to_string(),
+            Arc::new(|| {
+                Ok(Box::new(crate::destinations::KafkaDestination::new())
+                    as Box<dyn DestinationHandler>)
+            }),
+        );
+
         Self {
             source_connection_string: String::new(),
             destination_type: DestinationType::MySQL,
@@ -203,6 +362,7 @@ impl Default for Config {
             extra_options: HashMap::new(),
             bulk_insert_threshold: 500,
             max_rows_per_insert: 0,
+            destination_registry,
         }
     }
 }
@@ -412,6 +572,64 @@ impl ConfigBuilder {
         self
     }
 
+    /// Sentinel registry key used by `custom_destination` / `use_destination`.
+    const CUSTOM_DESTINATION_KEY: &'static str = "__custom__";
+
+    /// Register a destination factory under `key`. Use this for advanced multi-key
+    /// scenarios (e.g. swapping handlers per `DestinationType` at runtime).
+    /// For the common case of a single user-supplied destination, prefer
+    /// [`custom_destination`](Self::custom_destination) or
+    /// [`use_destination`](Self::use_destination).
+    ///
+    /// The closure may be invoked more than once (main + consumer handlers).
+    pub fn register_destination<F, H>(mut self, key: impl Into<String>, factory: F) -> Self
+    where
+        F: Fn() -> H + Send + Sync + 'static,
+        H: DestinationHandler + 'static,
+    {
+        let f: DestinationFactoryFn = Arc::new(move || Ok(Box::new(factory()) as _));
+        self.config.destination_registry.insert(key.into(), f);
+        self
+    }
+
+    /// Inject a custom `DestinationHandler` factory and switch `destination_type`
+    /// to `DestinationType::Custom`. The closure must return a fresh handler each
+    /// call (invoked once for the main pipeline and once for the consumer).
+    ///
+    /// ```ignore
+    /// Config::builder()
+    ///     .custom_destination(|| MyHandler::new())
+    ///     .build()?;
+    /// ```
+    pub fn custom_destination<F, H>(mut self, factory: F) -> Self
+    where
+        F: Fn() -> H + Send + Sync + 'static,
+        H: DestinationHandler + 'static,
+    {
+        let f: DestinationFactoryFn = Arc::new(move || Ok(Box::new(factory()) as _));
+        self.config
+            .destination_registry
+            .insert(Self::CUSTOM_DESTINATION_KEY.to_string(), f);
+        self.config.destination_type =
+            DestinationType::Custom(Self::CUSTOM_DESTINATION_KEY.to_string());
+        self
+    }
+
+    /// Zero-arg shortcut for any `DestinationHandler` that implements `Default`.
+    /// Useful for swapping in a built-in or a custom type with no construction args.
+    ///
+    /// ```ignore
+    /// Config::builder()
+    ///     .use_destination::<MySQLDestination>()
+    ///     .build()?;
+    /// ```
+    pub fn use_destination<H>(self) -> Self
+    where
+        H: DestinationHandler + Default + 'static,
+    {
+        self.custom_destination(H::default)
+    }
+
     /// Build the configuration
     pub fn build(self) -> Result<Config> {
         // Validate the configuration
@@ -467,6 +685,19 @@ impl Config {
     /// Create a new config builder
     pub fn builder() -> ConfigBuilder {
         ConfigBuilder::new()
+    }
+
+    /// Construct a destination handler by looking up `self.destination_type.registry_key()`
+    /// in the per-Config registry.
+    pub fn create_destination(&self) -> Result<Box<dyn DestinationHandler>> {
+        let key = self.destination_type.registry_key();
+        match self.destination_registry.get(key) {
+            Some(factory) => factory(),
+            None => Err(CdcError::unsupported(format!(
+                "No destination registered for key '{}'",
+                key
+            ))),
+        }
     }
 }
 

--- a/pg2any-lib/src/destinations/destination_factory.rs
+++ b/pg2any-lib/src/destinations/destination_factory.rs
@@ -1,24 +1,22 @@
 use crate::{
+    destinations::dialect::SqlDialect,
+    destinations::dialects::AnsiDialect,
     error::{CdcError, Result},
-    types::{DestinationType, Lsn},
+    types::Lsn,
 };
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use pg_walstream::ChangeEvent;
-use std::{collections::HashMap, future::Future, pin::Pin};
+use std::{collections::HashMap, future::Future, pin::Pin, sync::Arc};
 
 pub type PreCommitHook =
     Box<dyn FnOnce() -> Pin<Box<dyn Future<Output = Result<()>> + Send>> + Send>;
 
-// Import destination implementations
-#[cfg(feature = "mysql")]
-use super::mysql::MySQLDestination;
-
-#[cfg(feature = "sqlserver")]
-use super::sqlserver::SqlServerDestination;
-
-#[cfg(feature = "sqlite")]
-use super::sqlite::SQLiteDestination;
+/// Factory closure for constructing a destination handler.
+///
+/// `Fn` (not `FnOnce`) — the consumer creates an additional handler during
+/// `start_file_based_workflow`, so the factory may be invoked multiple times.
+pub type DestinationFactoryFn = Arc<dyn Fn() -> Result<Box<dyn DestinationHandler>> + Send + Sync>;
 
 /// Trait for database destination handlers
 ///
@@ -44,6 +42,20 @@ pub trait DestinationHandler: Send + Sync {
     /// Set the maximum number of rows per multi-value INSERT statement.
     /// 0 means no limit (database default applies).
     fn set_max_rows_per_insert(&mut self, _max_rows: usize) {}
+
+    /// Return the SQL dialect this destination renders for.
+    ///
+    /// Defaults to a generic ANSI-flavored dialect — matches the historical
+    /// `DestinationType::Custom(_)` fallback in `TransactionManager`, so
+    /// existing custom destinations registered via
+    /// `Config::register_destination` keep working without any changes.
+    ///
+    /// Override this to provide destination-specific quoting, hex literals,
+    /// value rendering, and TRUNCATE strategy.
+    fn dialect(&self) -> &'static dyn SqlDialect {
+        static ANSI: AnsiDialect = AnsiDialect;
+        &ANSI
+    }
 
     /// Execute a batch of SQL commands within a single transaction with optional pre-commit hook
     ///
@@ -119,78 +131,5 @@ pub trait DestinationHandler: Send + Sync {
         );
         self.execute_sql_batch_with_hook(&sqls, pre_commit_hook)
             .await
-    }
-}
-
-/// Factory for creating destination handlers
-pub struct DestinationFactory;
-
-impl DestinationFactory {
-    /// Create a new destination handler for the specified type
-    pub fn create(destination_type: &DestinationType) -> Result<Box<dyn DestinationHandler>> {
-        match *destination_type {
-            #[cfg(feature = "mysql")]
-            DestinationType::MySQL => Ok(Box::new(MySQLDestination::new())),
-
-            #[cfg(feature = "sqlserver")]
-            DestinationType::SqlServer => Ok(Box::new(SqlServerDestination::new())),
-
-            #[cfg(feature = "sqlite")]
-            DestinationType::SQLite => Ok(Box::new(SQLiteDestination::new())),
-
-            #[cfg(feature = "kafka")]
-            DestinationType::Kafka => Ok(Box::new(super::kafka::KafkaDestination::new())),
-
-            #[allow(unreachable_patterns)]
-            _ => Err(CdcError::unsupported(format!(
-                "Destination type {destination_type:?} is not supported or not enabled"
-            ))),
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_destination_factory_create() {
-        // Test factory creation for different destination types
-        #[cfg(feature = "mysql")]
-        {
-            let result = DestinationFactory::create(&DestinationType::MySQL);
-            assert!(result.is_ok());
-        }
-
-        #[cfg(feature = "sqlserver")]
-        {
-            let result = DestinationFactory::create(&DestinationType::SqlServer);
-            assert!(result.is_ok());
-        }
-
-        #[cfg(feature = "sqlite")]
-        {
-            let result = DestinationFactory::create(&DestinationType::SQLite);
-            assert!(result.is_ok());
-        }
-    }
-
-    #[test]
-    fn test_destination_types_serialization() {
-        use serde_json;
-
-        let mysql_type = DestinationType::MySQL;
-        let json = serde_json::to_string(&mysql_type).unwrap();
-        assert_eq!(json, "\"MySQL\"");
-
-        let deserialized: DestinationType = serde_json::from_str(&json).unwrap();
-        assert_eq!(deserialized, mysql_type);
-
-        let sqlite_type = DestinationType::SQLite;
-        let sqlite_json = serde_json::to_string(&sqlite_type).unwrap();
-        assert_eq!(sqlite_json, "\"SQLite\"");
-
-        let sqlite_deserialized: DestinationType = serde_json::from_str(&sqlite_json).unwrap();
-        assert_eq!(sqlite_deserialized, sqlite_type);
     }
 }

--- a/pg2any-lib/src/destinations/dialect.rs
+++ b/pg2any-lib/src/destinations/dialect.rs
@@ -1,0 +1,81 @@
+//! # Per-destination SQL dialect abstraction
+//!
+//! External destinations registered via [`crate::config::ConfigBuilder::register_destination`]
+//! (or `custom_destination` / `use_destination`) can supply their own SQL
+//! dialect by overriding
+//! [`crate::destinations::destination_factory::DestinationHandler::dialect`].
+//!
+//! Three integration patterns:
+//!
+//! 1. **Reuse a built-in dialect** — return a reference to a static instance
+//!    of one of the five built-ins ([`crate::destinations::dialects::MySqlDialect`],
+//!    [`crate::destinations::dialects::SqlServerDialect`],
+//!    [`crate::destinations::dialects::SqliteDialect`],
+//!    [`crate::destinations::dialects::KafkaDialect`], or
+//!    [`crate::destinations::dialects::AnsiDialect`]):
+//!
+//!    ```ignore
+//!    fn dialect(&self) -> &'static dyn SqlDialect {
+//!        use pg2any_lib::MySqlDialect;
+//!        static D: MySqlDialect = MySqlDialect;
+//!        &D
+//!    }
+//!    ```
+//!
+//! 2. **Accept the [`crate::destinations::dialects::AnsiDialect`] default** —
+//!    do nothing. `DestinationHandler::dialect`'s default impl returns
+//!    `&AnsiDialect`, which matches the historical `DestinationType::Custom(_)`
+//!    fallback (double-quoted identifiers, `X'…'` hex, `TRUNCATE TABLE`).
+//!
+//! 3. **Provide a fully custom dialect** — implement [`SqlDialect`] yourself
+//!    for your destination's quoting/value/truncate rules. See
+//!    `examples/src/bin/custom_destination.rs` for a worked example.
+//!
+//! See docs/superpowers/specs/2026-06-05-destination-dialect-extraction-design.md
+//! for design rationale.
+
+use pg_walstream::ColumnValue;
+
+/// SQL dialect rules for a destination database.
+///
+/// Implementations encapsulate quoting, value rendering, and DDL emission
+/// differences across destination engines. All methods write into a caller-
+/// supplied `String` buffer to avoid per-call allocation.
+///
+/// The four built-in implementations (`MySqlDialect`, `SqlServerDialect`,
+/// `SqliteDialect`, `KafkaDialect`) plus the generic `AnsiDialect` cover the
+/// pre-refactor branches that lived inside `TransactionManager`. External
+/// destinations registered via `Config::register_destination` may either reuse
+/// one of these or supply their own.
+pub trait SqlDialect: Send + Sync {
+    /// Append a quoted identifier (schema/table/column) into `out`.
+    fn quote_identifier(&self, ident: &str, out: &mut String);
+
+    /// Append a fully-qualified table reference into `out`.
+    /// `schema` is the already-mapped destination schema name (caller is
+    /// responsible for `map_schema`). Some dialects (SQLite, Kafka today)
+    /// ignore the schema and emit only the table.
+    fn qualify_table(&self, schema: &str, table: &str, out: &mut String);
+
+    /// Append a hex literal for raw bytes into `out`.
+    fn render_hex_literal(&self, bytes: &[u8], out: &mut String);
+
+    /// Append a SQL literal for a `ColumnValue` into `out`.
+    fn render_value(&self, value: &ColumnValue, out: &mut String);
+
+    /// Return the TRUNCATE statement for `schema.table`, or `None` if the
+    /// destination has no concept of TRUNCATE (e.g. Kafka).
+    fn truncate_table_sql(&self, schema: &str, table: &str) -> Option<String>;
+}
+
+/// Append `bytes` to `out` as ASCII hex digits (no prefix/suffix).
+///
+/// Shared helper for dialect impls that emit hex literals.
+pub(crate) fn push_hex_ascii(out: &mut String, bytes: &[u8]) {
+    static HEX: &[u8; 16] = b"0123456789abcdef";
+    out.reserve(bytes.len() * 2);
+    for &b in bytes {
+        out.push(HEX[(b >> 4) as usize] as char);
+        out.push(HEX[(b & 0x0f) as usize] as char);
+    }
+}

--- a/pg2any-lib/src/destinations/dialects/ansi.rs
+++ b/pg2any-lib/src/destinations/dialects/ansi.rs
@@ -1,0 +1,175 @@
+use crate::destinations::dialect::SqlDialect;
+use pg_walstream::ColumnValue;
+
+/// Generic ANSI-flavored SQL dialect — double-quoted identifiers, `X'…'` hex,
+/// `TRUNCATE TABLE` for truncate. Used as the default for `Custom(_)`
+/// destinations that do not provide their own dialect.
+#[derive(Default, Debug, Clone, Copy)]
+pub struct AnsiDialect;
+
+impl SqlDialect for AnsiDialect {
+    fn quote_identifier(&self, ident: &str, out: &mut String) {
+        // Mirrors transaction_manager.rs SQLite/Kafka/Custom(_) double-quote branch.
+        out.reserve(ident.len() + 2);
+        out.push('"');
+        if ident.contains('"') {
+            for ch in ident.chars() {
+                if ch == '"' {
+                    out.push('"');
+                }
+                out.push(ch);
+            }
+        } else {
+            out.push_str(ident);
+        }
+        out.push('"');
+    }
+
+    fn qualify_table(&self, schema: &str, table: &str, out: &mut String) {
+        // Mirrors Custom(_) arm: schema.table both quoted.
+        self.quote_identifier(schema, out);
+        out.push('.');
+        self.quote_identifier(table, out);
+    }
+
+    fn render_hex_literal(&self, bytes: &[u8], out: &mut String) {
+        out.push_str("X'");
+        crate::destinations::dialect::push_hex_ascii(out, bytes);
+        out.push('\'');
+    }
+
+    fn render_value(&self, value: &ColumnValue, out: &mut String) {
+        match value {
+            ColumnValue::Null => out.push_str("NULL"),
+            ColumnValue::Text(_) => match value.as_str() {
+                Some(s) => {
+                    if s == "t" {
+                        out.push('1');
+                        return;
+                    }
+                    if s == "f" {
+                        out.push('0');
+                        return;
+                    }
+                    out.reserve(s.len() + 2);
+                    out.push('\'');
+                    if s.contains('\'') {
+                        for ch in s.chars() {
+                            if ch == '\'' {
+                                out.push_str("''");
+                            } else {
+                                out.push(ch);
+                            }
+                        }
+                    } else {
+                        out.push_str(s);
+                    }
+                    out.push('\'');
+                }
+                None => self.render_hex_literal(value.as_bytes(), out),
+            },
+            ColumnValue::Binary(_) => self.render_hex_literal(value.as_bytes(), out),
+        }
+    }
+
+    fn truncate_table_sql(&self, schema: &str, table: &str) -> Option<String> {
+        let mut sql = String::new();
+        sql.push_str("TRUNCATE TABLE ");
+        self.qualify_table(schema, table, &mut sql);
+        sql.push(';');
+        Some(sql)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn s(f: impl Fn(&mut String)) -> String {
+        let mut o = String::new();
+        f(&mut o);
+        o
+    }
+
+    #[test]
+    fn quote_identifier() {
+        assert_eq!(s(|o| AnsiDialect.quote_identifier("users", o)), "\"users\"");
+        assert_eq!(
+            s(|o| AnsiDialect.quote_identifier("back`tick", o)),
+            "\"back`tick\""
+        );
+        assert_eq!(
+            s(|o| AnsiDialect.quote_identifier("bra]cket", o)),
+            "\"bra]cket\""
+        );
+        assert_eq!(
+            s(|o| AnsiDialect.quote_identifier("double\"quote", o)),
+            "\"double\"\"quote\""
+        );
+    }
+
+    #[test]
+    fn qualify_table() {
+        assert_eq!(
+            s(|o| AnsiDialect.qualify_table("public", "users", o)),
+            "\"public\".\"users\""
+        );
+        assert_eq!(
+            s(|o| AnsiDialect.qualify_table("custom", "items", o)),
+            "\"custom\".\"items\""
+        );
+    }
+
+    #[test]
+    fn render_hex_literal() {
+        assert_eq!(s(|o| AnsiDialect.render_hex_literal(&[], o)), "X''");
+        assert_eq!(
+            s(|o| AnsiDialect.render_hex_literal(&[0xde, 0xad, 0xbe, 0xef], o)),
+            "X'deadbeef'"
+        );
+    }
+
+    #[test]
+    fn render_value() {
+        use bytes::Bytes;
+        assert_eq!(
+            s(|o| AnsiDialect.render_value(&ColumnValue::Null, o)),
+            "NULL"
+        );
+        assert_eq!(
+            s(|o| AnsiDialect.render_value(&ColumnValue::text("t"), o)),
+            "1"
+        );
+        assert_eq!(
+            s(|o| AnsiDialect.render_value(&ColumnValue::text("f"), o)),
+            "0"
+        );
+        assert_eq!(
+            s(|o| AnsiDialect.render_value(&ColumnValue::text("hello"), o)),
+            "'hello'"
+        );
+        assert_eq!(
+            s(|o| AnsiDialect.render_value(&ColumnValue::text("o'reilly"), o)),
+            "'o''reilly'"
+        );
+        assert_eq!(
+            s(|o| AnsiDialect.render_value(&ColumnValue::text("back\\slash"), o)),
+            "'back\\slash'"
+        );
+        assert_eq!(
+            s(|o| AnsiDialect.render_value(
+                &ColumnValue::Binary(Bytes::from_static(&[0x00, 0xff, 0xab])),
+                o
+            )),
+            "X'00ffab'"
+        );
+    }
+
+    #[test]
+    fn truncate_table_sql() {
+        assert_eq!(
+            AnsiDialect.truncate_table_sql("public", "users").as_deref(),
+            Some("TRUNCATE TABLE \"public\".\"users\";")
+        );
+    }
+}

--- a/pg2any-lib/src/destinations/dialects/kafka.rs
+++ b/pg2any-lib/src/destinations/dialects/kafka.rs
@@ -1,0 +1,122 @@
+use crate::destinations::dialect::SqlDialect;
+use crate::destinations::dialects::ansi::AnsiDialect;
+use pg_walstream::ColumnValue;
+
+#[derive(Default, Debug, Clone, Copy)]
+pub struct KafkaDialect;
+
+impl SqlDialect for KafkaDialect {
+    fn quote_identifier(&self, ident: &str, out: &mut String) {
+        AnsiDialect.quote_identifier(ident, out);
+    }
+
+    fn qualify_table(&self, _schema: &str, table: &str, out: &mut String) {
+        self.quote_identifier(table, out);
+    }
+
+    fn render_hex_literal(&self, bytes: &[u8], out: &mut String) {
+        AnsiDialect.render_hex_literal(bytes, out);
+    }
+
+    fn render_value(&self, value: &ColumnValue, out: &mut String) {
+        AnsiDialect.render_value(value, out);
+    }
+
+    fn truncate_table_sql(&self, _schema: &str, _table: &str) -> Option<String> {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn s(f: impl Fn(&mut String)) -> String {
+        let mut o = String::new();
+        f(&mut o);
+        o
+    }
+
+    #[test]
+    fn quote_identifier() {
+        assert_eq!(
+            s(|o| KafkaDialect.quote_identifier("users", o)),
+            "\"users\""
+        );
+        assert_eq!(
+            s(|o| KafkaDialect.quote_identifier("back`tick", o)),
+            "\"back`tick\""
+        );
+        assert_eq!(
+            s(|o| KafkaDialect.quote_identifier("bra]cket", o)),
+            "\"bra]cket\""
+        );
+        assert_eq!(
+            s(|o| KafkaDialect.quote_identifier("double\"quote", o)),
+            "\"double\"\"quote\""
+        );
+    }
+
+    #[test]
+    fn qualify_table() {
+        // Schema dropped, table-only.
+        assert_eq!(
+            s(|o| KafkaDialect.qualify_table("public", "users", o)),
+            "\"users\""
+        );
+        assert_eq!(
+            s(|o| KafkaDialect.qualify_table("custom", "items", o)),
+            "\"items\""
+        );
+    }
+
+    #[test]
+    fn render_hex_literal() {
+        assert_eq!(s(|o| KafkaDialect.render_hex_literal(&[], o)), "X''");
+        assert_eq!(
+            s(|o| KafkaDialect.render_hex_literal(&[0xde, 0xad, 0xbe, 0xef], o)),
+            "X'deadbeef'"
+        );
+    }
+
+    #[test]
+    fn render_value() {
+        use bytes::Bytes;
+        assert_eq!(
+            s(|o| KafkaDialect.render_value(&ColumnValue::Null, o)),
+            "NULL"
+        );
+        assert_eq!(
+            s(|o| KafkaDialect.render_value(&ColumnValue::text("t"), o)),
+            "1"
+        );
+        assert_eq!(
+            s(|o| KafkaDialect.render_value(&ColumnValue::text("f"), o)),
+            "0"
+        );
+        assert_eq!(
+            s(|o| KafkaDialect.render_value(&ColumnValue::text("hello"), o)),
+            "'hello'"
+        );
+        assert_eq!(
+            s(|o| KafkaDialect.render_value(&ColumnValue::text("o'reilly"), o)),
+            "'o''reilly'"
+        );
+        assert_eq!(
+            s(|o| KafkaDialect.render_value(&ColumnValue::text("back\\slash"), o)),
+            "'back\\slash'"
+        );
+        assert_eq!(
+            s(|o| KafkaDialect.render_value(
+                &ColumnValue::Binary(Bytes::from_static(&[0x00, 0xff, 0xab])),
+                o
+            )),
+            "X'00ffab'"
+        );
+    }
+
+    #[test]
+    fn truncate_table_sql() {
+        assert_eq!(KafkaDialect.truncate_table_sql("public", "users"), None);
+    }
+}

--- a/pg2any-lib/src/destinations/dialects/mod.rs
+++ b/pg2any-lib/src/destinations/dialects/mod.rs
@@ -1,0 +1,11 @@
+mod ansi;
+mod kafka;
+mod mysql;
+mod sqlite;
+mod sqlserver;
+
+pub use ansi::AnsiDialect;
+pub use kafka::KafkaDialect;
+pub use mysql::MySqlDialect;
+pub use sqlite::SqliteDialect;
+pub use sqlserver::SqlServerDialect;

--- a/pg2any-lib/src/destinations/dialects/mysql.rs
+++ b/pg2any-lib/src/destinations/dialects/mysql.rs
@@ -1,0 +1,173 @@
+use crate::destinations::dialect::SqlDialect;
+use pg_walstream::ColumnValue;
+
+#[derive(Default, Debug, Clone, Copy)]
+pub struct MySqlDialect;
+
+impl SqlDialect for MySqlDialect {
+    fn quote_identifier(&self, ident: &str, out: &mut String) {
+        out.reserve(ident.len() + 2);
+        out.push('`');
+        if ident.contains('`') {
+            for ch in ident.chars() {
+                if ch == '`' {
+                    out.push('`');
+                }
+                out.push(ch);
+            }
+        } else {
+            out.push_str(ident);
+        }
+        out.push('`');
+    }
+
+    fn qualify_table(&self, schema: &str, table: &str, out: &mut String) {
+        self.quote_identifier(schema, out);
+        out.push('.');
+        self.quote_identifier(table, out);
+    }
+
+    fn render_hex_literal(&self, bytes: &[u8], out: &mut String) {
+        out.push_str("X'");
+        crate::destinations::dialect::push_hex_ascii(out, bytes);
+        out.push('\'');
+    }
+
+    fn render_value(&self, value: &ColumnValue, out: &mut String) {
+        match value {
+            ColumnValue::Null => out.push_str("NULL"),
+            ColumnValue::Text(_) => match value.as_str() {
+                Some(s) => {
+                    if s == "t" {
+                        out.push('1');
+                        return;
+                    }
+                    if s == "f" {
+                        out.push('0');
+                        return;
+                    }
+                    out.reserve(s.len() + 2);
+                    out.push('\'');
+                    let needs_escape = s.contains(['\'', '\\']);
+                    if needs_escape {
+                        for ch in s.chars() {
+                            match ch {
+                                '\'' => out.push_str("''"),
+                                '\\' => out.push_str("\\\\"),
+                                _ => out.push(ch),
+                            }
+                        }
+                    } else {
+                        out.push_str(s);
+                    }
+                    out.push('\'');
+                }
+                None => self.render_hex_literal(value.as_bytes(), out),
+            },
+            ColumnValue::Binary(_) => self.render_hex_literal(value.as_bytes(), out),
+        }
+    }
+
+    fn truncate_table_sql(&self, schema: &str, table: &str) -> Option<String> {
+        let mut sql = String::new();
+        sql.push_str("TRUNCATE TABLE ");
+        self.qualify_table(schema, table, &mut sql);
+        sql.push(';');
+        Some(sql)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn s(f: impl Fn(&mut String)) -> String {
+        let mut o = String::new();
+        f(&mut o);
+        o
+    }
+
+    #[test]
+    fn quote_identifier() {
+        assert_eq!(s(|o| MySqlDialect.quote_identifier("users", o)), "`users`");
+        assert_eq!(
+            s(|o| MySqlDialect.quote_identifier("back`tick", o)),
+            "`back``tick`"
+        );
+        assert_eq!(
+            s(|o| MySqlDialect.quote_identifier("bra]cket", o)),
+            "`bra]cket`"
+        );
+        assert_eq!(
+            s(|o| MySqlDialect.quote_identifier("double\"quote", o)),
+            "`double\"quote`"
+        );
+    }
+
+    #[test]
+    fn qualify_table() {
+        assert_eq!(
+            s(|o| MySqlDialect.qualify_table("public", "users", o)),
+            "`public`.`users`"
+        );
+        assert_eq!(
+            s(|o| MySqlDialect.qualify_table("custom", "items", o)),
+            "`custom`.`items`"
+        );
+    }
+
+    #[test]
+    fn render_hex_literal() {
+        assert_eq!(s(|o| MySqlDialect.render_hex_literal(&[], o)), "X''");
+        assert_eq!(
+            s(|o| MySqlDialect.render_hex_literal(&[0xde, 0xad, 0xbe, 0xef], o)),
+            "X'deadbeef'"
+        );
+    }
+
+    #[test]
+    fn render_value() {
+        use bytes::Bytes;
+        assert_eq!(
+            s(|o| MySqlDialect.render_value(&ColumnValue::Null, o)),
+            "NULL"
+        );
+        assert_eq!(
+            s(|o| MySqlDialect.render_value(&ColumnValue::text("t"), o)),
+            "1"
+        );
+        assert_eq!(
+            s(|o| MySqlDialect.render_value(&ColumnValue::text("f"), o)),
+            "0"
+        );
+        assert_eq!(
+            s(|o| MySqlDialect.render_value(&ColumnValue::text("hello"), o)),
+            "'hello'"
+        );
+        assert_eq!(
+            s(|o| MySqlDialect.render_value(&ColumnValue::text("o'reilly"), o)),
+            "'o''reilly'"
+        );
+        assert_eq!(
+            s(|o| MySqlDialect.render_value(&ColumnValue::text("back\\slash"), o)),
+            "'back\\\\slash'"
+        );
+        assert_eq!(
+            s(|o| MySqlDialect.render_value(
+                &ColumnValue::Binary(Bytes::from_static(&[0x00, 0xff, 0xab])),
+                o
+            )),
+            "X'00ffab'"
+        );
+    }
+
+    #[test]
+    fn truncate_table_sql() {
+        assert_eq!(
+            MySqlDialect
+                .truncate_table_sql("public", "users")
+                .as_deref(),
+            Some("TRUNCATE TABLE `public`.`users`;")
+        );
+    }
+}

--- a/pg2any-lib/src/destinations/dialects/sqlite.rs
+++ b/pg2any-lib/src/destinations/dialects/sqlite.rs
@@ -1,0 +1,133 @@
+use crate::destinations::dialect::SqlDialect;
+use crate::destinations::dialects::ansi::AnsiDialect;
+use pg_walstream::ColumnValue;
+
+#[derive(Default, Debug, Clone, Copy)]
+pub struct SqliteDialect;
+
+impl SqlDialect for SqliteDialect {
+    fn quote_identifier(&self, ident: &str, out: &mut String) {
+        AnsiDialect.quote_identifier(ident, out);
+    }
+
+    fn qualify_table(&self, _schema: &str, table: &str, out: &mut String) {
+        // SQLite drops the schema, emitting only the table.
+        self.quote_identifier(table, out);
+    }
+
+    fn render_hex_literal(&self, bytes: &[u8], out: &mut String) {
+        AnsiDialect.render_hex_literal(bytes, out);
+    }
+
+    fn render_value(&self, value: &ColumnValue, out: &mut String) {
+        AnsiDialect.render_value(value, out);
+    }
+
+    fn truncate_table_sql(&self, _schema: &str, table: &str) -> Option<String> {
+        // SQLite has no TRUNCATE — `DELETE FROM <table>` is used.
+        let mut sql = String::new();
+        sql.push_str("DELETE FROM ");
+        self.quote_identifier(table, &mut sql);
+        sql.push(';');
+        Some(sql)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn s(f: impl Fn(&mut String)) -> String {
+        let mut o = String::new();
+        f(&mut o);
+        o
+    }
+
+    #[test]
+    fn quote_identifier() {
+        assert_eq!(
+            s(|o| SqliteDialect.quote_identifier("users", o)),
+            "\"users\""
+        );
+        assert_eq!(
+            s(|o| SqliteDialect.quote_identifier("back`tick", o)),
+            "\"back`tick\""
+        );
+        assert_eq!(
+            s(|o| SqliteDialect.quote_identifier("bra]cket", o)),
+            "\"bra]cket\""
+        );
+        assert_eq!(
+            s(|o| SqliteDialect.quote_identifier("double\"quote", o)),
+            "\"double\"\"quote\""
+        );
+    }
+
+    #[test]
+    fn qualify_table() {
+        // Schema is dropped.
+        assert_eq!(
+            s(|o| SqliteDialect.qualify_table("public", "users", o)),
+            "\"users\""
+        );
+        assert_eq!(
+            s(|o| SqliteDialect.qualify_table("custom", "items", o)),
+            "\"items\""
+        );
+    }
+
+    #[test]
+    fn render_hex_literal() {
+        assert_eq!(s(|o| SqliteDialect.render_hex_literal(&[], o)), "X''");
+        assert_eq!(
+            s(|o| SqliteDialect.render_hex_literal(&[0xde, 0xad, 0xbe, 0xef], o)),
+            "X'deadbeef'"
+        );
+    }
+
+    #[test]
+    fn render_value() {
+        use bytes::Bytes;
+        assert_eq!(
+            s(|o| SqliteDialect.render_value(&ColumnValue::Null, o)),
+            "NULL"
+        );
+        assert_eq!(
+            s(|o| SqliteDialect.render_value(&ColumnValue::text("t"), o)),
+            "1"
+        );
+        assert_eq!(
+            s(|o| SqliteDialect.render_value(&ColumnValue::text("f"), o)),
+            "0"
+        );
+        assert_eq!(
+            s(|o| SqliteDialect.render_value(&ColumnValue::text("hello"), o)),
+            "'hello'"
+        );
+        assert_eq!(
+            s(|o| SqliteDialect.render_value(&ColumnValue::text("o'reilly"), o)),
+            "'o''reilly'"
+        );
+        assert_eq!(
+            s(|o| SqliteDialect.render_value(&ColumnValue::text("back\\slash"), o)),
+            "'back\\slash'"
+        );
+        assert_eq!(
+            s(|o| SqliteDialect.render_value(
+                &ColumnValue::Binary(Bytes::from_static(&[0x00, 0xff, 0xab])),
+                o
+            )),
+            "X'00ffab'"
+        );
+    }
+
+    #[test]
+    fn truncate_table_sql() {
+        assert_eq!(
+            SqliteDialect
+                .truncate_table_sql("public", "users")
+                .as_deref(),
+            Some("DELETE FROM \"users\";")
+        );
+    }
+}

--- a/pg2any-lib/src/destinations/dialects/sqlserver.rs
+++ b/pg2any-lib/src/destinations/dialects/sqlserver.rs
@@ -1,0 +1,174 @@
+use crate::destinations::dialect::SqlDialect;
+use pg_walstream::ColumnValue;
+
+#[derive(Default, Debug, Clone, Copy)]
+pub struct SqlServerDialect;
+
+impl SqlDialect for SqlServerDialect {
+    fn quote_identifier(&self, ident: &str, out: &mut String) {
+        out.reserve(ident.len() + 2);
+        out.push('[');
+        if ident.contains(']') {
+            for ch in ident.chars() {
+                if ch == ']' {
+                    out.push(']');
+                }
+                out.push(ch);
+            }
+        } else {
+            out.push_str(ident);
+        }
+        out.push(']');
+    }
+
+    fn qualify_table(&self, schema: &str, table: &str, out: &mut String) {
+        self.quote_identifier(schema, out);
+        out.push('.');
+        self.quote_identifier(table, out);
+    }
+
+    fn render_hex_literal(&self, bytes: &[u8], out: &mut String) {
+        out.push_str("0x");
+        crate::destinations::dialect::push_hex_ascii(out, bytes);
+    }
+
+    fn render_value(&self, value: &ColumnValue, out: &mut String) {
+        match value {
+            ColumnValue::Null => out.push_str("NULL"),
+            ColumnValue::Text(_) => match value.as_str() {
+                Some(s) => {
+                    if s == "t" {
+                        out.push('1');
+                        return;
+                    }
+                    if s == "f" {
+                        out.push('0');
+                        return;
+                    }
+                    out.reserve(s.len() + 2);
+                    out.push('\'');
+                    if s.contains('\'') {
+                        for ch in s.chars() {
+                            if ch == '\'' {
+                                out.push_str("''");
+                            } else {
+                                out.push(ch);
+                            }
+                        }
+                    } else {
+                        out.push_str(s);
+                    }
+                    out.push('\'');
+                }
+                None => self.render_hex_literal(value.as_bytes(), out),
+            },
+            ColumnValue::Binary(_) => self.render_hex_literal(value.as_bytes(), out),
+        }
+    }
+
+    fn truncate_table_sql(&self, schema: &str, table: &str) -> Option<String> {
+        let mut sql = String::new();
+        sql.push_str("TRUNCATE TABLE ");
+        self.qualify_table(schema, table, &mut sql);
+        sql.push(';');
+        Some(sql)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn s(f: impl Fn(&mut String)) -> String {
+        let mut o = String::new();
+        f(&mut o);
+        o
+    }
+
+    #[test]
+    fn quote_identifier() {
+        assert_eq!(
+            s(|o| SqlServerDialect.quote_identifier("users", o)),
+            "[users]"
+        );
+        assert_eq!(
+            s(|o| SqlServerDialect.quote_identifier("back`tick", o)),
+            "[back`tick]"
+        );
+        assert_eq!(
+            s(|o| SqlServerDialect.quote_identifier("bra]cket", o)),
+            "[bra]]cket]"
+        );
+        assert_eq!(
+            s(|o| SqlServerDialect.quote_identifier("double\"quote", o)),
+            "[double\"quote]"
+        );
+    }
+
+    #[test]
+    fn qualify_table() {
+        assert_eq!(
+            s(|o| SqlServerDialect.qualify_table("public", "users", o)),
+            "[public].[users]"
+        );
+        assert_eq!(
+            s(|o| SqlServerDialect.qualify_table("custom", "items", o)),
+            "[custom].[items]"
+        );
+    }
+
+    #[test]
+    fn render_hex_literal() {
+        assert_eq!(s(|o| SqlServerDialect.render_hex_literal(&[], o)), "0x");
+        assert_eq!(
+            s(|o| SqlServerDialect.render_hex_literal(&[0xde, 0xad, 0xbe, 0xef], o)),
+            "0xdeadbeef"
+        );
+    }
+
+    #[test]
+    fn render_value() {
+        use bytes::Bytes;
+        assert_eq!(
+            s(|o| SqlServerDialect.render_value(&ColumnValue::Null, o)),
+            "NULL"
+        );
+        assert_eq!(
+            s(|o| SqlServerDialect.render_value(&ColumnValue::text("t"), o)),
+            "1"
+        );
+        assert_eq!(
+            s(|o| SqlServerDialect.render_value(&ColumnValue::text("f"), o)),
+            "0"
+        );
+        assert_eq!(
+            s(|o| SqlServerDialect.render_value(&ColumnValue::text("hello"), o)),
+            "'hello'"
+        );
+        assert_eq!(
+            s(|o| SqlServerDialect.render_value(&ColumnValue::text("o'reilly"), o)),
+            "'o''reilly'"
+        );
+        assert_eq!(
+            s(|o| SqlServerDialect.render_value(&ColumnValue::text("back\\slash"), o)),
+            "'back\\slash'"
+        );
+        assert_eq!(
+            s(|o| SqlServerDialect.render_value(
+                &ColumnValue::Binary(Bytes::from_static(&[0x00, 0xff, 0xab])),
+                o
+            )),
+            "0x00ffab"
+        );
+    }
+
+    #[test]
+    fn truncate_table_sql() {
+        assert_eq!(
+            SqlServerDialect
+                .truncate_table_sql("public", "users")
+                .as_deref(),
+            Some("TRUNCATE TABLE [public].[users];")
+        );
+    }
+}

--- a/pg2any-lib/src/destinations/kafka.rs
+++ b/pg2any-lib/src/destinations/kafka.rs
@@ -1,4 +1,5 @@
 use super::destination_factory::{DestinationHandler, PreCommitHook};
+use crate::destinations::dialect::SqlDialect;
 use crate::error::{CdcError, Result};
 use async_trait::async_trait;
 use base64::prelude::*;
@@ -520,6 +521,12 @@ impl DestinationHandler for KafkaDestination {
 
     fn supports_event_mode(&self) -> bool {
         true
+    }
+
+    fn dialect(&self) -> &'static dyn SqlDialect {
+        use crate::destinations::dialects::KafkaDialect;
+        static D: KafkaDialect = KafkaDialect;
+        &D
     }
 
     async fn execute_events_batch_with_hook(

--- a/pg2any-lib/src/destinations/mod.rs
+++ b/pg2any-lib/src/destinations/mod.rs
@@ -1,5 +1,7 @@
 pub mod coalescing;
 pub mod common;
+pub mod dialect;
+pub mod dialects;
 
 /// Bulk insert utilities (TSV generation, INSERT detection)
 pub mod bulk_insert;
@@ -37,4 +39,4 @@ pub use sqlite::SQLiteDestination;
 pub use kafka::KafkaDestination;
 
 // Re-export factory and trait
-pub use destination_factory::{DestinationFactory, DestinationHandler, PreCommitHook};
+pub use destination_factory::{DestinationFactoryFn, DestinationHandler, PreCommitHook};

--- a/pg2any-lib/src/destinations/mysql.rs
+++ b/pg2any-lib/src/destinations/mysql.rs
@@ -1,4 +1,5 @@
 use super::destination_factory::{DestinationHandler, PreCommitHook};
+use crate::destinations::dialect::SqlDialect;
 use crate::error::{CdcError, Result};
 use async_trait::async_trait;
 use mysql_async::prelude::*;
@@ -192,6 +193,12 @@ impl DestinationHandler for MySQLDestination {
 
     fn supports_bulk_insert(&self) -> bool {
         self.load_data_available
+    }
+
+    fn dialect(&self) -> &'static dyn SqlDialect {
+        use crate::destinations::dialects::MySqlDialect;
+        static D: MySqlDialect = MySqlDialect;
+        &D
     }
 
     async fn execute_bulk_insert_with_hook(

--- a/pg2any-lib/src/destinations/sqlite.rs
+++ b/pg2any-lib/src/destinations/sqlite.rs
@@ -1,5 +1,6 @@
 use super::coalescing::{coalesce_commands, QuoteStyle};
 use super::destination_factory::{DestinationHandler, PreCommitHook};
+use crate::destinations::dialect::SqlDialect;
 use crate::error::{CdcError, Result};
 use async_trait::async_trait;
 use sqlx::{sqlite::SqliteConnectOptions, SqlitePool};
@@ -106,6 +107,12 @@ impl DestinationHandler for SQLiteDestination {
         if max_rows > 0 {
             self.max_rows_per_insert = max_rows;
         }
+    }
+
+    fn dialect(&self) -> &'static dyn SqlDialect {
+        use crate::destinations::dialects::SqliteDialect;
+        static D: SqliteDialect = SqliteDialect;
+        &D
     }
 
     async fn execute_sql_batch_with_hook(

--- a/pg2any-lib/src/destinations/sqlserver.rs
+++ b/pg2any-lib/src/destinations/sqlserver.rs
@@ -1,5 +1,6 @@
 use super::coalescing::{coalesce_commands, QuoteStyle};
 use super::destination_factory::{DestinationHandler, PreCommitHook};
+use crate::destinations::dialect::SqlDialect;
 use crate::error::{CdcError, Result};
 use async_trait::async_trait;
 use std::borrow::Cow;
@@ -172,6 +173,12 @@ impl DestinationHandler for SqlServerDestination {
 
     fn supports_bulk_insert(&self) -> bool {
         true
+    }
+
+    fn dialect(&self) -> &'static dyn SqlDialect {
+        use crate::destinations::dialects::SqlServerDialect;
+        static D: SqlServerDialect = SqlServerDialect;
+        &D
     }
 
     async fn execute_bulk_insert_with_hook(

--- a/pg2any-lib/src/env.rs
+++ b/pg2any-lib/src/env.rs
@@ -45,11 +45,9 @@ use std::time::Duration;
 /// - `CDC_CHANNEL_CAPACITY`: Capacity of the transaction channel between producer and consumer (default: "1000")
 ///   Controls how many complete transactions can be queued. Larger values handle burst traffic better but use more memory.
 ///   Recommended: 1000-5000 for typical workloads, 10000+ for high-throughput scenarios.
-///   (Deprecated alias: `CDC_BUFFER_SIZE`)
 /// - `CDC_BATCH_SIZE`: Number of rows per batch INSERT statement (default: "1000")
 ///   Higher values improve throughput for large streaming transactions (e.g., 400k+ inserts).
 ///   Recommended: 1000-5000 for typical workloads, adjust based on MySQL max_allowed_packet.
-///   (Deprecated alias: `CDC_COMMIT_BATCH_SIZE`)
 /// - `CDC_MAX_ROWS_PER_INSERT`: Maximum rows per multi-value INSERT statement (default: "0" = no limit)
 ///   SQL Server enforces a hard limit of 1000. Set to 1000 for SQL Server destinations.
 ///   When set to 0, the destination's own default applies (SQL Server defaults to 1000 internally).

--- a/pg2any-lib/src/lib.rs
+++ b/pg2any-lib/src/lib.rs
@@ -74,6 +74,9 @@ mod producer;
 // Transaction file persistence
 pub mod transaction_manager;
 
+// Pure SQL rendering (extracted from transaction_manager)
+pub mod sql_renderer;
+
 // Storage abstraction for transaction files
 pub mod storage;
 
@@ -144,8 +147,21 @@ pub use crate::destinations::SQLiteDestination;
 #[cfg(feature = "kafka")]
 pub use crate::destinations::KafkaDestination;
 
-pub use crate::destinations::{DestinationFactory, DestinationHandler};
+pub use crate::destinations::{DestinationFactoryFn, DestinationHandler, PreCommitHook};
 pub use crate::types::{DestinationType, Transaction};
+
+// SQL dialect customization for external destinations.
+//
+// Custom destinations registered via `Config::register_destination` can
+// override `DestinationHandler::dialect()` to return one of the built-in
+// dialects (e.g. `MySqlDialect`), the generic `AnsiDialect`, or a fully
+// custom `SqlDialect` impl. See `destinations::dialect` for the integration
+// guide and `examples/src/bin/custom_destination.rs` for a worked example.
+pub use crate::destinations::dialect::SqlDialect;
+pub use crate::destinations::dialects::{
+    AnsiDialect, KafkaDialect, MySqlDialect, SqlServerDialect, SqliteDialect,
+};
+pub use crate::sql_renderer::{RenderContext, RenderedStatement};
 
 // Conditionally export metrics server functionality
 #[cfg(feature = "metrics")]

--- a/pg2any-lib/src/sql_renderer.rs
+++ b/pg2any-lib/src/sql_renderer.rs
@@ -1,0 +1,678 @@
+//! Pure render functions: ChangeEvent → SQL string.
+//!
+//! All functions in this module are stateless given a [`RenderContext`].
+//! They are extracted from `transaction_manager.rs` to separate the
+//! read-and-apply path from batch grouping, file IO, and lifecycle code.
+//!
+//! See docs/superpowers/specs/2026-06-05-destination-dialect-extraction-design.md
+//! for design rationale.
+
+use crate::destinations::dialect::SqlDialect;
+use crate::error::{CdcError, Result};
+use crate::types::{ChangeEvent, EventType, ReplicaIdentity, RowData};
+use pg_walstream::ColumnValue;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+/// Borrowed view of the configuration the renderer needs.
+///
+/// Constructed cheaply by `TransactionManager` on each render call so that
+/// renderer functions remain stateless free functions instead of methods on
+/// a stateful manager.
+pub struct RenderContext<'a> {
+    pub dialect: &'a dyn SqlDialect,
+    pub schema_mappings: &'a HashMap<String, String>,
+}
+
+impl<'a> RenderContext<'a> {
+    /// Map a source schema to its destination equivalent.
+    /// Returns a borrow from the mapping table, the caller's input, or
+    /// the `"public"` literal — no per-call allocation.
+    pub fn map_schema(&self, source: Option<&'a str>) -> &'a str {
+        match source {
+            Some(s) => self.schema_mappings.get(s).map(String::as_str).unwrap_or(s),
+            None => "public",
+        }
+    }
+}
+
+/// Append a quoted identifier (schema/table/column) to `out`, performing
+/// destination-specific escaping of embedded quote characters.
+#[inline]
+pub fn append_quoted_identifier(ctx: &RenderContext, out: &mut String, name: &str) {
+    ctx.dialect.quote_identifier(name, out);
+}
+
+/// Append a quoted qualified table `schema.table` (or just table for SQLite) to `out`.
+#[inline]
+pub fn append_qualified_table(ctx: &RenderContext, out: &mut String, schema: &str, table: &str) {
+    ctx.dialect.qualify_table(schema, table, out);
+}
+
+/// Append a hex literal for raw bytes directly into `out`.
+#[inline]
+pub fn append_hex_literal(ctx: &RenderContext, out: &mut String, bytes: &[u8]) {
+    ctx.dialect.render_hex_literal(bytes, out);
+}
+
+/// Append a `ColumnValue` literal directly into `out`.
+#[inline]
+pub fn append_value(ctx: &RenderContext, out: &mut String, value: &ColumnValue) {
+    ctx.dialect.render_value(value, out);
+}
+
+/// Generate SQL command for a change event
+pub fn generate_sql_for_event(ctx: &RenderContext, event: &ChangeEvent) -> Result<String> {
+    match &event.event_type {
+        EventType::Insert {
+            schema,
+            table,
+            data,
+            ..
+        } => generate_insert_sql(ctx, schema, table, data),
+        EventType::Update {
+            schema,
+            table,
+            old_data,
+            new_data,
+            replica_identity,
+            key_columns,
+            ..
+        } => generate_update_sql(
+            ctx,
+            schema,
+            table,
+            new_data,
+            old_data.as_ref(),
+            replica_identity,
+            key_columns,
+        ),
+        EventType::Delete {
+            schema,
+            table,
+            old_data,
+            replica_identity,
+            key_columns,
+            ..
+        } => generate_delete_sql(ctx, schema, table, old_data, replica_identity, key_columns),
+        EventType::Truncate(tables) => generate_truncate_sql(ctx, tables),
+        _ => {
+            // Skip non-DML events
+            Ok(String::new())
+        }
+    }
+}
+
+/// Generate INSERT SQL command
+///
+/// Accepts `&RowData` directly. Uses `iter()` for column iteration.
+pub fn generate_insert_sql(
+    ctx: &RenderContext,
+    schema: &str,
+    table: &str,
+    new_data: &RowData,
+) -> Result<String> {
+    let schema = ctx.map_schema(Some(schema));
+
+    // Pre-size: assume ~32 bytes per (column, value) pair + overhead
+    let mut sql = String::with_capacity(64 + new_data.len() * 48);
+    sql.push_str("INSERT INTO ");
+    append_qualified_table(ctx, &mut sql, schema, table);
+    sql.push_str(" (");
+    for (i, (k, _)) in new_data.iter().enumerate() {
+        if i > 0 {
+            sql.push_str(", ");
+        }
+        append_quoted_identifier(ctx, &mut sql, k);
+    }
+    sql.push_str(") VALUES (");
+    for (i, (_, v)) in new_data.iter().enumerate() {
+        if i > 0 {
+            sql.push_str(", ");
+        }
+        append_value(ctx, &mut sql, v);
+    }
+    sql.push_str(");");
+
+    Ok(sql)
+}
+
+/// Generate UPDATE SQL command
+pub fn generate_update_sql(
+    ctx: &RenderContext,
+    schema: &str,
+    table: &str,
+    new_data: &RowData,
+    old_data: Option<&RowData>,
+    replica_identity: &ReplicaIdentity,
+    key_columns: &[Arc<str>],
+) -> Result<String> {
+    let schema = ctx.map_schema(Some(schema));
+
+    let mut sql = String::with_capacity(64 + new_data.len() * 64);
+    sql.push_str("UPDATE ");
+    append_qualified_table(ctx, &mut sql, schema, table);
+    sql.push_str(" SET ");
+    for (i, (col, val)) in new_data.iter().enumerate() {
+        if i > 0 {
+            sql.push_str(", ");
+        }
+        append_quoted_identifier(ctx, &mut sql, col);
+        sql.push_str(" = ");
+        append_value(ctx, &mut sql, val);
+    }
+    sql.push_str(" WHERE ");
+    append_where_clause(
+        ctx,
+        &mut sql,
+        replica_identity,
+        key_columns,
+        old_data,
+        new_data,
+    )?;
+    sql.push(';');
+
+    Ok(sql)
+}
+
+/// Generate DELETE SQL command
+///
+/// Accepts `&RowData` directly. For Default/Index replica identity (the most
+/// common case), this avoids cloning RowData entirely — only `RowData::get()`
+/// lookups are performed, with zero allocations.
+pub fn generate_delete_sql(
+    ctx: &RenderContext,
+    schema: &str,
+    table: &str,
+    old_data: &RowData,
+    replica_identity: &ReplicaIdentity,
+    key_columns: &[Arc<str>],
+) -> Result<String> {
+    let schema = ctx.map_schema(Some(schema));
+
+    let mut sql = String::with_capacity(64 + key_columns.len() * 32);
+    sql.push_str("DELETE FROM ");
+    append_qualified_table(ctx, &mut sql, schema, table);
+    sql.push_str(" WHERE ");
+    append_where_clause(
+        ctx,
+        &mut sql,
+        replica_identity,
+        key_columns,
+        Some(old_data),
+        old_data,
+    )?;
+    sql.push(';');
+
+    Ok(sql)
+}
+
+/// Generate TRUNCATE SQL command
+pub fn generate_truncate_sql(ctx: &RenderContext, tables: &[Arc<str>]) -> Result<String> {
+    // Build all TRUNCATE statements into a single `String` — no intermediate Vec.
+    // Pre-size for ~48 bytes per table (keyword + identifiers + punctuation).
+    let mut sql = String::with_capacity(tables.len() * 48);
+
+    for table_spec in tables.iter() {
+        let table_spec: &str = table_spec;
+        let (schema, table) = match table_spec.split_once('.') {
+            Some((s, t)) if !t.contains('.') => (ctx.map_schema(Some(s)), t),
+            _ => (ctx.map_schema(Some("public")), table_spec),
+        };
+
+        if let Some(stmt) = ctx.dialect.truncate_table_sql(schema, table) {
+            if !sql.is_empty() {
+                sql.push('\n');
+            }
+            sql.push_str(&stmt);
+        }
+    }
+
+    Ok(sql)
+}
+
+/// Append WHERE clause conditions directly into the provided buffer
+pub fn append_where_clause(
+    ctx: &RenderContext,
+    out: &mut String,
+    replica_identity: &ReplicaIdentity,
+    key_columns: &[Arc<str>],
+    old_data: Option<&RowData>,
+    new_data: &RowData,
+) -> Result<()> {
+    match replica_identity {
+        ReplicaIdentity::Default | ReplicaIdentity::Index => {
+            if key_columns.is_empty() {
+                return Err(CdcError::Generic(
+                    "No key columns found for UPDATE/DELETE with DEFAULT/INDEX replica identity"
+                        .to_string(),
+                ));
+            }
+            let data = old_data.unwrap_or(new_data);
+            for (i, col) in key_columns.iter().enumerate() {
+                if i > 0 {
+                    out.push_str(" AND ");
+                }
+                let col_str: &str = col;
+                let val = data
+                    .get(col_str)
+                    .ok_or_else(|| CdcError::Generic(format!("Key column {col_str} not found")))?;
+                append_quoted_identifier(ctx, out, col_str);
+                out.push_str(" = ");
+                append_value(ctx, out, val);
+            }
+        }
+        ReplicaIdentity::Full => {
+            let data = old_data.ok_or_else(|| {
+                CdcError::Generic("FULL replica identity requires old data".to_string())
+            })?;
+            for (i, (col, val)) in data.iter().enumerate() {
+                if i > 0 {
+                    out.push_str(" AND ");
+                }
+                append_quoted_identifier(ctx, out, col);
+                if val.is_null() {
+                    out.push_str(" IS NULL");
+                } else {
+                    out.push_str(" = ");
+                    append_value(ctx, out, val);
+                }
+            }
+        }
+        ReplicaIdentity::Nothing => {
+            return Err(CdcError::Generic(
+                "Cannot generate WHERE clause with NOTHING replica identity".to_string(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Output of rendering a single `ChangeEvent`.
+///
+/// `TransactionManager` will eventually route batches of these to the
+/// appropriate `DestinationHandler` method (SQL, bulk-insert, event-mode,
+/// or no-op) without re-parsing SQL strings. Currently this enum is
+/// substrate for that future work; the active execute path still uses the
+/// legacy string-reparse routing in
+/// `transaction_manager.rs::execute_batch_with_bulk_detection`.
+#[allow(dead_code)] // substrate for upcoming routing change; exercised by tests
+#[derive(Debug)]
+pub enum RenderedStatement {
+    /// Plain SQL statement (DML or DDL) ready to send to the destination.
+    Sql(String),
+    /// Structured bulk-insert intent. Matches the shape of
+    /// `DestinationHandler::execute_bulk_insert_with_hook`.
+    BulkInsert {
+        table: String,
+        columns: Vec<String>,
+        rows: Vec<Vec<String>>,
+    },
+    /// Raw event passthrough for event-mode destinations (Kafka).
+    Event(Box<ChangeEvent>),
+    /// Event produced no statement (e.g. TRUNCATE on Kafka, or filtered).
+    NoOp,
+}
+
+/// Structured (table, columns, single-row) tuple for bulk insert routing.
+#[allow(dead_code)]
+pub(crate) struct InsertBulkParts {
+    pub table: String,
+    pub columns: Vec<String>,
+    pub row: Vec<String>,
+}
+
+/// Render a single `ChangeEvent` into a structured statement.
+///
+/// `supports_bulk` should reflect the active destination handler's
+/// `supports_bulk_insert()`. When true and the event is an INSERT, the
+/// result is `RenderedStatement::BulkInsert`; otherwise the event is
+/// rendered as `RenderedStatement::Sql`.
+///
+/// `event_mode` should reflect the handler's `supports_event_mode()`.
+/// When true, INSERT/UPDATE/DELETE/TRUNCATE events are returned as
+/// `RenderedStatement::Event(...)` (with no SQL rendering); other event
+/// types become `NoOp`.
+#[allow(dead_code)]
+pub(crate) fn render_event(
+    ctx: &RenderContext,
+    event: &ChangeEvent,
+    supports_bulk: bool,
+    event_mode: bool,
+) -> Result<RenderedStatement> {
+    if event_mode {
+        return match &event.event_type {
+            EventType::Insert { .. }
+            | EventType::Update { .. }
+            | EventType::Delete { .. }
+            | EventType::Truncate(_) => Ok(RenderedStatement::Event(Box::new(event.clone()))),
+            _ => Ok(RenderedStatement::NoOp),
+        };
+    }
+
+    if supports_bulk {
+        if let EventType::Insert { .. } = &event.event_type {
+            let parts = render_insert_as_bulk(ctx, event)?;
+            return Ok(RenderedStatement::BulkInsert {
+                table: parts.table,
+                columns: parts.columns,
+                rows: vec![parts.row],
+            });
+        }
+    }
+
+    let sql = generate_sql_for_event(ctx, event)?;
+    if sql.is_empty() {
+        Ok(RenderedStatement::NoOp)
+    } else {
+        Ok(RenderedStatement::Sql(sql))
+    }
+}
+
+/// Render a single INSERT event into the structured tuple form expected by
+/// `DestinationHandler::execute_bulk_insert_with_hook`.
+///
+/// Produces the same `(table, columns, row)` triple that the legacy
+/// `destinations::bulk_insert::detect_bulk_insert_batch` extracts from
+/// rendered INSERT SQL strings — but without going through SQL. The
+/// `table` string is the dialect-qualified identifier (e.g.
+/// `` `public`.`users` ``); each column name and value is rendered with
+/// the same dialect helpers used by `generate_insert_sql`, so the strings
+/// are byte-identical to what would appear in the `VALUES (...)` tuple.
+#[allow(dead_code)]
+pub(crate) fn render_insert_as_bulk(
+    ctx: &RenderContext,
+    event: &ChangeEvent,
+) -> Result<InsertBulkParts> {
+    let (schema, table, data) = match &event.event_type {
+        EventType::Insert {
+            schema,
+            table,
+            data,
+            ..
+        } => (schema.as_ref(), table.as_ref(), data),
+        _ => {
+            return Err(CdcError::Generic(
+                "render_insert_as_bulk called with non-INSERT event".to_string(),
+            ));
+        }
+    };
+
+    let mapped_schema = ctx.map_schema(Some(schema));
+
+    let mut qualified_table = String::new();
+    append_qualified_table(ctx, &mut qualified_table, mapped_schema, table);
+
+    let mut columns: Vec<String> = Vec::with_capacity(data.len());
+    let mut row: Vec<String> = Vec::with_capacity(data.len());
+    for (col_name, val) in data.iter() {
+        let mut quoted_col = String::new();
+        append_quoted_identifier(ctx, &mut quoted_col, col_name);
+        columns.push(quoted_col);
+
+        let mut rendered_val = String::new();
+        append_value(ctx, &mut rendered_val, val);
+        row.push(rendered_val);
+    }
+
+    Ok(InsertBulkParts {
+        table: qualified_table,
+        columns,
+        row,
+    })
+}
+
+/// Coalesce a consecutive run of `RenderedStatement::BulkInsert` items
+/// targeting the same `(table, columns)` into a single BulkInsert with
+/// all rows accumulated. Stops at the first item that breaks the run.
+///
+/// Returns the coalesced BulkInsert and the number of items consumed,
+/// or `None` if the first item is not a BulkInsert.
+#[allow(dead_code)]
+pub(crate) fn coalesce_bulk_inserts(
+    items: &[RenderedStatement],
+) -> Option<(RenderedStatement, usize)> {
+    let (first_table, first_cols, mut all_rows) = match items.first()? {
+        RenderedStatement::BulkInsert {
+            table,
+            columns,
+            rows,
+        } => (table.clone(), columns.clone(), rows.clone()),
+        _ => return None,
+    };
+
+    let mut consumed = 1;
+    for item in &items[1..] {
+        match item {
+            RenderedStatement::BulkInsert {
+                table,
+                columns,
+                rows,
+            } if table == &first_table && columns == &first_cols => {
+                all_rows.extend(rows.iter().cloned());
+                consumed += 1;
+            }
+            _ => break,
+        }
+    }
+
+    Some((
+        RenderedStatement::BulkInsert {
+            table: first_table,
+            columns: first_cols,
+            rows: all_rows,
+        },
+        consumed,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::destinations::dialects::MySqlDialect;
+    use crate::types::{ChangeEvent, EventType, ReplicaIdentity, RowData};
+    use pg_walstream::{ColumnValue, Lsn};
+    use std::sync::Arc;
+
+    fn ctx() -> (MySqlDialect, HashMap<String, String>) {
+        (MySqlDialect, HashMap::new())
+    }
+
+    fn make_render_ctx<'a>(
+        dialect: &'a MySqlDialect,
+        mappings: &'a HashMap<String, String>,
+    ) -> RenderContext<'a> {
+        RenderContext {
+            dialect,
+            schema_mappings: mappings,
+        }
+    }
+
+    fn sample_insert() -> ChangeEvent {
+        let data = RowData::from_pairs(vec![
+            ("id", ColumnValue::text("1")),
+            ("name", ColumnValue::text("alice")),
+        ]);
+        ChangeEvent::insert("public", "users", 42, data, Lsn::new(0x100))
+    }
+
+    fn sample_update() -> ChangeEvent {
+        let new_data = RowData::from_pairs(vec![
+            ("id", ColumnValue::text("1")),
+            ("name", ColumnValue::text("bob")),
+        ]);
+        let old_data = RowData::from_pairs(vec![
+            ("id", ColumnValue::text("1")),
+            ("name", ColumnValue::text("alice")),
+        ]);
+        ChangeEvent::update(
+            "public",
+            "users",
+            42,
+            Some(old_data),
+            new_data,
+            ReplicaIdentity::Default,
+            vec![Arc::from("id")],
+            Lsn::new(0x101),
+        )
+    }
+
+    #[test]
+    fn render_event_insert_sql_form() {
+        let (d, m) = ctx();
+        let rc = make_render_ctx(&d, &m);
+        let event = sample_insert();
+        let result = render_event(&rc, &event, false, false).unwrap();
+        let expected = generate_sql_for_event(&rc, &event).unwrap();
+        match result {
+            RenderedStatement::Sql(s) => assert_eq!(s, expected),
+            other => panic!("expected Sql, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn render_event_insert_bulk_form_matches_legacy_parse() {
+        let (d, m) = ctx();
+        let rc = make_render_ctx(&d, &m);
+        let event = sample_insert();
+
+        let bulk_form = render_event(&rc, &event, true, false).unwrap();
+        let sql_form = match &event.event_type {
+            EventType::Insert {
+                schema,
+                table,
+                data,
+                ..
+            } => generate_insert_sql(&rc, schema, table, data).unwrap(),
+            _ => unreachable!(),
+        };
+        let parsed =
+            crate::destinations::bulk_insert::detect_bulk_insert_batch(&[sql_form]).unwrap();
+
+        match &bulk_form {
+            RenderedStatement::BulkInsert {
+                table,
+                columns,
+                rows,
+            } => {
+                assert_eq!(table, &parsed.table);
+                assert_eq!(columns, &parsed.columns);
+                assert_eq!(rows.len(), 1);
+                assert_eq!(rows[0], parsed.rows[0]);
+            }
+            other => panic!("expected BulkInsert, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn render_event_update_event_mode_returns_event() {
+        let (d, m) = ctx();
+        let rc = make_render_ctx(&d, &m);
+        let event = sample_update();
+        let result = render_event(&rc, &event, false, true).unwrap();
+        match result {
+            RenderedStatement::Event(_) => {}
+            other => panic!("expected Event, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn render_event_relation_event_mode_is_noop() {
+        let (d, m) = ctx();
+        let rc = make_render_ctx(&d, &m);
+        // Begin is one of the non-DML event types -> NoOp in event mode.
+        let event = ChangeEvent {
+            event_type: EventType::Begin {
+                transaction_id: 1,
+                final_lsn: Lsn::new(0x200),
+                commit_timestamp: chrono::Utc::now(),
+            },
+            lsn: Lsn::new(0x200),
+            metadata: None,
+        };
+        let result = render_event(&rc, &event, false, true).unwrap();
+        assert!(matches!(result, RenderedStatement::NoOp));
+    }
+
+    #[test]
+    fn render_event_truncate_sql_form() {
+        let (d, m) = ctx();
+        let rc = make_render_ctx(&d, &m);
+        let event = ChangeEvent {
+            event_type: EventType::Truncate(vec![Arc::from("public.users")]),
+            lsn: Lsn::new(0x300),
+            metadata: None,
+        };
+        let result = render_event(&rc, &event, false, false).unwrap();
+        let expected = generate_sql_for_event(&rc, &event).unwrap();
+        match result {
+            RenderedStatement::Sql(s) => assert_eq!(s, expected),
+            other => panic!("expected Sql, got {:?}", other),
+        }
+    }
+
+    fn bulk(table: &str, columns: &[&str], rows: Vec<Vec<&str>>) -> RenderedStatement {
+        RenderedStatement::BulkInsert {
+            table: table.to_string(),
+            columns: columns.iter().map(|s| s.to_string()).collect(),
+            rows: rows
+                .into_iter()
+                .map(|r| r.into_iter().map(|s| s.to_string()).collect())
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn coalesce_empty_returns_none() {
+        assert!(coalesce_bulk_inserts(&[]).is_none());
+    }
+
+    #[test]
+    fn coalesce_first_sql_returns_none() {
+        let items = vec![RenderedStatement::Sql(
+            "INSERT INTO x VALUES (1);".to_string(),
+        )];
+        assert!(coalesce_bulk_inserts(&items).is_none());
+    }
+
+    #[test]
+    fn coalesce_single_bulk() {
+        let items = vec![bulk("`t`", &["`a`"], vec![vec!["1"]])];
+        let (out, consumed) = coalesce_bulk_inserts(&items).unwrap();
+        assert_eq!(consumed, 1);
+        match out {
+            RenderedStatement::BulkInsert { rows, .. } => assert_eq!(rows.len(), 1),
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn coalesce_three_same_table() {
+        let items = vec![
+            bulk("`t`", &["`a`"], vec![vec!["1"]]),
+            bulk("`t`", &["`a`"], vec![vec!["2"]]),
+            bulk("`t`", &["`a`"], vec![vec!["3"]]),
+        ];
+        let (out, consumed) = coalesce_bulk_inserts(&items).unwrap();
+        assert_eq!(consumed, 3);
+        match out {
+            RenderedStatement::BulkInsert { rows, .. } => assert_eq!(rows.len(), 3),
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn coalesce_stops_at_different_table() {
+        let items = vec![
+            bulk("`t`", &["`a`"], vec![vec!["1"]]),
+            bulk("`t`", &["`a`"], vec![vec!["2"]]),
+            bulk("`other`", &["`a`"], vec![vec!["3"]]),
+        ];
+        let (out, consumed) = coalesce_bulk_inserts(&items).unwrap();
+        assert_eq!(consumed, 2);
+        match out {
+            RenderedStatement::BulkInsert { rows, .. } => assert_eq!(rows.len(), 2),
+            _ => panic!(),
+        }
+    }
+}

--- a/pg2any-lib/src/transaction_manager.rs
+++ b/pg2any-lib/src/transaction_manager.rs
@@ -36,14 +36,19 @@
 //! - Metadata in sql_received_tx/ are incomplete transactions (can be cleaned up with data files)
 //! - Metadata in sql_pending_tx/ are committed but not yet executed (must be processed)
 
+use crate::destinations::dialect::SqlDialect;
+use crate::destinations::dialects::{
+    AnsiDialect, KafkaDialect, MySqlDialect, SqlServerDialect, SqliteDialect,
+};
 use crate::destinations::{DestinationHandler, PreCommitHook};
 use crate::error::{CdcError, Result};
 use crate::lsn_tracker::{LsnTracker, SharedLsnFeedback};
 use crate::monitoring::{MetricsCollector, MetricsCollectorTrait};
 use crate::storage::{CompressionIndex, SqlStreamParser, StorageFactory, TransactionStorage};
-use crate::types::{ChangeEvent, DestinationType, EventType, Lsn, ReplicaIdentity, RowData};
+use crate::types::{ChangeEvent, DestinationType, EventType, Lsn};
 use async_compression::tokio::bufread::GzipDecoder;
 use chrono::{DateTime, Utc};
+#[cfg(test)]
 use pg_walstream::ColumnValue;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -64,6 +69,31 @@ const PENDING_TX_DIR: &str = "sql_pending_tx";
 const DATA_TX_DIR: &str = "sql_data_tx";
 /// Default buffer size for event accumulation (8MB)
 const DEFAULT_BUFFER_SIZE: usize = 8 * MB;
+
+fn dialect_for(dt: &DestinationType) -> &'static dyn SqlDialect {
+    match dt {
+        DestinationType::MySQL => {
+            static D: MySqlDialect = MySqlDialect;
+            &D
+        }
+        DestinationType::SqlServer => {
+            static D: SqlServerDialect = SqlServerDialect;
+            &D
+        }
+        DestinationType::SQLite => {
+            static D: SqliteDialect = SqliteDialect;
+            &D
+        }
+        DestinationType::Kafka => {
+            static D: KafkaDialect = KafkaDialect;
+            &D
+        }
+        DestinationType::Custom(_) => {
+            static D: AnsiDialect = AnsiDialect;
+            &D
+        }
+    }
+}
 struct BufferedEventWriter {
     /// File path being written to
     file_path: PathBuf,
@@ -266,6 +296,8 @@ pub struct TransactionManager {
     /// Whether bulk insert optimization is enabled
     /// Minimum INSERT count to trigger bulk insert path
     bulk_insert_threshold: usize,
+    /// SQL dialect for this destination (selected from `destination_type`).
+    dialect: &'static dyn SqlDialect,
 }
 
 impl TransactionManager {
@@ -273,6 +305,7 @@ impl TransactionManager {
     pub async fn new(
         base_path: impl AsRef<Path>,
         destination_type: DestinationType,
+        dialect_override: Option<&'static dyn SqlDialect>,
         segment_size_bytes: usize,
     ) -> Result<Self> {
         let base_path = base_path.as_ref().to_path_buf();
@@ -294,6 +327,8 @@ impl TransactionManager {
             base_path, destination_type, segment_size_bytes
         );
 
+        let dialect = dialect_override.unwrap_or_else(|| dialect_for(&destination_type));
+
         Ok(Self {
             base_path,
             destination_type,
@@ -305,6 +340,7 @@ impl TransactionManager {
             storage,
             event_mode: false,
             bulk_insert_threshold: 500,
+            dialect,
         })
     }
 
@@ -1075,273 +1111,43 @@ impl TransactionManager {
         Ok(())
     }
 
+    /// Build a `RenderContext` borrowing this manager's dialect + schema mappings.
+    #[inline]
+    fn render_ctx(&self) -> crate::sql_renderer::RenderContext<'_> {
+        crate::sql_renderer::RenderContext {
+            dialect: self.dialect,
+            schema_mappings: &self.schema_mappings,
+        }
+    }
+
     /// Generate SQL command for a change event
     fn generate_sql_for_event(&self, event: &ChangeEvent) -> Result<String> {
-        match &event.event_type {
-            EventType::Insert {
-                schema,
-                table,
-                data,
-                ..
-            } => self.generate_insert_sql(schema, table, data),
-            EventType::Update {
-                schema,
-                table,
-                old_data,
-                new_data,
-                replica_identity,
-                key_columns,
-                ..
-            } => self.generate_update_sql(
-                schema,
-                table,
-                new_data,
-                old_data.as_ref(),
-                replica_identity,
-                key_columns,
-            ),
-            EventType::Delete {
-                schema,
-                table,
-                old_data,
-                replica_identity,
-                key_columns,
-                ..
-            } => self.generate_delete_sql(schema, table, old_data, replica_identity, key_columns),
-            EventType::Truncate(tables) => self.generate_truncate_sql(tables),
-            _ => {
-                // Skip non-DML events
-                Ok(String::new())
-            }
-        }
-    }
-
-    /// Generate INSERT SQL command
-    ///
-    /// Accepts `&RowData` directly. Uses `iter()` for column iteration.
-    fn generate_insert_sql(&self, schema: &str, table: &str, new_data: &RowData) -> Result<String> {
-        let schema = self.map_schema(Some(schema));
-
-        // Pre-size: assume ~32 bytes per (column, value) pair + overhead
-        let mut sql = String::with_capacity(64 + new_data.len() * 48);
-        sql.push_str("INSERT INTO ");
-        self.append_qualified_table(&mut sql, schema, table);
-        sql.push_str(" (");
-        for (i, (k, _)) in new_data.iter().enumerate() {
-            if i > 0 {
-                sql.push_str(", ");
-            }
-            self.append_quoted_identifier(&mut sql, k);
-        }
-        sql.push_str(") VALUES (");
-        for (i, (_, v)) in new_data.iter().enumerate() {
-            if i > 0 {
-                sql.push_str(", ");
-            }
-            self.append_value(&mut sql, v);
-        }
-        sql.push_str(");");
-
-        Ok(sql)
-    }
-
-    /// Generate UPDATE SQL command
-    fn generate_update_sql(
-        &self,
-        schema: &str,
-        table: &str,
-        new_data: &RowData,
-        old_data: Option<&RowData>,
-        replica_identity: &ReplicaIdentity,
-        key_columns: &[Arc<str>],
-    ) -> Result<String> {
-        let schema = self.map_schema(Some(schema));
-
-        let mut sql = String::with_capacity(64 + new_data.len() * 64);
-        sql.push_str("UPDATE ");
-        self.append_qualified_table(&mut sql, schema, table);
-        sql.push_str(" SET ");
-        for (i, (col, val)) in new_data.iter().enumerate() {
-            if i > 0 {
-                sql.push_str(", ");
-            }
-            self.append_quoted_identifier(&mut sql, col);
-            sql.push_str(" = ");
-            self.append_value(&mut sql, val);
-        }
-        sql.push_str(" WHERE ");
-        self.append_where_clause(&mut sql, replica_identity, key_columns, old_data, new_data)?;
-        sql.push(';');
-
-        Ok(sql)
-    }
-
-    /// Generate DELETE SQL command
-    ///
-    /// Accepts `&RowData` directly. For Default/Index replica identity (the most
-    /// common case), this avoids cloning RowData entirely — only `RowData::get()`
-    /// lookups are performed, with zero allocations.
-    fn generate_delete_sql(
-        &self,
-        schema: &str,
-        table: &str,
-        old_data: &RowData,
-        replica_identity: &ReplicaIdentity,
-        key_columns: &[Arc<str>],
-    ) -> Result<String> {
-        let schema = self.map_schema(Some(schema));
-
-        let mut sql = String::with_capacity(64 + key_columns.len() * 32);
-        sql.push_str("DELETE FROM ");
-        self.append_qualified_table(&mut sql, schema, table);
-        sql.push_str(" WHERE ");
-        self.append_where_clause(
-            &mut sql,
-            replica_identity,
-            key_columns,
-            Some(old_data),
-            old_data,
-        )?;
-        sql.push(';');
-
-        Ok(sql)
+        crate::sql_renderer::generate_sql_for_event(&self.render_ctx(), event)
     }
 
     /// Generate TRUNCATE SQL command
+    #[cfg(test)]
     fn generate_truncate_sql(&self, tables: &[Arc<str>]) -> Result<String> {
-        // Build all TRUNCATE statements into a single `String` — no intermediate Vec.
-        // Pre-size for ~48 bytes per table (keyword + identifiers + punctuation).
-        let mut sql = String::with_capacity(tables.len() * 48);
-
-        for (i, table_spec) in tables.iter().enumerate() {
-            let table_spec: &str = table_spec;
-            let (schema, table) = match table_spec.split_once('.') {
-                Some((s, t)) if !t.contains('.') => (self.map_schema(Some(s)), t),
-                _ => (self.map_schema(Some("public")), table_spec),
-            };
-
-            if i > 0 {
-                sql.push('\n');
-            }
-            match self.destination_type {
-                DestinationType::MySQL | DestinationType::SqlServer => {
-                    sql.push_str("TRUNCATE TABLE ");
-                    self.append_quoted_identifier(&mut sql, &schema);
-                    sql.push('.');
-                    self.append_quoted_identifier(&mut sql, table);
-                    sql.push(';');
-                }
-                DestinationType::SQLite => {
-                    sql.push_str("DELETE FROM ");
-                    self.append_quoted_identifier(&mut sql, table);
-                    sql.push(';');
-                }
-                DestinationType::Kafka => {}
-            }
-        }
-
-        Ok(sql)
-    }
-
-    /// Append WHERE clause conditions directly into the provided buffer
-    fn append_where_clause(
-        &self,
-        out: &mut String,
-        replica_identity: &ReplicaIdentity,
-        key_columns: &[Arc<str>],
-        old_data: Option<&RowData>,
-        new_data: &RowData,
-    ) -> Result<()> {
-        match replica_identity {
-            ReplicaIdentity::Default | ReplicaIdentity::Index => {
-                let data = old_data.unwrap_or(new_data);
-                for (i, col) in key_columns.iter().enumerate() {
-                    if i > 0 {
-                        out.push_str(" AND ");
-                    }
-                    let col_str: &str = col;
-                    let val = data.get(col_str).ok_or_else(|| {
-                        CdcError::Generic(format!("Key column {col_str} not found"))
-                    })?;
-                    self.append_quoted_identifier(out, col_str);
-                    out.push_str(" = ");
-                    self.append_value(out, val);
-                }
-            }
-            ReplicaIdentity::Full => {
-                let data = old_data.ok_or_else(|| {
-                    CdcError::Generic("FULL replica identity requires old data".to_string())
-                })?;
-                for (i, (col, val)) in data.iter().enumerate() {
-                    if i > 0 {
-                        out.push_str(" AND ");
-                    }
-                    self.append_quoted_identifier(out, col);
-                    if val.is_null() {
-                        out.push_str(" IS NULL");
-                    } else {
-                        out.push_str(" = ");
-                        self.append_value(out, val);
-                    }
-                }
-            }
-            ReplicaIdentity::Nothing => {
-                return Err(CdcError::Generic(
-                    "Cannot generate WHERE clause with NOTHING replica identity".to_string(),
-                ));
-            }
-        }
-        Ok(())
+        crate::sql_renderer::generate_truncate_sql(&self.render_ctx(), tables)
     }
 
     /// Append a quoted qualified table `schema.table` (or just table for SQLite) to `out`.
     #[inline]
+    #[cfg(test)]
     fn append_qualified_table(&self, out: &mut String, schema: &str, table: &str) {
-        match self.destination_type {
-            DestinationType::MySQL | DestinationType::SqlServer => {
-                self.append_quoted_identifier(out, schema);
-                out.push('.');
-                self.append_quoted_identifier(out, table);
-            }
-            DestinationType::SQLite => {
-                self.append_quoted_identifier(out, table);
-            }
-            DestinationType::Kafka => {
-                self.append_quoted_identifier(out, table);
-            }
-        }
+        self.dialect.qualify_table(schema, table, out);
     }
 
     /// Append a quoted identifier (schema/table/column) to `out`, performing
     /// destination-specific escaping of embedded quote characters.
     #[inline]
+    #[cfg(test)]
     fn append_quoted_identifier(&self, out: &mut String, name: &str) {
-        let (open, close, escape_ch) = match self.destination_type {
-            DestinationType::MySQL => ('`', '`', '`'),
-            DestinationType::SqlServer => ('[', ']', ']'),
-            DestinationType::SQLite | DestinationType::Kafka => ('"', '"', '"'),
-        };
-        out.reserve(name.len() + 2);
-        out.push(open);
-        if name.as_bytes().contains(&(escape_ch as u8)) {
-            for ch in name.chars() {
-                if ch == escape_ch {
-                    out.push(escape_ch);
-                }
-                out.push(ch);
-            }
-        } else {
-            out.push_str(name);
-        }
-        out.push(close);
+        self.dialect.quote_identifier(name, out);
     }
 
     /// Escape a database identifier (schema, table, or column name) for safe
     /// inclusion in generated SQL, preventing SQL injection via malicious names.
-    ///
-    /// - MySQL:      wraps in backticks, doubling any embedded backticks.
-    /// - SQL Server: wraps in brackets, doubling any embedded closing brackets.
-    /// - SQLite:     wraps in double quotes, doubling any embedded double quotes.
     #[cfg(test)]
     fn quote_identifier(&self, name: &str) -> String {
         let mut out = String::with_capacity(name.len() + 2);
@@ -1350,97 +1156,23 @@ impl TransactionManager {
     }
 
     /// Append a hex literal for raw bytes directly into `out`.
+    #[cfg(test)]
     fn append_hex_literal(&self, out: &mut String, bytes: &[u8]) {
-        static HEX: &[u8; 16] = b"0123456789abcdef";
-        let (prefix, suffix) = match self.destination_type {
-            DestinationType::SqlServer => ("0x", ""),
-            DestinationType::MySQL | DestinationType::SQLite | DestinationType::Kafka => {
-                ("X'", "'")
-            }
-        };
-        out.reserve(prefix.len() + bytes.len() * 2 + suffix.len());
-        out.push_str(prefix);
-        // Safety: we only push ASCII hex chars + prefix/suffix which are ASCII.
-        let buf = unsafe { out.as_mut_vec() };
-        for &b in bytes {
-            buf.push(HEX[(b >> 4) as usize]);
-            buf.push(HEX[(b & 0x0f) as usize]);
-        }
-        out.push_str(suffix);
+        self.dialect.render_hex_literal(bytes, out);
     }
 
     /// Append a `ColumnValue` literal directly into `out`.
+    #[cfg(test)]
     fn append_value(&self, out: &mut String, value: &ColumnValue) {
-        match value {
-            ColumnValue::Null => out.push_str("NULL"),
-            ColumnValue::Text(_) => match value.as_str() {
-                Some(s) => {
-                    if s == "t" {
-                        out.push('1');
-                        return;
-                    }
-                    if s == "f" {
-                        out.push('0');
-                        return;
-                    }
-                    out.reserve(s.len() + 2);
-                    out.push('\'');
-                    let escape_backslash = matches!(self.destination_type, DestinationType::MySQL);
-                    let needs_escape = if escape_backslash {
-                        s.as_bytes().iter().any(|&b| b == b'\'' || b == b'\\')
-                    } else {
-                        s.as_bytes().contains(&b'\'')
-                    };
-                    if needs_escape {
-                        for ch in s.chars() {
-                            match ch {
-                                '\'' => out.push_str("''"),
-                                '\\' if escape_backslash => out.push_str("\\\\"),
-                                _ => out.push(ch),
-                            }
-                        }
-                    } else {
-                        out.push_str(s);
-                    }
-                    out.push('\'');
-                }
-                None => {
-                    self.append_hex_literal(out, value.as_bytes());
-                }
-            },
-            ColumnValue::Binary(_) => self.append_hex_literal(out, value.as_bytes()),
-        }
+        self.dialect.render_value(value, out);
     }
 
     /// Format a `ColumnValue` as a SQL literal.
-    ///
-    /// Handles the three upstream variants correctly:
-    /// - `Null`   → SQL `NULL`
-    /// - `Text`   → UTF-8 string; PostgreSQL pgoutput booleans (`"t"` / `"f"`)
-    ///              are converted to `1` / `0`. All other text is always quoted
-    ///              to preserve values like leading-zero strings (e.g. zip codes).
-    ///              Falls back to a hex literal when the payload is not valid UTF-8.
-    /// - `Binary` → destination-specific hex literal (`X'…'` or `0x…`).
     #[cfg(test)]
     fn format_value(&self, value: &ColumnValue) -> String {
         let mut out = String::new();
         self.append_value(&mut out, value);
         out
-    }
-
-    /// Map source schema to destination schema.
-    ///
-    /// Returns a borrow from the mapping table, the caller's input, or the
-    /// `"public"` literal — no per-call allocation.
-    fn map_schema<'a>(&'a self, source_schema: Option<&'a str>) -> &'a str {
-        match source_schema {
-            Some(schema) => self
-                .schema_mappings
-                .get(schema)
-                .map(String::as_str)
-                .unwrap_or(schema),
-            None => "public",
-        }
     }
 }
 
@@ -2273,7 +2005,7 @@ mod tests {
             std::process::id()
         ));
         let _ = tokio::fs::create_dir_all(&dir).await;
-        TransactionManager::new(&dir, dest, 10 * 1024 * 1024)
+        TransactionManager::new(&dir, dest, None, 10 * 1024 * 1024)
             .await
             .expect("test manager creation should succeed")
     }
@@ -2458,5 +2190,302 @@ mod tests {
     async fn test_empty_string_is_quoted() {
         let mgr = test_manager(DestinationType::MySQL).await;
         assert_eq!(mgr.format_value(&ColumnValue::text("")), "''");
+    }
+
+    // ── Dialect snapshot safety net ─────────────────────────────────
+    //
+    // These five tests pin byte-exact output of the dialect-leaking helpers
+    // (`append_quoted_identifier`, `append_value`, `append_qualified_table`,
+    // `append_hex_literal`, `generate_truncate_sql`) across every
+    // `DestinationType`. They exist to gate the upcoming `SqlDialect`
+    // extraction refactor: any change in observable SQL output will fail
+    // these tests. Expected strings were captured verbatim from the current
+    // implementation — do not hand-edit, regenerate from the scratch test.
+
+    fn all_dests() -> [(&'static str, DestinationType); 5] {
+        [
+            ("MySQL", DestinationType::MySQL),
+            ("SqlServer", DestinationType::SqlServer),
+            ("SQLite", DestinationType::SQLite),
+            ("Kafka", DestinationType::Kafka),
+            ("Custom", DestinationType::Custom("test".to_string())),
+        ]
+    }
+
+    #[tokio::test]
+    async fn snapshot_quote_identifier() {
+        let ids = ["users", "back`tick", "bra]cket", "double\"quote"];
+        let expected: &[(&str, [&str; 4])] = &[
+            // MySQL — backtick quoting, only backticks escaped
+            (
+                "MySQL",
+                ["`users`", "`back``tick`", "`bra]cket`", "`double\"quote`"],
+            ),
+            // SqlServer — bracket quoting, only `]` escaped
+            (
+                "SqlServer",
+                ["[users]", "[back`tick]", "[bra]]cket]", "[double\"quote]"],
+            ),
+            // SQLite — double-quote quoting, only `"` escaped
+            (
+                "SQLite",
+                [
+                    "\"users\"",
+                    "\"back`tick\"",
+                    "\"bra]cket\"",
+                    "\"double\"\"quote\"",
+                ],
+            ),
+            // Kafka — double-quote quoting (same as SQLite)
+            (
+                "Kafka",
+                [
+                    "\"users\"",
+                    "\"back`tick\"",
+                    "\"bra]cket\"",
+                    "\"double\"\"quote\"",
+                ],
+            ),
+            // Custom — double-quote quoting (same as SQLite)
+            (
+                "Custom",
+                [
+                    "\"users\"",
+                    "\"back`tick\"",
+                    "\"bra]cket\"",
+                    "\"double\"\"quote\"",
+                ],
+            ),
+        ];
+        for (name, dest) in all_dests().iter() {
+            let mgr = test_manager(dest.clone()).await;
+            let row = expected.iter().find(|(n, _)| n == name).unwrap();
+            for (i, id) in ids.iter().enumerate() {
+                assert_eq!(
+                    mgr.quote_identifier(id),
+                    row.1[i],
+                    "quote_identifier({:?}) for {}",
+                    id,
+                    name
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn snapshot_format_value() {
+        use bytes::Bytes;
+        let vals: Vec<(&str, ColumnValue)> = vec![
+            ("Null", ColumnValue::Null),
+            ("text_t", ColumnValue::text("t")),
+            ("text_f", ColumnValue::text("f")),
+            ("text_hello", ColumnValue::text("hello")),
+            ("text_oreilly", ColumnValue::text("o'reilly")),
+            ("text_backslash", ColumnValue::text("back\\slash")),
+            (
+                "binary",
+                ColumnValue::Binary(Bytes::from_static(&[0x00, 0xff, 0xab])),
+            ),
+        ];
+        let expected: &[(&str, [&str; 7])] = &[
+            // MySQL — pgoutput booleans → 1/0, single quotes doubled, backslash doubled, binary → X'…'
+            (
+                "MySQL",
+                [
+                    "NULL",
+                    "1",
+                    "0",
+                    "'hello'",
+                    "'o''reilly'",
+                    "'back\\\\slash'",
+                    "X'00ffab'",
+                ],
+            ),
+            // SqlServer — booleans → 1/0, single quote doubled, backslash NOT doubled, binary → 0x…
+            (
+                "SqlServer",
+                [
+                    "NULL",
+                    "1",
+                    "0",
+                    "'hello'",
+                    "'o''reilly'",
+                    "'back\\slash'",
+                    "0x00ffab",
+                ],
+            ),
+            // SQLite — booleans → 1/0, single quote doubled, backslash NOT doubled, binary → X'…'
+            (
+                "SQLite",
+                [
+                    "NULL",
+                    "1",
+                    "0",
+                    "'hello'",
+                    "'o''reilly'",
+                    "'back\\slash'",
+                    "X'00ffab'",
+                ],
+            ),
+            // Kafka — same as SQLite (text formatting path is not dialect-specific outside MySQL)
+            (
+                "Kafka",
+                [
+                    "NULL",
+                    "1",
+                    "0",
+                    "'hello'",
+                    "'o''reilly'",
+                    "'back\\slash'",
+                    "X'00ffab'",
+                ],
+            ),
+            // Custom — same as SQLite
+            (
+                "Custom",
+                [
+                    "NULL",
+                    "1",
+                    "0",
+                    "'hello'",
+                    "'o''reilly'",
+                    "'back\\slash'",
+                    "X'00ffab'",
+                ],
+            ),
+        ];
+        for (name, dest) in all_dests().iter() {
+            let mgr = test_manager(dest.clone()).await;
+            let row = expected.iter().find(|(n, _)| n == name).unwrap();
+            for (i, (vname, val)) in vals.iter().enumerate() {
+                assert_eq!(
+                    mgr.format_value(val),
+                    row.1[i],
+                    "format_value({}) for {}",
+                    vname,
+                    name
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn snapshot_qualified_table() {
+        let tables = [("public", "users"), ("custom", "items")];
+        let expected: &[(&str, [&str; 2])] = &[
+            // MySQL — schema.table both backticked
+            ("MySQL", ["`public`.`users`", "`custom`.`items`"]),
+            // SqlServer — schema.table both bracketed
+            ("SqlServer", ["[public].[users]", "[custom].[items]"]),
+            // SQLite — schema dropped, table-only
+            ("SQLite", ["\"users\"", "\"items\""]),
+            // Kafka — schema dropped, table-only (same as SQLite)
+            ("Kafka", ["\"users\"", "\"items\""]),
+            // Custom — schema.table both double-quoted (schema preserved)
+            ("Custom", ["\"public\".\"users\"", "\"custom\".\"items\""]),
+        ];
+        for (name, dest) in all_dests().iter() {
+            let mgr = test_manager(dest.clone()).await;
+            let row = expected.iter().find(|(n, _)| n == name).unwrap();
+            for (i, (s, t)) in tables.iter().enumerate() {
+                let mut out = String::new();
+                mgr.append_qualified_table(&mut out, s, t);
+                assert_eq!(
+                    out, row.1[i],
+                    "append_qualified_table({}.{}) for {}",
+                    s, t, name
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn snapshot_hex_literal() {
+        let blobs: Vec<(&str, Vec<u8>)> = vec![
+            ("empty", vec![]),
+            ("deadbeef", vec![0xde, 0xad, 0xbe, 0xef]),
+        ];
+        let expected: &[(&str, [&str; 2])] = &[
+            // MySQL — X'…' literal
+            ("MySQL", ["X''", "X'deadbeef'"]),
+            // SqlServer — 0x… literal (no prefix/suffix quotes)
+            ("SqlServer", ["0x", "0xdeadbeef"]),
+            // SQLite — X'…' literal
+            ("SQLite", ["X''", "X'deadbeef'"]),
+            // Kafka — X'…' literal
+            ("Kafka", ["X''", "X'deadbeef'"]),
+            // Custom — X'…' literal
+            ("Custom", ["X''", "X'deadbeef'"]),
+        ];
+        for (name, dest) in all_dests().iter() {
+            let mgr = test_manager(dest.clone()).await;
+            let row = expected.iter().find(|(n, _)| n == name).unwrap();
+            for (i, (bname, bytes)) in blobs.iter().enumerate() {
+                let mut out = String::new();
+                mgr.append_hex_literal(&mut out, bytes);
+                assert_eq!(out, row.1[i], "append_hex_literal({}) for {}", bname, name);
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn snapshot_truncate_sql() {
+        let inputs: Vec<(&str, Vec<Arc<str>>)> = vec![
+            ("public.users", vec![Arc::from("public.users")]),
+            ("users_bare", vec![Arc::from("users")]),
+            ("two_tables", vec![Arc::from("a.b"), Arc::from("c.d")]),
+        ];
+        let expected: &[(&str, [&str; 3])] = &[
+            // MySQL — TRUNCATE TABLE `schema`.`table`; bare-name implicitly `public`
+            (
+                "MySQL",
+                [
+                    "TRUNCATE TABLE `public`.`users`;",
+                    "TRUNCATE TABLE `public`.`users`;",
+                    "TRUNCATE TABLE `a`.`b`;\nTRUNCATE TABLE `c`.`d`;",
+                ],
+            ),
+            // SqlServer — TRUNCATE TABLE [schema].[table];
+            (
+                "SqlServer",
+                [
+                    "TRUNCATE TABLE [public].[users];",
+                    "TRUNCATE TABLE [public].[users];",
+                    "TRUNCATE TABLE [a].[b];\nTRUNCATE TABLE [c].[d];",
+                ],
+            ),
+            // SQLite — DELETE FROM "table"; (schema dropped)
+            (
+                "SQLite",
+                [
+                    "DELETE FROM \"users\";",
+                    "DELETE FROM \"users\";",
+                    "DELETE FROM \"b\";\nDELETE FROM \"d\";",
+                ],
+            ),
+            // Kafka — no-op: empty string per table (no statements emitted)
+            ("Kafka", ["", "", ""]),
+            // Custom — TRUNCATE TABLE "schema"."table";
+            (
+                "Custom",
+                [
+                    "TRUNCATE TABLE \"public\".\"users\";",
+                    "TRUNCATE TABLE \"public\".\"users\";",
+                    "TRUNCATE TABLE \"a\".\"b\";\nTRUNCATE TABLE \"c\".\"d\";",
+                ],
+            ),
+        ];
+        for (name, dest) in all_dests().iter() {
+            let mgr = test_manager(dest.clone()).await;
+            let row = expected.iter().find(|(n, _)| n == name).unwrap();
+            for (i, (iname, tables)) in inputs.iter().enumerate() {
+                let out = mgr.generate_truncate_sql(tables).unwrap();
+                assert_eq!(
+                    out, row.1[i],
+                    "generate_truncate_sql({}) for {}",
+                    iname, name
+                );
+            }
+        }
     }
 }

--- a/pg2any-lib/src/types.rs
+++ b/pg2any-lib/src/types.rs
@@ -9,16 +9,26 @@ pub enum DestinationType {
     SqlServer,
     SQLite,
     Kafka,
+    /// Externally registered destination identified by registry key
+    Custom(String),
+}
+
+impl DestinationType {
+    /// Returns the registry key used to look up this destination's factory.
+    pub fn registry_key(&self) -> &str {
+        match self {
+            DestinationType::MySQL => "mysql",
+            DestinationType::SqlServer => "sqlserver",
+            DestinationType::SQLite => "sqlite",
+            DestinationType::Kafka => "kafka",
+            DestinationType::Custom(key) => key.as_str(),
+        }
+    }
 }
 
 impl std::fmt::Display for DestinationType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            DestinationType::MySQL => write!(f, "mysql"),
-            DestinationType::SqlServer => write!(f, "sqlserver"),
-            DestinationType::SQLite => write!(f, "sqlite"),
-            DestinationType::Kafka => write!(f, "kafka"),
-        }
+        f.write_str(self.registry_key())
     }
 }
 

--- a/pg2any-lib/tests/custom_destination_tests.rs
+++ b/pg2any-lib/tests/custom_destination_tests.rs
@@ -1,0 +1,181 @@
+//! Tests for the pluggable destination registry on `Config`.
+
+use async_trait::async_trait;
+use pg2any_lib::destinations::{DestinationHandler, PreCommitHook};
+use pg2any_lib::{Config, ConfigBuilder, DestinationType};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+type Recorder = Arc<Mutex<Vec<String>>>;
+
+struct MockHandler {
+    calls: Recorder,
+}
+
+impl MockHandler {
+    fn new(calls: Recorder) -> Self {
+        Self { calls }
+    }
+
+    fn record(&self, s: impl Into<String>) {
+        self.calls.lock().unwrap().push(s.into());
+    }
+}
+
+#[async_trait]
+impl DestinationHandler for MockHandler {
+    async fn connect(&mut self, _connection_string: &str) -> pg2any_lib::CdcResult<()> {
+        self.record("connect");
+        Ok(())
+    }
+
+    fn set_schema_mappings(&mut self, _mappings: HashMap<String, String>) {}
+
+    async fn execute_sql_batch_with_hook(
+        &mut self,
+        commands: &[String],
+        pre_commit_hook: Option<PreCommitHook>,
+    ) -> pg2any_lib::CdcResult<()> {
+        self.record(format!("execute_sql_batch_with_hook:{}", commands.len()));
+        if let Some(hook) = pre_commit_hook {
+            hook().await?;
+            self.record("hook_invoked");
+        }
+        Ok(())
+    }
+
+    async fn close(&mut self) -> pg2any_lib::CdcResult<()> {
+        self.record("close");
+        Ok(())
+    }
+}
+
+fn base_builder() -> ConfigBuilder {
+    Config::builder()
+        .source_connection_string("postgres://localhost/src")
+        .destination_connection_string("custom://nowhere")
+}
+
+#[tokio::test]
+async fn test_custom_destination_via_registry() {
+    let calls: Recorder = Arc::new(Mutex::new(Vec::new()));
+    let calls_for_factory = calls.clone();
+
+    let config = base_builder()
+        .custom_destination(move || MockHandler::new(calls_for_factory.clone()))
+        .build()
+        .expect("config builds");
+
+    assert!(matches!(
+        config.destination_type,
+        DestinationType::Custom(_)
+    ));
+
+    let mut handler = config
+        .create_destination()
+        .expect("factory returns handler");
+
+    handler.connect("custom://nowhere").await.unwrap();
+
+    let hook_flag: Arc<Mutex<bool>> = Arc::new(Mutex::new(false));
+    let hook_flag_inner = hook_flag.clone();
+    let hook: PreCommitHook = Box::new(move || {
+        let flag = hook_flag_inner.clone();
+        Box::pin(async move {
+            *flag.lock().unwrap() = true;
+            Ok(())
+        })
+    });
+
+    handler
+        .execute_sql_batch_with_hook(&["INSERT INTO t VALUES (1)".to_string()], Some(hook))
+        .await
+        .unwrap();
+
+    handler.close().await.unwrap();
+
+    assert!(*hook_flag.lock().unwrap(), "pre_commit_hook ran");
+
+    let recorded = calls.lock().unwrap().clone();
+    assert_eq!(
+        recorded,
+        vec![
+            "connect".to_string(),
+            "execute_sql_batch_with_hook:1".to_string(),
+            "hook_invoked".to_string(),
+            "close".to_string(),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn test_builtin_destinations_via_registry() {
+    #[cfg(feature = "mysql")]
+    {
+        let cfg = base_builder()
+            .destination_type(DestinationType::MySQL)
+            .build()
+            .unwrap();
+        assert!(cfg.create_destination().is_ok());
+    }
+    #[cfg(feature = "sqlserver")]
+    {
+        let cfg = base_builder()
+            .destination_type(DestinationType::SqlServer)
+            .build()
+            .unwrap();
+        assert!(cfg.create_destination().is_ok());
+    }
+    #[cfg(feature = "sqlite")]
+    {
+        let cfg = base_builder()
+            .destination_type(DestinationType::SQLite)
+            .build()
+            .unwrap();
+        assert!(cfg.create_destination().is_ok());
+    }
+    #[cfg(feature = "kafka")]
+    {
+        let cfg = base_builder()
+            .destination_type(DestinationType::Kafka)
+            .build()
+            .unwrap();
+        assert!(cfg.create_destination().is_ok());
+    }
+}
+
+#[tokio::test]
+async fn test_custom_variant_missing_registration_errors() {
+    let cfg = base_builder()
+        .destination_type(DestinationType::Custom("not-registered".to_string()))
+        .build()
+        .unwrap();
+
+    let err = match cfg.create_destination() {
+        Ok(_) => panic!("expected create_destination to fail for unregistered key"),
+        Err(e) => e,
+    };
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("not-registered"),
+        "error mentions missing key: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn test_config_clone_preserves_registry() {
+    let calls: Recorder = Arc::new(Mutex::new(Vec::new()));
+    let calls_for_factory = calls.clone();
+
+    let config = base_builder()
+        .custom_destination(move || MockHandler::new(calls_for_factory.clone()))
+        .build()
+        .unwrap();
+
+    let cloned = config.clone();
+    let mut handler = cloned.create_destination().expect("clone has registry");
+    handler.connect("ignored").await.unwrap();
+
+    let recorded = calls.lock().unwrap().clone();
+    assert_eq!(recorded, vec!["connect".to_string()]);
+}

--- a/pg2any-lib/tests/destination_integration_tests.rs
+++ b/pg2any-lib/tests/destination_integration_tests.rs
@@ -1,10 +1,16 @@
 use pg2any_lib::{
-    destinations::{mysql::MySQLDestination, sqlserver::SqlServerDestination, DestinationFactory},
+    destinations::{mysql::MySQLDestination, sqlserver::SqlServerDestination, DestinationHandler},
     types::{ChangeEvent, EventType, ReplicaIdentity},
     DestinationType,
 };
 use pg_walstream::{ColumnValue, Lsn, RowData};
 use std::sync::Arc;
+
+fn make(dt: DestinationType) -> pg2any_lib::CdcResult<Box<dyn DestinationHandler>> {
+    let mut cfg = pg2any_lib::Config::default();
+    cfg.destination_type = dt;
+    cfg.create_destination()
+}
 
 /// Test that destination handlers have consistent interfaces
 #[tokio::test]
@@ -17,7 +23,7 @@ async fn test_destination_handler_interface() {
 
     #[cfg(feature = "mysql")]
     {
-        let mut destination = DestinationFactory::create(&DestinationType::MySQL).unwrap();
+        let mut destination = make(DestinationType::MySQL).unwrap();
 
         // Test execute_sql_batch interface with empty batch (should succeed)
         let empty_batch_result = destination.execute_sql_batch_with_hook(&[], None).await;
@@ -37,7 +43,7 @@ async fn test_destination_handler_interface() {
 
     #[cfg(feature = "sqlserver")]
     {
-        let mut destination = DestinationFactory::create(&DestinationType::SqlServer).unwrap();
+        let mut destination = make(DestinationType::SqlServer).unwrap();
 
         // Test execute_sql_batch interface with empty batch (should succeed)
         let empty_batch_result = destination.execute_sql_batch_with_hook(&[], None).await;
@@ -88,14 +94,14 @@ fn test_unsupported_destination_types() {
     // SQLite is now supported, so it should succeed
     #[cfg(feature = "sqlite")]
     {
-        let sqlite_result = DestinationFactory::create(&DestinationType::SQLite);
+        let sqlite_result = make(DestinationType::SQLite);
         assert!(sqlite_result.is_ok());
     }
 
     // If SQLite feature is not enabled, it should fail
     #[cfg(not(feature = "sqlite"))]
     {
-        let sqlite_result = DestinationFactory::create(&DestinationType::SQLite);
+        let sqlite_result = make(DestinationType::SQLite);
         assert!(sqlite_result.is_err());
     }
 }

--- a/pg2any-lib/tests/graceful_shutdown_integration_tests.rs
+++ b/pg2any-lib/tests/graceful_shutdown_integration_tests.rs
@@ -86,9 +86,14 @@ async fn setup_pending_transaction_with_events(
     event_count: usize,
 ) -> (Arc<TransactionManager>, PendingTransactionFile) {
     let manager = Arc::new(
-        TransactionManager::new(temp_dir.path(), DestinationType::MySQL, 64 * 1024 * 1024)
-            .await
-            .unwrap(),
+        TransactionManager::new(
+            temp_dir.path(),
+            DestinationType::MySQL,
+            None,
+            64 * 1024 * 1024,
+        )
+        .await
+        .unwrap(),
     );
 
     let timestamp = Utc::now();
@@ -221,9 +226,14 @@ async fn test_incomplete_transaction_not_in_pending() {
     let temp_dir = TempDir::new().unwrap();
 
     let manager = Arc::new(
-        TransactionManager::new(temp_dir.path(), DestinationType::MySQL, 64 * 1024 * 1024)
-            .await
-            .unwrap(),
+        TransactionManager::new(
+            temp_dir.path(),
+            DestinationType::MySQL,
+            None,
+            64 * 1024 * 1024,
+        )
+        .await
+        .unwrap(),
     );
 
     let timestamp = Utc::now();
@@ -332,9 +342,14 @@ async fn test_mid_batch_cancellation_completes_drain() {
     let lsn_path = lsn_file.to_str().unwrap();
 
     let manager = Arc::new(
-        TransactionManager::new(temp_dir.path(), DestinationType::MySQL, 64 * 1024 * 1024)
-            .await
-            .unwrap(),
+        TransactionManager::new(
+            temp_dir.path(),
+            DestinationType::MySQL,
+            None,
+            64 * 1024 * 1024,
+        )
+        .await
+        .unwrap(),
     );
 
     let mut pending_txs = Vec::new();
@@ -400,9 +415,14 @@ async fn test_committed_but_undelivered_recovered_on_restart() {
     let lsn_path = lsn_file.to_str().unwrap();
 
     let manager = Arc::new(
-        TransactionManager::new(temp_dir.path(), DestinationType::MySQL, 64 * 1024 * 1024)
-            .await
-            .unwrap(),
+        TransactionManager::new(
+            temp_dir.path(),
+            DestinationType::MySQL,
+            None,
+            64 * 1024 * 1024,
+        )
+        .await
+        .unwrap(),
     );
 
     let timestamp = Utc::now();
@@ -518,9 +538,14 @@ async fn test_drain_on_error_preserves_file_for_recovery() {
     let lsn_path = lsn_file.to_str().unwrap();
 
     let manager = Arc::new(
-        TransactionManager::new(temp_dir.path(), DestinationType::MySQL, 64 * 1024 * 1024)
-            .await
-            .unwrap(),
+        TransactionManager::new(
+            temp_dir.path(),
+            DestinationType::MySQL,
+            None,
+            64 * 1024 * 1024,
+        )
+        .await
+        .unwrap(),
     );
 
     let mut pending_txs = Vec::new();

--- a/pg2any-lib/tests/graceful_shutdown_tests.rs
+++ b/pg2any-lib/tests/graceful_shutdown_tests.rs
@@ -59,9 +59,14 @@ async fn test_lsn_zero_is_ignored() {
 async fn test_transaction_file_lifecycle() {
     let temp_dir = TempDir::new().unwrap();
     let manager = Arc::new(
-        TransactionManager::new(temp_dir.path(), DestinationType::MySQL, 64 * 1024 * 1024)
-            .await
-            .unwrap(),
+        TransactionManager::new(
+            temp_dir.path(),
+            DestinationType::MySQL,
+            None,
+            64 * 1024 * 1024,
+        )
+        .await
+        .unwrap(),
     );
 
     // Directories should have been created

--- a/pg2any-lib/tests/kafka_destination_tests.rs
+++ b/pg2any-lib/tests/kafka_destination_tests.rs
@@ -3,11 +3,12 @@ mod kafka_tests {
     use pg2any_lib::destinations::destination_factory::DestinationHandler;
     use pg2any_lib::destinations::kafka::KafkaDestination;
     use pg2any_lib::types::DestinationType;
-    use pg2any_lib::DestinationFactory;
 
     #[test]
     fn test_destination_factory_creates_kafka() {
-        let result = DestinationFactory::create(&DestinationType::Kafka);
+        let mut cfg = pg2any_lib::Config::default();
+        cfg.destination_type = DestinationType::Kafka;
+        let result = cfg.create_destination();
         assert!(result.is_ok());
     }
 

--- a/pg2any-lib/tests/shutdown_no_replay_regression_tests.rs
+++ b/pg2any-lib/tests/shutdown_no_replay_regression_tests.rs
@@ -1,0 +1,115 @@
+//! Regression test for the shutdown / no-replay invariant.
+//!
+//! We use the simpler unit-style approach (per the spec): construct a
+//! `PendingTransactionFile` whose `commit_lsn` is already covered by the
+//! `LsnTracker`'s `flush_lsn`, invoke `process_transaction_file`, and assert
+//! that the destination handler is NOT invoked. This exercises the core
+//! "already-applied" skip path in `transaction_manager.rs:1763` that prevents
+//! replay after a crash/restart at the on-disk LSN.
+//!
+//! Wiring up a full producer/consumer integration would require significant
+//! scaffolding for the LogicalReplicationStream; the unit-style test covers
+//! the actual anti-replay invariant from requirement #5 directly.
+
+use async_trait::async_trait;
+use chrono::Utc;
+use pg2any_lib::destinations::{DestinationHandler, PreCommitHook};
+use pg2any_lib::transaction_manager::{
+    PendingTransactionFile, TransactionFileMetadata, TransactionManager,
+};
+use pg2any_lib::{DestinationType, LsnTracker, MetricsCollectorTrait, SharedLsnFeedback};
+use pg_walstream::Lsn;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use tempfile::tempdir;
+use tokio_util::sync::CancellationToken;
+
+type ApplyLog = Arc<Mutex<Vec<(u32, Option<Lsn>)>>>;
+
+struct RecordingHandler {
+    log: ApplyLog,
+}
+
+#[async_trait]
+impl DestinationHandler for RecordingHandler {
+    async fn connect(&mut self, _connection_string: &str) -> pg2any_lib::CdcResult<()> {
+        Ok(())
+    }
+
+    fn set_schema_mappings(&mut self, _mappings: HashMap<String, String>) {}
+
+    async fn execute_sql_batch_with_hook(
+        &mut self,
+        _commands: &[String],
+        _hook: Option<PreCommitHook>,
+    ) -> pg2any_lib::CdcResult<()> {
+        // Recording placeholder: a real call would push (tx_id, commit_lsn).
+        // For the skip path we expect this to never be called.
+        self.log.lock().unwrap().push((u32::MAX, None));
+        Ok(())
+    }
+
+    async fn close(&mut self) -> pg2any_lib::CdcResult<()> {
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn test_skip_already_applied_transaction_no_replay() {
+    let dir = tempdir().unwrap();
+    let base = dir.path();
+
+    let manager = TransactionManager::new(base, DestinationType::SQLite, None, 64 * 1024 * 1024)
+        .await
+        .unwrap();
+    let manager = Arc::new(manager);
+
+    // Pre-populate the LSN tracker so flush_lsn is ahead of the pending txn's commit_lsn.
+    let lsn_file = base.join("lsn.metadata");
+    let tracker = LsnTracker::new(Some(lsn_file.to_str().unwrap())).await;
+    tracker.commit_lsn(200);
+    assert_eq!(tracker.get(), 200);
+
+    // Construct a pending file that should be skipped (commit_lsn=100 <= flush_lsn=200).
+    let pending_path = base.join("pg2any_pending_tx").join("tx_42.metadata");
+    let pending = PendingTransactionFile {
+        file_path: pending_path,
+        metadata: TransactionFileMetadata {
+            transaction_id: 42,
+            commit_timestamp: Utc::now(),
+            commit_lsn: Some(Lsn(100)),
+            destination_type: DestinationType::SQLite,
+            segments: Vec::new(),
+            current_segment_index: 0,
+            last_executed_command_index: None,
+            last_update_timestamp: None,
+            transaction_type: "normal".to_string(),
+        },
+    };
+
+    let log: ApplyLog = Arc::new(Mutex::new(Vec::new()));
+    let mut handler: Box<dyn DestinationHandler> = Box::new(RecordingHandler { log: log.clone() });
+
+    let cancel = CancellationToken::new();
+    let metrics = Arc::new(pg2any_lib::MetricsCollector::new());
+    let feedback = SharedLsnFeedback::new_shared();
+
+    let result = manager
+        .clone()
+        .process_transaction_file(
+            &pending,
+            &mut handler,
+            &cancel,
+            &tracker,
+            &metrics,
+            100,
+            &feedback,
+        )
+        .await;
+
+    assert!(result.is_ok(), "skip path returns Ok: {result:?}");
+    assert!(
+        log.lock().unwrap().is_empty(),
+        "handler must not be invoked for already-applied transaction"
+    );
+}

--- a/pg2any-lib/tests/sqlite_comprehensive_tests.rs
+++ b/pg2any-lib/tests/sqlite_comprehensive_tests.rs
@@ -3,7 +3,7 @@ mod common;
 use chrono::Utc;
 use common::{format_column_value, wrap_in_transaction};
 use pg2any_lib::{
-    destinations::{DestinationFactory, DestinationHandler},
+    destinations::DestinationHandler,
     types::{ChangeEvent, DestinationType, ReplicaIdentity},
     Transaction,
 };
@@ -1142,7 +1142,11 @@ async fn test_sqlite_complete_crud_cycle() {
 #[tokio::test]
 async fn test_sqlite_destination_factory_integration() {
     // Test that the factory creates a working SQLite destination
-    let mut destination = DestinationFactory::create(&DestinationType::SQLite).unwrap();
+    let mut destination = {
+        let mut cfg = pg2any_lib::Config::default();
+        cfg.destination_type = DestinationType::SQLite;
+        cfg.create_destination().unwrap()
+    };
 
     let temp_db = TempDatabase::new("factory_integration");
     let connection_string = temp_db.connection_string();

--- a/pg2any-lib/tests/sqlite_destination_tests.rs
+++ b/pg2any-lib/tests/sqlite_destination_tests.rs
@@ -2,7 +2,7 @@ mod common;
 
 use common::{format_column_value, wrap_in_transaction};
 use pg2any_lib::{
-    destinations::{DestinationFactory, DestinationHandler},
+    destinations::DestinationHandler,
     types::{ChangeEvent, DestinationType, EventType, ReplicaIdentity},
     Transaction,
 };
@@ -217,7 +217,9 @@ async fn create_test_table(pool: &SqlitePool) -> Result<(), sqlx::Error> {
 #[cfg(feature = "sqlite")]
 #[tokio::test]
 async fn test_sqlite_destination_factory() {
-    let destination = DestinationFactory::create(&DestinationType::SQLite);
+    let mut cfg = pg2any_lib::Config::default();
+    cfg.destination_type = DestinationType::SQLite;
+    let destination = cfg.create_destination();
     assert!(destination.is_ok());
 }
 

--- a/pg2any-lib/tests/streaming_transaction_tests.rs
+++ b/pg2any-lib/tests/streaming_transaction_tests.rs
@@ -1,7 +1,14 @@
 /// Tests for destination handler trait and factory functionality
-use pg2any_lib::destinations::destination_factory::DestinationFactory;
 use pg2any_lib::types::{DestinationType, Transaction};
 use std::collections::HashMap;
+
+fn make(
+    dt: DestinationType,
+) -> pg2any_lib::CdcResult<Box<dyn pg2any_lib::destinations::DestinationHandler>> {
+    let mut cfg = pg2any_lib::Config::default();
+    cfg.destination_type = dt;
+    cfg.create_destination()
+}
 
 #[cfg(test)]
 mod destination_tests {
@@ -11,19 +18,19 @@ mod destination_tests {
     async fn test_all_destinations_can_be_created() {
         #[cfg(feature = "mysql")]
         {
-            let mysql_dest = DestinationFactory::create(&DestinationType::MySQL);
+            let mysql_dest = make(DestinationType::MySQL);
             assert!(mysql_dest.is_ok());
         }
 
         #[cfg(feature = "sqlite")]
         {
-            let sqlite_dest = DestinationFactory::create(&DestinationType::SQLite);
+            let sqlite_dest = make(DestinationType::SQLite);
             assert!(sqlite_dest.is_ok());
         }
 
         #[cfg(feature = "sqlserver")]
         {
-            let sqlserver_dest = DestinationFactory::create(&DestinationType::SqlServer);
+            let sqlserver_dest = make(DestinationType::SqlServer);
             assert!(sqlserver_dest.is_ok());
         }
     }
@@ -32,19 +39,19 @@ mod destination_tests {
     fn test_destination_handler_trait_completeness() {
         #[cfg(feature = "mysql")]
         {
-            let result = DestinationFactory::create(&DestinationType::MySQL);
+            let result = make(DestinationType::MySQL);
             assert!(result.is_ok());
         }
 
         #[cfg(feature = "sqlite")]
         {
-            let result = DestinationFactory::create(&DestinationType::SQLite);
+            let result = make(DestinationType::SQLite);
             assert!(result.is_ok());
         }
 
         #[cfg(feature = "sqlserver")]
         {
-            let result = DestinationFactory::create(&DestinationType::SqlServer);
+            let result = make(DestinationType::SqlServer);
             assert!(result.is_ok());
         }
     }
@@ -53,14 +60,13 @@ mod destination_tests {
     async fn test_graceful_shutdown() {
         #[cfg(feature = "sqlite")]
         {
-            let mut sqlite_dest = DestinationFactory::create(&DestinationType::SQLite).unwrap();
+            let mut sqlite_dest = make(DestinationType::SQLite).unwrap();
             assert!(sqlite_dest.close().await.is_ok());
         }
 
         #[cfg(feature = "sqlserver")]
         {
-            let mut sqlserver_dest =
-                DestinationFactory::create(&DestinationType::SqlServer).unwrap();
+            let mut sqlserver_dest = make(DestinationType::SqlServer).unwrap();
             assert!(sqlserver_dest.close().await.is_ok());
         }
     }
@@ -69,7 +75,7 @@ mod destination_tests {
     async fn test_schema_mappings() {
         #[cfg(feature = "sqlite")]
         {
-            let mut sqlite_dest = DestinationFactory::create(&DestinationType::SQLite).unwrap();
+            let mut sqlite_dest = make(DestinationType::SQLite).unwrap();
             let mut mappings = HashMap::new();
             mappings.insert("public".to_string(), "cdc_db".to_string());
             sqlite_dest.set_schema_mappings(mappings);
@@ -77,8 +83,7 @@ mod destination_tests {
 
         #[cfg(feature = "sqlserver")]
         {
-            let mut sqlserver_dest =
-                DestinationFactory::create(&DestinationType::SqlServer).unwrap();
+            let mut sqlserver_dest = make(DestinationType::SqlServer).unwrap();
             let mut mappings = HashMap::new();
             mappings.insert("public".to_string(), "cdc_db".to_string());
             sqlserver_dest.set_schema_mappings(mappings);


### PR DESCRIPTION
- Refactored destination handling by introducing a per-Config registry for destination factories.
- Updated ConfigBuilder to allow registration of custom destinations and simplified destination creation.
- Enhanced DestinationType to support externally registered destinations.
- Added examples and tests for custom destination integration.
- Removed the DestinationFactory struct in favor of a more flexible factory function approach.