### PR TITLE
perf: drop redundant data-file re-read when finalizing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,10 @@ pg2any is a Rust CDC (Change Data Capture) library that streams PostgreSQL WAL c
 - Shutdown coordination: `CancellationToken` + `oneshot` channel (producer -> consumer)
 - Destinations behind `DestinationHandler` trait; Kafka uses event mode, SQL destinations use SQL batch mode
 - Destinations are constructed via the per-Config registry (`Config::create_destination`). Built-ins self-register in `Config::default()`; external users add their own via `ConfigBuilder::custom_destination` (factory closure) or `ConfigBuilder::use_destination::<H>()` (for `H: Default`).
-- `TransactionStorage` trait abstracts compressed vs uncompressed file I/O
+- `TransactionStorage` trait abstracts compressed vs uncompressed file I/O. Finalize passes the producer-tracked statement count through the trait (`write_transaction_from_file(path, known_count)` / `write_raw_lines_from_file`); uncompressed finalize does NO file re-read (compressed still reads to compress)
+- `commit_transaction` returns `(PathBuf, TransactionFileMetadata)`; the producer builds the consumer notification from that in-memory metadata, never re-reading the `.meta` file it just wrote
+- Statement-count invariant: producer-tracked `segment_statement_counts` is authoritative for `TransactionSegment.statement_count` and MUST equal what the consumer's `SqlStreamParser` reads back (it drives crash-resume segment-skip arithmetic). Events that render multiple `;`-statements (e.g. multi-table `TRUNCATE`) are counted via `count_rendered_statements`, which mirrors the parser in-memory — never `+= 1` per event
+- Pending-transaction count is an in-memory `AtomicUsize` (`pending_tx_count`, `Ordering::Relaxed`), monitoring-only: seeded once at startup from the pending-dir scan, `+1` on commit, `-1` on finalize. Never gate control flow / LSN persistence on it
 - MySQL uses dual pools: sqlx for normal SQL batches, mysql_async for LOAD DATA LOCAL INFILE
 - SQL Server uses TDS Bulk Load (tiberius `bulk_insert`) for homogeneous INSERT batches, falls back to multi-value INSERT
 - Consumer detects homogeneous INSERT batches and routes to bulk insert path when threshold met
@@ -35,7 +38,7 @@ pg2any is a Rust CDC (Change Data Capture) library that streams PostgreSQL WAL c
 - `pg2any-lib/src/client.rs` - Core orchestration logic, startup, recovery, shutdown
 - `pg2any-lib/src/producer.rs` - WAL reader, transaction file writer (extracted from client.rs)
 - `pg2any-lib/src/consumer.rs` - File executor, drain_and_shutdown, retry logic (extracted from client.rs)
-- `pg2any-lib/src/transaction_manager.rs` - File-based transaction lifecycle + bulk insert routing + `analyze_transaction_content`
+- `pg2any-lib/src/transaction_manager.rs` - File-based transaction lifecycle + bulk insert routing + `analyze_transaction_content`. Also: `count_rendered_statements` (producer statement counting that mirrors the consumer parser), `pending_tx_count` monitoring counter
 - `pg2any-lib/src/destinations/destination_factory.rs` - `DestinationHandler` trait definition
 - `pg2any-lib/src/destinations/mysql.rs` - MySQL destination (sqlx + mysql_async dual pool)
 - `pg2any-lib/src/destinations/sqlserver.rs` - SQL Server destination (tiberius TDS Bulk Load)
@@ -59,3 +62,5 @@ pg2any is a Rust CDC (Change Data Capture) library that streams PostgreSQL WAL c
 - Don't add blocking I/O on the hot path - everything is async
 - Don't modify LSN tracking from the producer - only the consumer updates `flush_lsn`
 - Don't skip the file persistence step - it's the crash recovery mechanism
+- Don't increment `segment_statement_counts` by 1 per event - count via `count_rendered_statements` so it matches the consumer's `SqlStreamParser` (multi-statement events like multi-table TRUNCATE would otherwise corrupt crash-resume skip arithmetic)
+- Don't re-read a transaction file at commit/finalize just to count or to fetch metadata you already hold in memory

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ The factory closure must return a fresh handler each call (it is invoked once fo
 - **Bulk insert optimization** - LOAD DATA LOCAL INFILE for MySQL, TDS Bulk Load for SQL Server + session tuning for large batches
 - **DML coalescing** - Multi-value INSERT, CASE-WHEN UPDATE, OR-combined DELETE batching
 - **Smart batching** - Merges consecutive homogeneous INSERT-only transactions across boundaries for higher throughput
+- **Low-overhead commit path** - Per-transaction finalize avoids redundant work: no file re-read just to count statements, no `.meta` re-parse after writing it, and an in-memory pending counter instead of a per-transaction directory scan
 
 ## Quick Start
 

--- a/examples/src/bin/deadwork_demo.rs
+++ b/examples/src/bin/deadwork_demo.rs
@@ -1,0 +1,51 @@
+//! Phase 1 dead-work demo: finalizing an uncompressed transaction file no
+//! longer re-reads the file from disk to count its statements.
+//!
+//! After Phase 1, `UncompressedStorage::write_transaction_from_file(path, n)`
+//! is O(1): the statement count is supplied by the producer, so the finalize
+//! path never opens or scans the file. This demo contrasts that O(1) call with
+//! the manual re-read + line-count loop the code used to perform.
+//!
+//! Run: cargo run -p pg2any --bin phase1_deadwork_demo
+
+use pg2any_lib::storage::{TransactionStorage, UncompressedStorage};
+use std::io::Write;
+use std::time::Instant;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let n: usize = 50_000;
+
+    // Write a large temp .sql file (one statement per line).
+    let path = std::env::temp_dir().join("pg2any_phase1_deadwork_demo.sql");
+    {
+        let mut f = std::io::BufWriter::new(std::fs::File::create(&path)?);
+        for i in 0..n {
+            writeln!(f, "INSERT INTO demo (id, val) VALUES ({i}, 'row-{i}');")?;
+        }
+        f.flush()?;
+    }
+    println!("Wrote {n} statements to {path:?}");
+
+    // (a) NEW O(1) finalize: count is known, file is never re-read.
+    let storage = UncompressedStorage::new();
+    let start = Instant::now();
+    storage.write_transaction_from_file(&path, n).await?;
+    let new_elapsed = start.elapsed();
+
+    // (b) OLD behavior: re-open the file and count lines to learn the count.
+    let start = Instant::now();
+    let contents = std::fs::read_to_string(&path)?;
+    let counted = contents.lines().count();
+    let old_elapsed = start.elapsed();
+    assert_eq!(counted, n, "sanity: re-read count must match");
+
+    let speedup = old_elapsed.as_secs_f64() / new_elapsed.as_secs_f64().max(f64::MIN_POSITIVE);
+    println!("Phase 1 demo: finalize of {n} statements");
+    println!("  NEW (O(1), no re-read): {new_elapsed:?}");
+    println!("  OLD (re-read + count):  {old_elapsed:?}");
+    println!("  speedup: {speedup:.1}x (dead disk work removed from the commit/finalize path)");
+
+    let _ = std::fs::remove_file(&path);
+    Ok(())
+}

--- a/examples/src/bin/phase2_hotpath_demo.rs
+++ b/examples/src/bin/phase2_hotpath_demo.rs
@@ -1,0 +1,79 @@
+//! Phase 2 hot-path demo: counting statements in a transaction file no longer
+//! allocates a `String` per statement.
+//!
+//! After Phase 2, `SqlStreamParser::count_line`/`finish_count` walk the same
+//! quote/bracket/escape state machine as `parse_line` but only tally completed
+//! statements -- they never buffer or allocate a `String`. This demo contrasts
+//! that allocation-free count with the OLD approach (`parse_line` into a
+//! `Vec<String>` + `finish_statement`), which materializes every statement.
+//!
+//! Best-of-N timing is used per path to drown out allocator/cache warmup noise.
+//!
+//! Run: cargo run --release -p pg2any --bin phase2_hotpath_demo
+
+use pg2any_lib::storage::sql_parser::SqlStreamParser;
+use std::hint::black_box;
+use std::time::{Duration, Instant};
+
+const N: usize = 50_000;
+const ROUNDS: usize = 20;
+
+/// NEW path: allocation-free count via `count_line` + `finish_count`.
+fn count_new(lines: &[String]) -> usize {
+    let mut parser = SqlStreamParser::new();
+    let mut count = 0usize;
+    for line in lines {
+        count += parser.count_line(line);
+    }
+    if parser.finish_count() {
+        count += 1;
+    }
+    count
+}
+
+/// OLD path: to learn the count you had to materialize every statement as an
+/// owned `String` in a growing `Vec`, then read its length.
+fn count_old(lines: &[String]) -> usize {
+    let mut parser = SqlStreamParser::new();
+    let mut out: Vec<String> = Vec::new();
+    for line in lines {
+        parser.parse_line(line, &mut out).expect("parse_line");
+    }
+    if let Some(last) = parser.finish_statement() {
+        out.push(last);
+    }
+    out.len()
+}
+
+fn best_of(rounds: usize, mut f: impl FnMut() -> usize) -> (Duration, usize) {
+    let mut best = Duration::MAX;
+    let mut count = 0;
+    for _ in 0..rounds {
+        let start = Instant::now();
+        count = black_box(f());
+        best = best.min(start.elapsed());
+    }
+    (best, count)
+}
+
+fn main() {
+    let lines: Vec<String> = (0..N)
+        .map(|i| format!("INSERT INTO demo (id, val) VALUES ({i}, 'row-{i}');"))
+        .collect();
+
+    let (new_elapsed, new_count) = best_of(ROUNDS, || count_new(&lines));
+    let (old_elapsed, old_count) = best_of(ROUNDS, || count_old(&lines));
+    assert_eq!(new_count, old_count, "counts must match");
+
+    let speedup = old_elapsed.as_secs_f64() / new_elapsed.as_secs_f64().max(f64::MIN_POSITIVE);
+    println!("Phase 2 demo: counting {new_count} statements (best of {ROUNDS} rounds)");
+    println!("  NEW (alloc-free count):   {new_elapsed:?}");
+    println!("  OLD (Vec<String> alloc):  {old_elapsed:?}");
+    println!("  speedup: {speedup:.2}x (per-statement String allocation removed from hot path)");
+    if cfg!(debug_assertions) {
+        println!(
+            "  note: run with --release for the optimized hot-path number; \
+             count_line's char iteration is only fully optimized then."
+        );
+    }
+}

--- a/pg2any-lib/Cargo.toml
+++ b/pg2any-lib/Cargo.toml
@@ -49,3 +49,4 @@ metrics = ["hyper", "hyper-util", "http-body-util", "prometheus"]
 [dev-dependencies]
 tempfile = "3"
 
+

--- a/pg2any-lib/src/client.rs
+++ b/pg2any-lib/src/client.rs
@@ -300,6 +300,11 @@ impl CdcClient {
 
         let pending_txs = file_mgr.list_pending_transactions().await?;
 
+        // Seed the in-memory pending counter from the authoritative dir scan.
+        // The recovery loop below finalizes each of these, decrementing the
+        // counter back toward 0 (dedup-skipped duplicates decrement on delete too).
+        file_mgr.seed_pending_count(pending_txs.len());
+
         if pending_txs.is_empty() {
             info!("No pending transaction files found");
             return Ok(());

--- a/pg2any-lib/src/destinations/coalescing.rs
+++ b/pg2any-lib/src/destinations/coalescing.rs
@@ -930,6 +930,11 @@ pub(crate) fn coalesce_commands<'a>(
     let mut result: Vec<Cow<'a, str>> = Vec::with_capacity(commands.len());
     let mut i = 0;
     // Carry-over from a group's lookahead: the statement at `i` has already been classified.
+    // ponytail: this guarantees single-pass classification — every lookahead that fails to
+    // join its group is stashed here and consumed by the next outer-loop iteration via
+    // `pending.take()`, so no statement is ever passed through `classify` twice. (The only
+    // lookahead-loop exits that store nothing are `i >= len` and the row/group cap, both of
+    // which leave `commands[i]` un-classified.) No double-classification redundancy exists.
     let mut pending: Option<ParsedCmd<'a>> = None;
 
     let effective_max = if max_rows_per_insert == 0 {

--- a/pg2any-lib/src/destinations/kafka.rs
+++ b/pg2any-lib/src/destinations/kafka.rs
@@ -20,6 +20,15 @@ const DEFAULT_FLUSH_TIMEOUT: Duration = Duration::from_secs(30);
 const DELIVERY_FUTURE_TIMEOUT: Duration = Duration::from_secs(30);
 const LIB_VERSION: &str = env!("CARGO_PKG_VERSION");
 
+/// Per-table cached names, built once per table and reused across all events
+/// for that table. Keyed by the per-event `source_table_key` ("{schema}.{table}").
+#[cfg_attr(test, derive(Clone))]
+struct TableNames {
+    topic: String,
+    key_schema: String,
+    envelope: String,
+}
+
 pub struct KafkaDestination {
     producer: Option<FutureProducer>,
     topic_prefix: String,
@@ -27,14 +36,13 @@ pub struct KafkaDestination {
     schema_mappings: HashMap<String, String>,
     key_columns_config: HashMap<String, Vec<String>>,
     field_schema_cache: HashMap<String, Value>,
-    topic_cache: HashMap<String, String>,
+    /// Cached per-table names (topic, key schema, envelope schema) keyed by
+    /// `source_table_key` ("{schema}.{table}"). Built once per table; zero key
+    /// allocation on the cache-hit (hot) path.
+    table_names_cache: HashMap<String, TableNames>,
     /// Cached key columns from Update/Delete events, used as fallback for Insert events
     /// that don't carry key_columns in the replication protocol.
     stream_key_columns: HashMap<String, Vec<Arc<str>>>,
-    /// Cached per-table key schema name ("{prefix}.{schema}.{table}.Key")
-    key_schema_name_cache: HashMap<String, String>,
-    /// Cached per-table envelope schema name ("{prefix}.{schema}.{table}.Envelope")
-    envelope_schema_name_cache: HashMap<String, String>,
     /// Cached static source schema fields (constant across all events)
     source_schema_fields: Value,
 }
@@ -48,10 +56,8 @@ impl KafkaDestination {
             schema_mappings: HashMap::new(),
             key_columns_config: HashMap::new(),
             field_schema_cache: HashMap::new(),
-            topic_cache: HashMap::new(),
+            table_names_cache: HashMap::new(),
             stream_key_columns: HashMap::new(),
-            key_schema_name_cache: HashMap::new(),
-            envelope_schema_name_cache: HashMap::new(),
             source_schema_fields: Self::build_source_schema_fields(),
         }
     }
@@ -70,25 +76,27 @@ impl KafkaDestination {
         ], "optional": false, "field": "source"})
     }
 
-    fn get_key_schema_name(&mut self, schema: &str, table: &str) -> &str {
-        let cache_key = format!("{}.{}", schema, table);
-        self.key_schema_name_cache
-            .entry(cache_key)
-            .or_insert_with_key(|_| format!("{}.{}.{}.Key", self.topic_prefix, schema, table))
-    }
-
-    fn get_envelope_schema_name(&mut self, schema: &str, table: &str) -> &str {
-        let cache_key = format!("{}.{}", schema, table);
-        self.envelope_schema_name_cache
-            .entry(cache_key)
-            .or_insert_with_key(|_| format!("{}.{}.{}.Envelope", self.topic_prefix, schema, table))
-    }
-
-    fn topic_name(&mut self, schema: &str, table: &str) -> &str {
-        let cache_key = format!("{}.{}", schema, table);
-        self.topic_cache
-            .entry(cache_key)
-            .or_insert_with_key(|_| format!("{}.{}.{}", self.topic_prefix, schema, table))
+    /// Returns cached per-table names, building them once on a cache miss.
+    /// On a cache hit this performs a single borrowed-key lookup with zero
+    /// key allocation; on a miss it allocates one owned key (`source_table_key`)
+    /// plus the three name strings.
+    fn table_names(
+        &mut self,
+        source_table_key: &str,
+        mapped_schema: &str,
+        table: &str,
+    ) -> &TableNames {
+        if !self.table_names_cache.contains_key(source_table_key) {
+            let prefix = &self.topic_prefix;
+            let names = TableNames {
+                topic: format!("{}.{}.{}", prefix, mapped_schema, table),
+                key_schema: format!("{}.{}.{}.Key", prefix, mapped_schema, table),
+                envelope: format!("{}.{}.{}.Envelope", prefix, mapped_schema, table),
+            };
+            self.table_names_cache
+                .insert(source_table_key.to_owned(), names);
+        }
+        &self.table_names_cache[source_table_key]
     }
 
     fn map_schema<'a>(&'a self, source_schema: &'a str) -> &'a str {
@@ -156,9 +164,8 @@ impl KafkaDestination {
     }
 
     fn build_key_for_insert(
-        &mut self,
-        schema: &str,
-        table: &str,
+        &self,
+        key_schema_name: &str,
         table_key: &str,
         data: &pg_walstream::RowData,
     ) -> Result<Option<String>> {
@@ -189,7 +196,7 @@ impl KafkaDestination {
             return Ok(None);
         }
 
-        let key_schema_name = self.get_key_schema_name(schema, table).to_owned();
+        let key_schema_name = key_schema_name.to_owned();
         let key = json!({
             "schema": {
                 "type": "struct",
@@ -231,6 +238,7 @@ impl KafkaDestination {
         op: &str,
         schema: &str,
         table: &str,
+        envelope_name: &str,
         before: Option<Value>,
         after: Option<Value>,
         before_fields: Option<Value>,
@@ -240,7 +248,6 @@ impl KafkaDestination {
         lsn: Option<Lsn>,
     ) -> Value {
         let source = self.build_source_block(schema, table, transaction_id, commit_timestamp, lsn);
-        let envelope_name = self.get_envelope_schema_name(schema, table).to_owned();
 
         let unified_fields = after_fields
             .as_ref()
@@ -285,9 +292,8 @@ impl KafkaDestination {
     }
 
     fn build_key_from_data(
-        &mut self,
-        schema: &str,
-        table: &str,
+        &self,
+        key_schema_name: &str,
         source_table_key: &str,
         data: &pg_walstream::RowData,
         key_columns: &[Arc<str>],
@@ -321,7 +327,7 @@ impl KafkaDestination {
             return Ok(None);
         }
 
-        let key_schema_name = self.get_key_schema_name(schema, table).to_owned();
+        let key_schema_name = key_schema_name.to_owned();
         let key = json!({
             "schema": {
                 "type": "struct",
@@ -556,16 +562,19 @@ impl DestinationHandler for KafkaDestination {
                 } => {
                     let mapped_schema = self.map_schema(schema).to_owned();
                     let source_table_key = format!("{}.{}", schema, table);
-                    let topic = self.topic_name(&mapped_schema, table).to_owned();
+                    let names = self.table_names(&source_table_key, &mapped_schema, table);
+                    let topic = names.topic.clone();
+                    let key_schema = names.key_schema.clone();
+                    let envelope_name = names.envelope.clone();
                     let after_fields =
                         Some(self.get_or_build_field_schema(&source_table_key, data));
                     let after = Some(Self::row_data_to_json(data));
-                    let key =
-                        self.build_key_for_insert(&mapped_schema, table, &source_table_key, data)?;
+                    let key = self.build_key_for_insert(&key_schema, &source_table_key, data)?;
                     let envelope = self.build_change_envelope(
                         "c",
                         &mapped_schema,
                         table,
+                        &envelope_name,
                         None,
                         after,
                         None,
@@ -595,7 +604,10 @@ impl DestinationHandler for KafkaDestination {
                             .entry(source_table_key.clone())
                             .or_insert_with(|| key_columns.clone());
                     }
-                    let topic = self.topic_name(&mapped_schema, table).to_owned();
+                    let names = self.table_names(&source_table_key, &mapped_schema, table);
+                    let topic = names.topic.clone();
+                    let key_schema = names.key_schema.clone();
+                    let envelope_name = names.envelope.clone();
                     let before_fields = old_data
                         .as_ref()
                         .map(|d| self.get_or_build_field_schema(&source_table_key, d));
@@ -605,8 +617,7 @@ impl DestinationHandler for KafkaDestination {
                     let after = Some(Self::row_data_to_json(new_data));
                     let key_data = old_data.as_ref().unwrap_or(new_data);
                     let key = self.build_key_from_data(
-                        &mapped_schema,
-                        table,
+                        &key_schema,
                         &source_table_key,
                         key_data,
                         key_columns,
@@ -615,6 +626,7 @@ impl DestinationHandler for KafkaDestination {
                         "u",
                         &mapped_schema,
                         table,
+                        &envelope_name,
                         before,
                         after,
                         before_fields,
@@ -643,13 +655,15 @@ impl DestinationHandler for KafkaDestination {
                             .entry(source_table_key.clone())
                             .or_insert_with(|| key_columns.clone());
                     }
-                    let topic = self.topic_name(&mapped_schema, table).to_owned();
+                    let names = self.table_names(&source_table_key, &mapped_schema, table);
+                    let topic = names.topic.clone();
+                    let key_schema = names.key_schema.clone();
+                    let envelope_name = names.envelope.clone();
                     let before_fields =
                         Some(self.get_or_build_field_schema(&source_table_key, old_data));
                     let before = Some(Self::row_data_to_json(old_data));
                     let key = self.build_key_from_data(
-                        &mapped_schema,
-                        table,
+                        &key_schema,
                         &source_table_key,
                         old_data,
                         key_columns,
@@ -658,6 +672,7 @@ impl DestinationHandler for KafkaDestination {
                         "d",
                         &mapped_schema,
                         table,
+                        &envelope_name,
                         before,
                         None,
                         before_fields,
@@ -678,11 +693,15 @@ impl DestinationHandler for KafkaDestination {
                             Some((s, t)) if !t.contains('.') => (self.map_schema(s).to_owned(), t),
                             _ => (self.map_schema("public").to_owned(), table_spec.as_ref()),
                         };
-                        let topic = self.topic_name(&schema, table).to_owned();
+                        let source_table_key = format!("{}.{}", schema, table);
+                        let names = self.table_names(&source_table_key, &schema, table);
+                        let topic = names.topic.clone();
+                        let envelope_name = names.envelope.clone();
                         let envelope = self.build_change_envelope(
                             "t",
                             &schema,
                             table,
+                            &envelope_name,
                             None,
                             None,
                             None,
@@ -747,13 +766,27 @@ mod tests {
     fn test_topic_name() {
         let mut dest = test_destination();
         assert_eq!(
-            dest.topic_name("public", "users"),
+            dest.table_names("public.users", "public", "users").topic,
             "test_prefix.public.users"
         );
         assert_eq!(
-            dest.topic_name("myschema", "orders"),
+            dest.table_names("myschema.orders", "myschema", "orders")
+                .topic,
             "test_prefix.myschema.orders"
         );
+    }
+
+    #[test]
+    fn test_topic_and_schema_name_caches_are_stable() {
+        let mut dest = test_destination();
+        let names1 = dest.table_names("public.users", "public", "users").clone();
+        let names2 = dest.table_names("public.users", "public", "users").clone();
+        assert_eq!(names1.topic, names2.topic);
+        assert_eq!(names1.key_schema, names2.key_schema);
+        assert_eq!(names1.envelope, names2.envelope);
+        assert_eq!(names1.topic, "test_prefix.public.users");
+        assert_eq!(names1.key_schema, "test_prefix.public.users.Key");
+        assert_eq!(names1.envelope, "test_prefix.public.users.Envelope");
     }
 
     #[test]
@@ -821,6 +854,7 @@ mod tests {
             "c",
             "public",
             "users",
+            "test_prefix.public.users.Envelope",
             None,
             Some(after_data.clone()),
             None,
@@ -855,6 +889,7 @@ mod tests {
             "d",
             "public",
             "users",
+            "test_prefix.public.users.Envelope",
             Some(before_data.clone()),
             None,
             Some(json!([{"type": "string", "optional": true, "field": "id"}])),
@@ -879,6 +914,7 @@ mod tests {
             "t",
             "public",
             "users",
+            "test_prefix.public.users.Envelope",
             None,
             None,
             None,
@@ -895,7 +931,7 @@ mod tests {
 
     #[test]
     fn test_build_key_from_data_with_keys() {
-        let mut dest = test_destination();
+        let dest = test_destination();
         let data = RowData::from_pairs(vec![
             ("id", ColumnValue::text("42")),
             ("name", ColumnValue::text("Alice")),
@@ -903,7 +939,12 @@ mod tests {
         let key_columns = vec![Arc::from("id")];
 
         let key = dest
-            .build_key_from_data("public", "users", "public.users", &data, &key_columns)
+            .build_key_from_data(
+                "test_prefix.public.users.Key",
+                "public.users",
+                &data,
+                &key_columns,
+            )
             .unwrap();
         assert!(key.is_some());
 
@@ -917,19 +958,24 @@ mod tests {
 
     #[test]
     fn test_build_key_from_data_no_keys() {
-        let mut dest = test_destination();
+        let dest = test_destination();
         let data = RowData::from_pairs(vec![("id", ColumnValue::text("42"))]);
         let key_columns: Vec<Arc<str>> = vec![];
 
         let key = dest
-            .build_key_from_data("public", "users", "public.users", &data, &key_columns)
+            .build_key_from_data(
+                "test_prefix.public.users.Key",
+                "public.users",
+                &data,
+                &key_columns,
+            )
             .unwrap();
         assert!(key.is_none());
     }
 
     #[test]
     fn test_build_key_composite() {
-        let mut dest = test_destination();
+        let dest = test_destination();
         let data = RowData::from_pairs(vec![
             ("tenant_id", ColumnValue::text("t1")),
             ("user_id", ColumnValue::text("u1")),
@@ -938,7 +984,12 @@ mod tests {
         let key_columns = vec![Arc::from("tenant_id"), Arc::from("user_id")];
 
         let key = dest
-            .build_key_from_data("public", "users", "public.users", &data, &key_columns)
+            .build_key_from_data(
+                "test_prefix.public.users.Key",
+                "public.users",
+                &data,
+                &key_columns,
+            )
             .unwrap();
         assert!(key.is_some());
 
@@ -968,8 +1019,7 @@ mod tests {
 
         let key = dest
             .build_key_from_data(
-                "public",
-                "users",
+                "test_prefix.public.users.Key",
                 "public.users",
                 &data,
                 &stream_key_columns,
@@ -1048,7 +1098,7 @@ mod tests {
         ]);
 
         let key = dest
-            .build_key_for_insert("public", "users", "public.users", &data)
+            .build_key_for_insert("test_prefix.public.users.Key", "public.users", &data)
             .unwrap();
         assert!(key.is_some());
         let key_json: Value = serde_json::from_str(key.as_ref().unwrap()).unwrap();
@@ -1057,11 +1107,11 @@ mod tests {
 
     #[test]
     fn test_build_key_for_insert_no_config() {
-        let mut dest = test_destination();
+        let dest = test_destination();
         let data = RowData::from_pairs(vec![("id", ColumnValue::text("42"))]);
 
         let key = dest
-            .build_key_for_insert("public", "users", "public.users", &data)
+            .build_key_for_insert("test_prefix.public.users.Key", "public.users", &data)
             .unwrap();
         assert!(key.is_none());
     }

--- a/pg2any-lib/src/destinations/mysql.rs
+++ b/pg2any-lib/src/destinations/mysql.rs
@@ -365,8 +365,8 @@ fn generate_tsv_buffer(rows: &[Vec<String>]) -> Vec<u8> {
                 .and_then(|s| s.strip_suffix('\''))
             {
                 tsv_escape_string(unquoted, &mut buf);
-            } else if let Some(decoded) = decode_hex_literal(trimmed) {
-                tsv_escape_raw(&decoded, &mut buf);
+            } else if decode_hex_into(trimmed, &mut buf) {
+                // decoded + escaped directly into buf
             } else {
                 tsv_escape_raw(trimmed.as_bytes(), &mut buf);
             }
@@ -377,22 +377,35 @@ fn generate_tsv_buffer(rows: &[Vec<String>]) -> Vec<u8> {
     buf
 }
 
-fn decode_hex_literal(s: &str) -> Option<Vec<u8>> {
+fn decode_hex_into(s: &str, out: &mut Vec<u8>) -> bool {
     if s.len() < 3 {
-        return None;
+        return false;
     }
     if !(s.starts_with("X'") || s.starts_with("x'")) || !s.ends_with('\'') {
-        return None;
+        return false;
     }
     let hex_str = &s[2..s.len() - 1];
     if hex_str.len() % 2 != 0 || !hex_str.bytes().all(|b| b.is_ascii_hexdigit()) {
-        return None;
+        return false;
     }
-    let bytes: Vec<u8> = (0..hex_str.len())
-        .step_by(2)
-        .map(|i| u8::from_str_radix(&hex_str[i..i + 2], 16).unwrap())
-        .collect();
-    Some(bytes)
+    // All chars validated as ASCII hex digits above, so decode with a fast bitwise
+    // map instead of from_str_radix + UTF-8 slicing.
+    let hex_val = |b: u8| -> u8 {
+        match b {
+            b'0'..=b'9' => b - b'0',
+            b'a'..=b'f' => b - b'a' + 10,
+            b'A'..=b'F' => b - b'A' + 10,
+            _ => 0,
+        }
+    };
+    let bytes = hex_str.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        let byte = (hex_val(bytes[i]) << 4) | hex_val(bytes[i + 1]);
+        tsv_escape_byte(byte, out);
+        i += 2;
+    }
+    true
 }
 
 fn tsv_escape_string(s: &str, buf: &mut Vec<u8>) {
@@ -458,16 +471,20 @@ fn tsv_escape_string(s: &str, buf: &mut Vec<u8>) {
     }
 }
 
+fn tsv_escape_byte(b: u8, buf: &mut Vec<u8>) {
+    match b {
+        b'\\' => buf.extend_from_slice(b"\\\\"),
+        b'\t' => buf.extend_from_slice(b"\\t"),
+        b'\n' => buf.extend_from_slice(b"\\n"),
+        b'\r' => buf.extend_from_slice(b"\\r"),
+        0 => buf.extend_from_slice(b"\\0"),
+        _ => buf.push(b),
+    }
+}
+
 fn tsv_escape_raw(data: &[u8], buf: &mut Vec<u8>) {
     for &b in data {
-        match b {
-            b'\\' => buf.extend_from_slice(b"\\\\"),
-            b'\t' => buf.extend_from_slice(b"\\t"),
-            b'\n' => buf.extend_from_slice(b"\\n"),
-            b'\r' => buf.extend_from_slice(b"\\r"),
-            0 => buf.extend_from_slice(b"\\0"),
-            _ => buf.push(b),
-        }
+        tsv_escape_byte(b, buf);
     }
 }
 
@@ -557,9 +574,26 @@ mod tests {
 
     #[test]
     fn test_decode_hex_literal_invalid() {
-        assert!(decode_hex_literal("hello").is_none());
-        assert!(decode_hex_literal("X'zz'").is_none());
-        assert!(decode_hex_literal("X'abc'").is_none());
-        assert!(decode_hex_literal("0xdead").is_none());
+        let mut out = Vec::new();
+        assert!(!decode_hex_into("hello", &mut out));
+        assert!(!decode_hex_into("X'zz'", &mut out));
+        assert!(!decode_hex_into("X'abc'", &mut out));
+        assert!(!decode_hex_into("0xdead", &mut out));
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn test_tsv_hex_decode_into_matches_previous() {
+        // A row with a bytea hex literal, a NULL, a quoted string, and a bare value.
+        let rows = vec![vec![
+            "X'48656C6C6F'".to_string(), // "Hello"
+            "NULL".to_string(),
+            "'a\tb'".to_string(), // tab must be escaped
+            "42".to_string(),
+        ]];
+        let buf = generate_tsv_buffer(&rows);
+        // Expected bytes: Hello \t \N \t a\\tb \t 42 \n
+        let expected = b"Hello\t\\N\ta\\tb\t42\n";
+        assert_eq!(buf, expected);
     }
 }

--- a/pg2any-lib/src/producer.rs
+++ b/pg2any-lib/src/producer.rs
@@ -1,8 +1,6 @@
 use crate::error::Result;
 use crate::monitoring::{MetricsCollector, MetricsCollectorTrait};
-use crate::transaction_manager::{
-    PendingTransactionFile, TransactionFileMetadata, TransactionManager,
-};
+use crate::transaction_manager::{PendingTransactionFile, TransactionManager};
 use crate::types::{EventType, Lsn};
 use chrono::{DateTime, Utc};
 use pg_walstream::LogicalReplicationStream;
@@ -29,35 +27,21 @@ pub(crate) async fn handle_transaction_commit(
         .commit_transaction(transaction_id, event_lsn)
         .await
     {
-        Ok(pending_path) => {
+        Ok((pending_path, metadata)) => {
             info!(
                 "Committed {} transaction file to: {:?} (commit_lsn: {:?})",
                 transaction_type, pending_path, event_lsn
             );
 
-            match tokio::fs::read_to_string(&pending_path).await {
-                Ok(content) => match serde_json::from_str::<TransactionFileMetadata>(&content) {
-                    Ok(metadata) => {
-                        let notification = PendingTransactionFile {
-                            file_path: pending_path.clone(),
-                            metadata,
-                        };
-                        if let Err(e) = commit_notifier.send(notification).await {
-                            warn!(
-                                    "Failed to send commit notification to consumer: {}. Consumer may have stopped.",
-                                    e
-                                );
-                        }
-                    }
-                    Err(e) => {
-                        error!("Failed to parse metadata from {:?}: {}", pending_path, e);
-                        metrics_collector.record_error("metadata_parse_failed", "producer");
-                    }
-                },
-                Err(e) => {
-                    error!("Failed to read metadata from {:?}: {}", pending_path, e);
-                    metrics_collector.record_error("metadata_read_failed", "producer");
-                }
+            let notification = PendingTransactionFile {
+                file_path: pending_path,
+                metadata,
+            };
+            if let Err(e) = commit_notifier.send(notification).await {
+                warn!(
+                    "Failed to send commit notification to consumer: {}. Consumer may have stopped.",
+                    e
+                );
             }
             Ok(())
         }

--- a/pg2any-lib/src/sql_renderer.rs
+++ b/pg2any-lib/src/sql_renderer.rs
@@ -63,13 +63,29 @@ pub fn append_value(ctx: &RenderContext, out: &mut String, value: &ColumnValue) 
 
 /// Generate SQL command for a change event
 pub fn generate_sql_for_event(ctx: &RenderContext, event: &ChangeEvent) -> Result<String> {
+    let mut out = String::new();
+    render_sql_for_event_into(ctx, event, &mut out)?;
+    Ok(out)
+}
+
+/// Render the SQL for a change event into `out`. No allocation when `out`
+/// already has capacity — enables buffer reuse across events.
+///
+/// Each per-type `render_*_into` helper clears `out` at its top (single
+/// source of truth), so this dispatcher does NOT clear; the non-DML arm
+/// clears explicitly so `out` ends empty for skipped events.
+pub fn render_sql_for_event_into(
+    ctx: &RenderContext,
+    event: &ChangeEvent,
+    out: &mut String,
+) -> Result<()> {
     match &event.event_type {
         EventType::Insert {
             schema,
             table,
             data,
             ..
-        } => generate_insert_sql(ctx, schema, table, data),
+        } => render_insert_into(ctx, schema, table, data, out),
         EventType::Update {
             schema,
             table,
@@ -78,7 +94,7 @@ pub fn generate_sql_for_event(ctx: &RenderContext, event: &ChangeEvent) -> Resul
             replica_identity,
             key_columns,
             ..
-        } => generate_update_sql(
+        } => render_update_into(
             ctx,
             schema,
             table,
@@ -86,6 +102,7 @@ pub fn generate_sql_for_event(ctx: &RenderContext, event: &ChangeEvent) -> Resul
             old_data.as_ref(),
             replica_identity,
             key_columns,
+            out,
         ),
         EventType::Delete {
             schema,
@@ -94,11 +111,20 @@ pub fn generate_sql_for_event(ctx: &RenderContext, event: &ChangeEvent) -> Resul
             replica_identity,
             key_columns,
             ..
-        } => generate_delete_sql(ctx, schema, table, old_data, replica_identity, key_columns),
-        EventType::Truncate(tables) => generate_truncate_sql(ctx, tables),
+        } => render_delete_into(
+            ctx,
+            schema,
+            table,
+            old_data,
+            replica_identity,
+            key_columns,
+            out,
+        ),
+        EventType::Truncate(tables) => render_truncate_into(ctx, tables, out),
         _ => {
-            // Skip non-DML events
-            Ok(String::new())
+            // Skip non-DML events; ensure `out` ends empty.
+            out.clear();
+            Ok(())
         }
     }
 }
@@ -112,29 +138,42 @@ pub fn generate_insert_sql(
     table: &str,
     new_data: &RowData,
 ) -> Result<String> {
+    // Pre-size: assume ~48 bytes per (column, value) pair + overhead
+    let mut sql = String::with_capacity(64 + new_data.len() * 48);
+    render_insert_into(ctx, schema, table, new_data, &mut sql)?;
+    Ok(sql)
+}
+
+/// Render INSERT SQL into `out` (cleared first).
+fn render_insert_into(
+    ctx: &RenderContext,
+    schema: &str,
+    table: &str,
+    new_data: &RowData,
+    out: &mut String,
+) -> Result<()> {
     let schema = ctx.map_schema(Some(schema));
 
-    // Pre-size: assume ~32 bytes per (column, value) pair + overhead
-    let mut sql = String::with_capacity(64 + new_data.len() * 48);
-    sql.push_str("INSERT INTO ");
-    append_qualified_table(ctx, &mut sql, schema, table);
-    sql.push_str(" (");
+    out.clear();
+    out.push_str("INSERT INTO ");
+    append_qualified_table(ctx, out, schema, table);
+    out.push_str(" (");
     for (i, (k, _)) in new_data.iter().enumerate() {
         if i > 0 {
-            sql.push_str(", ");
+            out.push_str(", ");
         }
-        append_quoted_identifier(ctx, &mut sql, k);
+        append_quoted_identifier(ctx, out, k);
     }
-    sql.push_str(") VALUES (");
+    out.push_str(") VALUES (");
     for (i, (_, v)) in new_data.iter().enumerate() {
         if i > 0 {
-            sql.push_str(", ");
+            out.push_str(", ");
         }
-        append_value(ctx, &mut sql, v);
+        append_value(ctx, out, v);
     }
-    sql.push_str(");");
+    out.push_str(");");
 
-    Ok(sql)
+    Ok(())
 }
 
 /// Generate UPDATE SQL command
@@ -147,32 +186,51 @@ pub fn generate_update_sql(
     replica_identity: &ReplicaIdentity,
     key_columns: &[Arc<str>],
 ) -> Result<String> {
-    let schema = ctx.map_schema(Some(schema));
-
     let mut sql = String::with_capacity(64 + new_data.len() * 64);
-    sql.push_str("UPDATE ");
-    append_qualified_table(ctx, &mut sql, schema, table);
-    sql.push_str(" SET ");
-    for (i, (col, val)) in new_data.iter().enumerate() {
-        if i > 0 {
-            sql.push_str(", ");
-        }
-        append_quoted_identifier(ctx, &mut sql, col);
-        sql.push_str(" = ");
-        append_value(ctx, &mut sql, val);
-    }
-    sql.push_str(" WHERE ");
-    append_where_clause(
+    render_update_into(
         ctx,
-        &mut sql,
+        schema,
+        table,
+        new_data,
+        old_data,
         replica_identity,
         key_columns,
-        old_data,
-        new_data,
+        &mut sql,
     )?;
-    sql.push(';');
-
     Ok(sql)
+}
+
+/// Render UPDATE SQL into `out` (cleared first).
+#[allow(clippy::too_many_arguments)]
+fn render_update_into(
+    ctx: &RenderContext,
+    schema: &str,
+    table: &str,
+    new_data: &RowData,
+    old_data: Option<&RowData>,
+    replica_identity: &ReplicaIdentity,
+    key_columns: &[Arc<str>],
+    out: &mut String,
+) -> Result<()> {
+    let schema = ctx.map_schema(Some(schema));
+
+    out.clear();
+    out.push_str("UPDATE ");
+    append_qualified_table(ctx, out, schema, table);
+    out.push_str(" SET ");
+    for (i, (col, val)) in new_data.iter().enumerate() {
+        if i > 0 {
+            out.push_str(", ");
+        }
+        append_quoted_identifier(ctx, out, col);
+        out.push_str(" = ");
+        append_value(ctx, out, val);
+    }
+    out.push_str(" WHERE ");
+    append_where_clause(ctx, out, replica_identity, key_columns, old_data, new_data)?;
+    out.push(';');
+
+    Ok(())
 }
 
 /// Generate DELETE SQL command
@@ -188,30 +246,60 @@ pub fn generate_delete_sql(
     replica_identity: &ReplicaIdentity,
     key_columns: &[Arc<str>],
 ) -> Result<String> {
+    let mut sql = String::with_capacity(64 + key_columns.len() * 32);
+    render_delete_into(
+        ctx,
+        schema,
+        table,
+        old_data,
+        replica_identity,
+        key_columns,
+        &mut sql,
+    )?;
+    Ok(sql)
+}
+
+/// Render DELETE SQL into `out` (cleared first).
+fn render_delete_into(
+    ctx: &RenderContext,
+    schema: &str,
+    table: &str,
+    old_data: &RowData,
+    replica_identity: &ReplicaIdentity,
+    key_columns: &[Arc<str>],
+    out: &mut String,
+) -> Result<()> {
     let schema = ctx.map_schema(Some(schema));
 
-    let mut sql = String::with_capacity(64 + key_columns.len() * 32);
-    sql.push_str("DELETE FROM ");
-    append_qualified_table(ctx, &mut sql, schema, table);
-    sql.push_str(" WHERE ");
+    out.clear();
+    out.push_str("DELETE FROM ");
+    append_qualified_table(ctx, out, schema, table);
+    out.push_str(" WHERE ");
     append_where_clause(
         ctx,
-        &mut sql,
+        out,
         replica_identity,
         key_columns,
         Some(old_data),
         old_data,
     )?;
-    sql.push(';');
+    out.push(';');
 
-    Ok(sql)
+    Ok(())
 }
 
 /// Generate TRUNCATE SQL command
 pub fn generate_truncate_sql(ctx: &RenderContext, tables: &[Arc<str>]) -> Result<String> {
-    // Build all TRUNCATE statements into a single `String` — no intermediate Vec.
     // Pre-size for ~48 bytes per table (keyword + identifiers + punctuation).
     let mut sql = String::with_capacity(tables.len() * 48);
+    render_truncate_into(ctx, tables, &mut sql)?;
+    Ok(sql)
+}
+
+/// Render TRUNCATE SQL into `out` (cleared first).
+fn render_truncate_into(ctx: &RenderContext, tables: &[Arc<str>], out: &mut String) -> Result<()> {
+    // Build all TRUNCATE statements into a single `String` — no intermediate Vec.
+    out.clear();
 
     for table_spec in tables.iter() {
         let table_spec: &str = table_spec;
@@ -221,14 +309,14 @@ pub fn generate_truncate_sql(ctx: &RenderContext, tables: &[Arc<str>]) -> Result
         };
 
         if let Some(stmt) = ctx.dialect.truncate_table_sql(schema, table) {
-            if !sql.is_empty() {
-                sql.push('\n');
+            if !out.is_empty() {
+                out.push('\n');
             }
-            sql.push_str(&stmt);
+            out.push_str(&stmt);
         }
     }
 
-    Ok(sql)
+    Ok(())
 }
 
 /// Append WHERE clause conditions directly into the provided buffer
@@ -515,6 +603,40 @@ mod tests {
             vec![Arc::from("id")],
             Lsn::new(0x101),
         )
+    }
+
+    fn sample_delete() -> ChangeEvent {
+        let old_data = RowData::from_pairs(vec![
+            ("id", ColumnValue::text("1")),
+            ("name", ColumnValue::text("alice")),
+        ]);
+        ChangeEvent::delete(
+            "public",
+            "users",
+            42,
+            old_data,
+            ReplicaIdentity::Default,
+            vec![Arc::from("id")],
+            Lsn::new(0x102),
+        )
+    }
+
+    #[test]
+    fn test_render_into_matches_string_variant() {
+        let (d, m) = ctx();
+        let rc = make_render_ctx(&d, &m);
+        let event = sample_insert();
+        let owned = generate_sql_for_event(&rc, &event).unwrap();
+
+        let mut buf = String::from("STALE-PRELOAD"); // must be cleared by the fn
+        render_sql_for_event_into(&rc, &event, &mut buf).unwrap();
+        assert_eq!(buf, owned);
+
+        // Reuse the same buffer for a second event — no leftover bytes.
+        let event2 = sample_delete();
+        let owned2 = generate_sql_for_event(&rc, &event2).unwrap();
+        render_sql_for_event_into(&rc, &event2, &mut buf).unwrap();
+        assert_eq!(buf, owned2);
     }
 
     #[test]

--- a/pg2any-lib/src/storage/compressed.rs
+++ b/pg2any-lib/src/storage/compressed.rs
@@ -233,7 +233,11 @@ impl TransactionStorage for CompressedStorage {
         Ok(compressed_path)
     }
 
-    async fn write_transaction_from_file(&self, file_path: &Path) -> Result<(PathBuf, usize)> {
+    async fn write_transaction_from_file(
+        &self,
+        file_path: &Path,
+        _known_statement_count: usize,
+    ) -> Result<PathBuf> {
         let compressed_path = file_path.with_extension("sql.gz");
 
         info!(
@@ -331,10 +335,14 @@ impl TransactionStorage for CompressedStorage {
             total_statements
         );
 
-        Ok((compressed_path, total_statements))
+        Ok(compressed_path)
     }
 
-    async fn write_raw_lines_from_file(&self, file_path: &Path) -> Result<(PathBuf, usize)> {
+    async fn write_raw_lines_from_file(
+        &self,
+        file_path: &Path,
+        _known_line_count: usize,
+    ) -> Result<PathBuf> {
         let compressed_path = file_path.with_extension("sql.gz");
 
         info!(
@@ -401,7 +409,7 @@ impl TransactionStorage for CompressedStorage {
 
         if total_lines == 0 {
             let _ = fs::remove_file(&compressed_path).await;
-            return Ok((compressed_path, 0));
+            return Ok(compressed_path);
         }
 
         dest_file
@@ -421,7 +429,7 @@ impl TransactionStorage for CompressedStorage {
             total_lines
         );
 
-        Ok((compressed_path, total_lines))
+        Ok(compressed_path)
     }
 
     async fn read_transaction(&self, file_path: &Path, start_index: usize) -> Result<Vec<String>> {
@@ -719,8 +727,8 @@ mod tests {
         tokio::fs::write(&source_path, &content).await.unwrap();
 
         let storage = CompressedStorage::new();
-        let (compressed_path, _) = storage
-            .write_transaction_from_file(&source_path)
+        let compressed_path = storage
+            .write_transaction_from_file(&source_path, 1)
             .await
             .unwrap();
 
@@ -774,12 +782,11 @@ mod tests {
         tokio::fs::write(&source_path, &content).await.unwrap();
 
         let storage = CompressedStorage::new();
-        let (compressed_path, line_count) = storage
-            .write_raw_lines_from_file(&source_path)
+        let compressed_path = storage
+            .write_raw_lines_from_file(&source_path, 3)
             .await
             .unwrap();
 
-        assert_eq!(line_count, 3);
         assert!(compressed_path.to_string_lossy().ends_with(".sql.gz"));
 
         // Read back using the same path the event-mode consumer uses:
@@ -829,12 +836,10 @@ mod tests {
         tokio::fs::write(&source_path, &content).await.unwrap();
 
         let storage = CompressedStorage::new();
-        let (compressed_path, line_count) = storage
-            .write_raw_lines_from_file(&source_path)
+        let compressed_path = storage
+            .write_raw_lines_from_file(&source_path, 1500)
             .await
             .unwrap();
-
-        assert_eq!(line_count, 1500);
 
         // Verify index has 2 sync points (0 and 1000)
         let index_path = CompressedStorage::index_path(&compressed_path);

--- a/pg2any-lib/src/storage/sql_parser.rs
+++ b/pg2any-lib/src/storage/sql_parser.rs
@@ -42,6 +42,9 @@ pub struct SqlStreamParser {
     statement_buffer: Vec<u8>,
     /// Total statements parsed
     statement_count: usize,
+    /// Non-whitespace byte count of the in-progress statement, for count-only
+    /// parsing (see `count_line`). Parallel to `statement_buffer` but allocation-free.
+    count_nonws: usize,
 }
 
 impl SqlStreamParser {
@@ -51,6 +54,7 @@ impl SqlStreamParser {
             state: ParseState::Normal,
             statement_buffer: Vec::with_capacity(512),
             statement_count: 0,
+            count_nonws: 0,
         }
     }
 
@@ -203,6 +207,105 @@ impl SqlStreamParser {
         Ok(())
     }
 
+    /// Count completed statements in `line` WITHOUT allocating per statement.
+    /// Mirrors `parse_line`'s state machine exactly (quotes/brackets/escapes),
+    /// but instead of buffering bytes it tracks whether the in-progress
+    /// statement contains any non-whitespace byte, so a trailing `;` on a
+    /// blank/whitespace-only buffer is not counted (parity with
+    /// `take_trimmed_statement` returning None on empty).
+    pub fn count_line(&mut self, line: &str) -> usize {
+        let mut completed = 0usize;
+        // Iterate by `char` (not byte) so emptiness uses the SAME Unicode
+        // whitespace definition as `str::trim` (`char::is_whitespace`) on the
+        // read path. All delimiters/quote chars dispatched on below are ASCII
+        // single-byte, so matching on a `char` is identical to matching a byte
+        // for those cases. `peekable` lets us look ahead for doubled-quote
+        // escapes, mirroring `parse_line`'s `bytes[i + 1]` lookahead.
+        let mut chars = line.chars().peekable();
+        while let Some(ch) = chars.next() {
+            match self.state {
+                ParseState::Normal => match ch {
+                    '\'' => {
+                        self.state = ParseState::SingleQuote;
+                        self.count_nonws += 1;
+                    }
+                    '"' => {
+                        self.state = ParseState::DoubleQuote;
+                        self.count_nonws += 1;
+                    }
+                    '`' => {
+                        self.state = ParseState::Backtick;
+                        self.count_nonws += 1;
+                    }
+                    '[' => {
+                        self.state = ParseState::Bracket;
+                        self.count_nonws += 1;
+                    }
+                    ';' => {
+                        if self.count_nonws > 0 {
+                            completed += 1;
+                        }
+                        self.count_nonws = 0;
+                    }
+                    _ => {
+                        if !ch.is_whitespace() {
+                            self.count_nonws += 1;
+                        }
+                    }
+                },
+                ParseState::SingleQuote => {
+                    self.count_nonws += 1;
+                    if ch == '\'' {
+                        if chars.peek() == Some(&'\'') {
+                            chars.next();
+                            self.count_nonws += 1;
+                        } else {
+                            self.state = ParseState::Normal;
+                        }
+                    }
+                }
+                ParseState::DoubleQuote => {
+                    self.count_nonws += 1;
+                    if ch == '"' {
+                        if chars.peek() == Some(&'"') {
+                            chars.next();
+                            self.count_nonws += 1;
+                        } else {
+                            self.state = ParseState::Normal;
+                        }
+                    }
+                }
+                ParseState::Backtick => {
+                    self.count_nonws += 1;
+                    if ch == '`' {
+                        if chars.peek() == Some(&'`') {
+                            chars.next();
+                            self.count_nonws += 1;
+                        } else {
+                            self.state = ParseState::Normal;
+                        }
+                    }
+                }
+                ParseState::Bracket => {
+                    self.count_nonws += 1;
+                    if ch == ']' {
+                        self.state = ParseState::Normal;
+                    }
+                }
+            }
+        }
+        // parse_line pushes a trailing '\n' into the buffer; '\n' is whitespace
+        // so it does not affect count_nonws. Nothing to do here.
+        completed
+    }
+
+    /// Mirror of `finish_statement().is_some()` for the count-only path.
+    pub fn finish_count(&mut self) -> bool {
+        let has = self.count_nonws > 0;
+        self.count_nonws = 0;
+        has
+    }
+
     /// Finalize parsing at EOF and return the remaining statement, if any
     pub fn finish_statement(&mut self) -> Option<String> {
         if self.statement_buffer.is_empty() {
@@ -265,6 +368,83 @@ mod tests {
         file.write_all(content.as_bytes()).await.unwrap();
         file.flush().await.unwrap();
         (file_path.to_string_lossy().to_string(), temp_dir)
+    }
+
+    #[test]
+    fn test_count_line_matches_parse_line_statement_count() {
+        // Compute the reference statement count via the real read path
+        // (parse_line + finish_statement) — two independent paths, not a
+        // tautology.
+        fn ref_count(case: &str) -> usize {
+            let mut p_ref = SqlStreamParser::new();
+            let mut n = 0usize;
+            for physical in case.split('\n') {
+                let mut o = Vec::new();
+                p_ref.parse_line(physical, &mut o).unwrap();
+                n += o.len();
+            }
+            if p_ref.finish_statement().is_some() {
+                n += 1;
+            }
+            n
+        }
+
+        fn new_count(case: &str) -> usize {
+            let mut p2 = SqlStreamParser::new();
+            let mut n = 0usize;
+            for physical in case.split('\n') {
+                n += p2.count_line(physical);
+            }
+            if p2.finish_count() {
+                n += 1;
+            }
+            n
+        }
+
+        // Cases that must agree, including a semicolon inside a quoted literal
+        // (must NOT be counted as a terminator) and a multi-statement line.
+        let cases = [
+            "INSERT INTO t (a) VALUES (1);",
+            "INSERT INTO t (a) VALUES ('a;b');", // ; inside quotes -> 1 stmt
+            "TRUNCATE TABLE a;\nTRUNCATE TABLE b;\nTRUNCATE TABLE c;", // 3 stmts
+            "UPDATE t SET a = '' WHERE id = 2;",
+            "", // 0 stmts
+            // Unicode-whitespace cases: NBSP / ideographic space are whitespace
+            // under str::trim (char::is_whitespace) but NOT is_ascii_whitespace.
+            "\u{a0};",        // all-whitespace before ; -> 0 stmts
+            "\u{3000}",       // hits finish_count, all-whitespace -> 0 stmts
+            "\u{a0}x\u{a0};", // interior content -> non-empty -> 1 stmt
+            "  \u{a0}  ;",    // mixed all-whitespace -> 0 stmts
+        ];
+        for case in cases {
+            assert_eq!(
+                new_count(case),
+                ref_count(case),
+                "count mismatch for case: {case:?}"
+            );
+        }
+
+        // Deterministic fuzz over an alphabet that INCLUDES a multibyte
+        // whitespace char (\u{a0}). Generate every string up to length 4 and
+        // assert the count-only path equals the read path. This FAILS before
+        // the Unicode-aware fix and PASSES after.
+        let alphabet = ['a', ';', '\'', '"', '`', '[', ']', ' ', '\t', '\u{a0}'];
+        let n = alphabet.len();
+        for len in 0..=4usize {
+            let total = n.pow(len as u32);
+            for mut idx in 0..total {
+                let mut s = String::new();
+                for _ in 0..len {
+                    s.push(alphabet[idx % n]);
+                    idx /= n;
+                }
+                assert_eq!(
+                    new_count(&s),
+                    ref_count(&s),
+                    "fuzz count mismatch for input: {s:?}"
+                );
+            }
+        }
     }
 
     #[tokio::test]

--- a/pg2any-lib/src/storage/traits.rs
+++ b/pg2any-lib/src/storage/traits.rs
@@ -31,10 +31,15 @@ pub trait TransactionStorage: Send + Sync {
     ///
     /// # Arguments
     /// * `file_path` - Uncompressed file path
+    /// * `known_statement_count` - Producer-tracked statement count (avoids re-parsing)
     ///
     /// # Returns
-    /// * `(PathBuf, usize)` - Actual path where data was written and total statements
-    async fn write_transaction_from_file(&self, file_path: &Path) -> Result<(PathBuf, usize)>;
+    /// * `PathBuf` - Actual path where data was written (may differ for compressed storage)
+    async fn write_transaction_from_file(
+        &self,
+        file_path: &Path,
+        known_statement_count: usize,
+    ) -> Result<PathBuf>;
 
     /// Write a raw-lines file (event mode) from an existing uncompressed file
     ///
@@ -44,11 +49,17 @@ pub trait TransactionStorage: Send + Sync {
     ///
     /// # Arguments
     /// * `file_path` - Uncompressed file path containing newline-delimited records
+    /// * `known_line_count` - Producer-tracked line count (avoids re-parsing)
     ///
     /// # Returns
-    /// * `(PathBuf, usize)` - Actual path where data was written and total line count
-    async fn write_raw_lines_from_file(&self, file_path: &Path) -> Result<(PathBuf, usize)> {
-        self.write_transaction_from_file(file_path).await
+    /// * `PathBuf` - Actual path where data was written (may differ for compressed storage)
+    async fn write_raw_lines_from_file(
+        &self,
+        file_path: &Path,
+        known_line_count: usize,
+    ) -> Result<PathBuf> {
+        self.write_transaction_from_file(file_path, known_line_count)
+            .await
     }
 
     /// Read SQL commands from a transaction file, starting from a specific index

--- a/pg2any-lib/src/storage/uncompressed.rs
+++ b/pg2any-lib/src/storage/uncompressed.rs
@@ -9,7 +9,7 @@ use crate::storage::traits::TransactionStorage;
 use async_trait::async_trait;
 use std::path::{Path, PathBuf};
 use tokio::fs;
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufWriter};
+use tokio::io::{AsyncWriteExt, BufWriter};
 use tracing::debug;
 
 /// Uncompressed storage handler for transaction files
@@ -67,54 +67,27 @@ impl TransactionStorage for UncompressedStorage {
         Ok(file_path.to_path_buf())
     }
 
-    async fn write_transaction_from_file(&self, file_path: &Path) -> Result<(PathBuf, usize)> {
-        let file = tokio::fs::File::open(file_path)
-            .await
-            .map_err(|e| CdcError::generic(format!("Failed to open file {file_path:?}: {e}")))?;
-
-        let reader = tokio::io::BufReader::new(file);
-        let mut lines = reader.lines();
-        let mut parser = SqlStreamParser::new();
-        let mut statement_count = 0usize;
-        let mut statements: Vec<String> = Vec::new();
-
-        while let Some(line) = lines
-            .next_line()
-            .await
-            .map_err(|e| CdcError::generic(format!("Failed to read line: {e}")))?
-        {
-            statements.clear();
-            parser.parse_line(&line, &mut statements)?;
-            statement_count += statements.len();
-        }
-
-        if parser.finish_statement().is_some() {
-            statement_count += 1;
-        }
-
-        Ok((file_path.to_path_buf(), statement_count))
+    async fn write_transaction_from_file(
+        &self,
+        file_path: &Path,
+        known_statement_count: usize,
+    ) -> Result<PathBuf> {
+        // Uncompressed files are already final — no transform needed and the
+        // statement count is supplied by the producer (segment_statement_counts),
+        // so we never re-read or re-parse the file here.
+        debug!(
+            "Uncompressed finalize: {:?} ({} statements, no re-read)",
+            file_path, known_statement_count
+        );
+        Ok(file_path.to_path_buf())
     }
 
-    async fn write_raw_lines_from_file(&self, file_path: &Path) -> Result<(PathBuf, usize)> {
-        let file = tokio::fs::File::open(file_path)
-            .await
-            .map_err(|e| CdcError::generic(format!("Failed to open file {file_path:?}: {e}")))?;
-
-        let reader = tokio::io::BufReader::new(file);
-        let mut lines = reader.lines();
-        let mut line_count = 0usize;
-
-        while let Some(line) = lines
-            .next_line()
-            .await
-            .map_err(|e| CdcError::generic(format!("Failed to read line: {e}")))?
-        {
-            if !line.trim().is_empty() {
-                line_count += 1;
-            }
-        }
-
-        Ok((file_path.to_path_buf(), line_count))
+    async fn write_raw_lines_from_file(
+        &self,
+        file_path: &Path,
+        _known_line_count: usize,
+    ) -> Result<PathBuf> {
+        Ok(file_path.to_path_buf())
     }
 
     async fn read_transaction(&self, file_path: &Path, start_index: usize) -> Result<Vec<String>> {
@@ -231,6 +204,29 @@ mod tests {
         );
 
         // Clean up
+        storage.delete_transaction(&file_path).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_write_from_file_uses_known_count_without_reading() {
+        let temp_dir = create_temp_dir().await;
+        let file_path = temp_dir.join("count.sql");
+        let storage = UncompressedStorage::new();
+
+        // File content deliberately does NOT match the known count:
+        // proves the function trusts the passed count and does not re-parse.
+        let statements = vec!["INSERT INTO t VALUES (1);".to_string()];
+        storage
+            .write_transaction(&file_path, &statements)
+            .await
+            .unwrap();
+
+        let path = storage
+            .write_transaction_from_file(&file_path, 999)
+            .await
+            .unwrap();
+
+        assert_eq!(path, file_path);
         storage.delete_transaction(&file_path).await.unwrap();
     }
 

--- a/pg2any-lib/src/transaction_manager.rs
+++ b/pg2any-lib/src/transaction_manager.rs
@@ -53,6 +53,7 @@ use pg_walstream::ColumnValue;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
 use tokio::fs::{self, File};
@@ -260,6 +261,8 @@ struct ActiveTransactionState {
     current_segment_size_bytes: usize,
     /// Buffered writer for the current segment
     writer: BufferedEventWriter,
+    /// Reused render buffer for SQL-mode events, avoids a per-event allocation.
+    render_buf: String,
 }
 
 struct StatementProcessingState<'a> {
@@ -298,6 +301,10 @@ pub struct TransactionManager {
     bulk_insert_threshold: usize,
     /// SQL dialect for this destination (selected from `destination_type`).
     dialect: &'static dyn SqlDialect,
+    /// In-memory count of transactions in sql_pending_tx/ (committed, not yet
+    /// finalized). Seeded at startup from the dir scan; kept in sync on
+    /// commit (+1) and finalize/delete (-1). Avoids a per-transaction dir scan.
+    pending_tx_count: AtomicUsize,
 }
 
 impl TransactionManager {
@@ -341,6 +348,7 @@ impl TransactionManager {
             event_mode: false,
             bulk_insert_threshold: 500,
             dialect,
+            pending_tx_count: AtomicUsize::new(0),
         })
     }
 
@@ -357,6 +365,28 @@ impl TransactionManager {
     /// Configure bulk insert optimization parameters
     pub fn set_bulk_insert_config(&mut self, threshold: usize) {
         self.bulk_insert_threshold = threshold;
+    }
+
+    /// Current in-memory count of committed-but-not-finalized pending transactions.
+    pub fn pending_count(&self) -> usize {
+        self.pending_tx_count.load(Ordering::Relaxed)
+    }
+
+    /// Seed the pending counter at startup from the authoritative dir scan.
+    pub fn seed_pending_count(&self, n: usize) {
+        self.pending_tx_count.store(n, Ordering::Relaxed);
+    }
+
+    /// Atomically saturating-decrement the pending counter, returning the new value.
+    /// saturating_sub guards against underflow if a recovery path uncounts a tx that
+    /// wasn't counted at startup (the atomic itself never wraps to usize::MAX).
+    fn decrement_pending_count(&self) -> usize {
+        self.pending_tx_count
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |val| {
+                Some(val.saturating_sub(1))
+            })
+            .map(|prev| prev.saturating_sub(1))
+            .unwrap_or(0)
     }
 
     /// Flush all pending buffered writes
@@ -480,6 +510,7 @@ impl TransactionManager {
                 current_segment_index: 0,
                 current_segment_size_bytes: 0,
                 writer: BufferedEventWriter::new(data_file_path.clone(), self.buffer_size),
+                render_buf: String::new(),
             },
         );
 
@@ -536,25 +567,49 @@ impl TransactionManager {
         Ok(())
     }
 
+    /// Count statements in an already-rendered SQL `line` exactly as the
+    /// consumer's `SqlStreamParser` would read them back from disk.
+    ///
+    /// This MUST mirror the consumer read path (and the legacy
+    /// `UncompressedStorage::write_transaction_from_file` counting loop): split
+    /// on physical newlines, feed each line to a fresh parser, then count any
+    /// trailing statement at EOF. A single event-line may contain multiple
+    /// `;`-terminated statements (e.g. a multi-table TRUNCATE), so the producer
+    /// must count per-statement to keep crash-resume skip arithmetic correct.
+    fn count_rendered_statements(line: &str) -> Result<usize> {
+        let mut parser = SqlStreamParser::new();
+        let mut count = 0usize;
+        for physical_line in line.split('\n') {
+            count += parser.count_line(physical_line);
+        }
+        if parser.finish_count() {
+            count += 1;
+        }
+        Ok(count)
+    }
+
     /// Append a change event to a running transaction file
     /// Uses buffered I/O to accumulate events in memory before flushing to disk
     /// Automatically flushes when buffer reaches capacity
     pub async fn append_event(&self, tx_id: u32, event: &ChangeEvent) -> Result<()> {
-        let line = if self.event_mode {
+        // Event mode serializes JSON into its own owned String before locking
+        // (out of scope for buffer reuse). For SQL mode we render into the
+        // per-transaction reusable buffer AFTER locking, so `event_line` stays
+        // `None` here and the line is borrowed from `tx_state.render_buf`.
+        let event_line: Option<String> = if self.event_mode {
             match &event.event_type {
                 EventType::Insert { .. }
                 | EventType::Update { .. }
                 | EventType::Delete { .. }
-                | EventType::Truncate(_) => serde_json::to_string(event)
-                    .map_err(|e| CdcError::generic(format!("Failed to serialize event: {e}")))?,
+                | EventType::Truncate(_) => {
+                    Some(serde_json::to_string(event).map_err(|e| {
+                        CdcError::generic(format!("Failed to serialize event: {e}"))
+                    })?)
+                }
                 _ => return Ok(()),
             }
         } else {
-            let sql = self.generate_sql_for_event(event)?;
-            if sql.is_empty() {
-                return Ok(());
-            }
-            sql
+            None
         };
 
         let mut transactions = self.active_transactions.lock().await;
@@ -565,6 +620,20 @@ impl TransactionManager {
                 tx_id
             ))
         })?;
+
+        // Resolve the line to append as a `&str`, shared by both paths below.
+        // SQL mode renders into the reusable per-transaction buffer; event mode
+        // borrows the owned JSON String computed above.
+        let line: &str = if let Some(ref json) = event_line {
+            json.as_str()
+        } else {
+            let ctx = self.render_ctx();
+            crate::sql_renderer::render_sql_for_event_into(&ctx, event, &mut tx_state.render_buf)?;
+            if tx_state.render_buf.is_empty() {
+                return Ok(());
+            }
+            tx_state.render_buf.as_str()
+        };
 
         let line_bytes = line.len() + 1; // include newline
         let estimated_size =
@@ -604,12 +673,29 @@ impl TransactionManager {
             );
         }
 
-        let should_flush = tx_state.writer.append(&line);
+        // Count statements EXACTLY as the consumer will read them back, computed
+        // in-memory from the already-rendered `line` (no file re-read — that would
+        // undo the Fix 1.1 perf win). The producer-tracked count is authoritative
+        // for `TransactionSegment.statement_count`, which drives crash-resume
+        // segment-skip arithmetic measured in parser-statement units. A single
+        // event-line can render MULTIPLE `;`-terminated statements (e.g. a
+        // multi-table TRUNCATE), so a naive +1 would under-count and cause the
+        // consumer to re-execute already-applied statements after a mid-tx crash.
+        let stmt_count = if self.event_mode {
+            // Event mode mirrors `write_raw_lines_from_file`: one non-empty
+            // physical line == one event (normally exactly 1).
+            line.split('\n').filter(|l| !l.trim().is_empty()).count()
+        } else {
+            // SQL mode mirrors `write_transaction_from_file` / the consumer's
+            // `SqlStreamParser` read path.
+            Self::count_rendered_statements(line)?
+        };
+        let should_flush = tx_state.writer.append(line);
         if let Some(count) = tx_state
             .segment_statement_counts
             .get_mut(tx_state.current_segment_index)
         {
-            *count += 1;
+            *count += stmt_count;
         }
         if should_flush {
             let buffered_bytes = tx_state.writer.buffer_size();
@@ -667,24 +753,20 @@ impl TransactionManager {
         let mut final_segments = Vec::new();
 
         for (idx, segment_path) in segment_paths.iter().enumerate() {
-            let (final_data_path, statement_count) = if self.event_mode {
-                self.storage.write_raw_lines_from_file(segment_path).await?
+            let known_count = segment_counts.get(idx).copied().unwrap_or(0);
+            let final_data_path = if self.event_mode {
+                self.storage
+                    .write_raw_lines_from_file(segment_path, known_count)
+                    .await?
             } else {
                 self.storage
-                    .write_transaction_from_file(segment_path)
+                    .write_transaction_from_file(segment_path, known_count)
                     .await?
-            };
-
-            let fallback_count = segment_counts.get(idx).copied().unwrap_or(0);
-            let final_count = if statement_count == 0 {
-                fallback_count
-            } else {
-                statement_count
             };
 
             final_segments.push(TransactionSegment {
                 path: final_data_path,
-                statement_count: final_count,
+                statement_count: known_count,
             });
         }
 
@@ -745,14 +827,23 @@ impl TransactionManager {
     /// If a pending metadata file already exists with `last_executed_command_index` set
     /// (indicating a previous run already applied this transaction to the destination),
     /// the existing file is preserved to prevent duplicate re-execution on recovery.
-    pub async fn commit_transaction(&self, tx_id: u32, commit_lsn: Option<Lsn>) -> Result<PathBuf> {
+    pub async fn commit_transaction(
+        &self,
+        tx_id: u32,
+        commit_lsn: Option<Lsn>,
+    ) -> Result<(PathBuf, TransactionFileMetadata)> {
         let received_metadata_path = self.get_received_tx_path(tx_id);
         let pending_metadata_path = self.get_pending_tx_path(tx_id);
+
+        // Whether this tx was already counted in pending_tx_count (its pending file
+        // already exists from a prior commit). Used below to avoid double-incrementing
+        // on a duplicate/recovery commit that overwrites the existing pending file.
+        let already_committed = fs::metadata(&pending_metadata_path).await.is_ok();
 
         // CRASH SAFETY: If pending file already exists with execution progress,
         // a previous run already applied this transaction. Don't overwrite — the
         // consumer's dedup check or recovery finalize will handle it correctly.
-        if fs::metadata(&pending_metadata_path).await.is_ok() {
+        if already_committed {
             if let Ok(existing) = self.read_metadata(&pending_metadata_path).await {
                 if existing.last_executed_command_index.is_some() {
                     info!(
@@ -772,7 +863,7 @@ impl TransactionManager {
                             let _ = fs::remove_file(seg_path).await;
                         }
                     }
-                    return Ok(pending_metadata_path);
+                    return Ok((pending_metadata_path, existing));
                 }
             }
         }
@@ -805,7 +896,14 @@ impl TransactionManager {
             tx_id, commit_lsn
         );
 
-        Ok(pending_metadata_path)
+        // Only count a newly-created pending file. A duplicate/recovery commit that
+        // overwrote an existing pending file (with no execution progress) was already
+        // counted, so re-incrementing would inflate the monitoring counter.
+        if !already_committed {
+            self.pending_tx_count.fetch_add(1, Ordering::Relaxed);
+        }
+
+        Ok((pending_metadata_path, metadata))
     }
 
     /// Delete transaction files (metadata and data) on abort
@@ -1074,6 +1172,7 @@ impl TransactionManager {
                 current_segment_index,
                 current_segment_size_bytes: current_size,
                 writer: BufferedEventWriter::new(current_segment_path, self.buffer_size),
+                render_buf: String::new(),
             },
         );
 
@@ -1118,11 +1217,6 @@ impl TransactionManager {
             dialect: self.dialect,
             schema_mappings: &self.schema_mappings,
         }
-    }
-
-    /// Generate SQL command for a change event
-    fn generate_sql_for_event(&self, event: &ChangeEvent) -> Result<String> {
-        crate::sql_renderer::generate_sql_for_event(&self.render_ctx(), event)
     }
 
     /// Generate TRUNCATE SQL command
@@ -1502,6 +1596,9 @@ impl TransactionManager {
                 if let Err(e) = self.delete_pending_transaction(&pending_tx.file_path).await {
                     warn!("Failed to delete duplicate pending file: {}", e);
                 }
+                // Keep the monitoring counter accurate in real-time: this counted
+                // pending tx is being removed without going through finalize.
+                self.decrement_pending_count();
                 return Ok(());
             }
         }
@@ -1972,8 +2069,12 @@ impl TransactionManager {
         self.clear_staged_pending_progress(&pending_tx.file_path)
             .await;
 
+        // Decrement to match the increment in `commit_transaction`: any transaction
+        // that reached the committed/pending state was counted, so it must be
+        // uncounted here regardless of `commit_lsn`.
+        let pending_count = self.decrement_pending_count();
+
         if pending_tx.metadata.commit_lsn.is_some() {
-            let pending_count = self.list_pending_transactions().await?.len();
             lsn_tracker.update_consumer_state(
                 tx_id,
                 pending_tx.metadata.commit_timestamp,
@@ -1981,7 +2082,7 @@ impl TransactionManager {
             );
 
             debug!(
-                "Updated LSN tracker consumer state: tx_id={}, pending_count={} (after deletion)",
+                "Updated LSN tracker consumer state: tx_id={}, pending_count={} (in-memory)",
                 tx_id, pending_count
             );
         }
@@ -1994,7 +2095,8 @@ impl TransactionManager {
 mod tests {
     use super::*;
     use bytes::Bytes;
-    use pg_walstream::ColumnValue;
+    use pg_walstream::{ColumnValue, RowData};
+    use std::sync::atomic::{AtomicU32, Ordering};
 
     /// Create a minimal `TransactionManager` for unit-testing `format_value`
     /// and SQL generation helpers without filesystem side-effects.
@@ -2008,6 +2110,139 @@ mod tests {
         TransactionManager::new(&dir, dest, None, 10 * 1024 * 1024)
             .await
             .expect("test manager creation should succeed")
+    }
+
+    /// Build a `TransactionManager` in a unique temp dir for tests that need
+    /// real filesystem transaction lifecycle (begin/append/commit).
+    async fn test_manager_fs() -> (TransactionManager, std::path::PathBuf) {
+        static COUNTER: AtomicU32 = AtomicU32::new(0);
+        let dir = std::env::temp_dir().join(format!(
+            "pg2any_tx_lifecycle_test_{}_{}",
+            std::process::id(),
+            COUNTER.fetch_add(1, Ordering::SeqCst)
+        ));
+        let _ = tokio::fs::create_dir_all(&dir).await;
+        let mgr = TransactionManager::new(&dir, DestinationType::MySQL, None, 10 * 1024 * 1024)
+            .await
+            .expect("test manager creation should succeed");
+        (mgr, dir)
+    }
+
+    /// Begin a normal transaction, append one INSERT event, and flush buffers so
+    /// the transaction is ready to commit.
+    async fn seed_simple_transaction(manager: &TransactionManager, tx_id: u32) {
+        let data = RowData::from_pairs(vec![
+            ("id", ColumnValue::text("1")),
+            ("name", ColumnValue::text("test")),
+        ]);
+        let event = ChangeEvent::insert("public", "test", 12345, data, crate::types::Lsn(1));
+        manager
+            .begin_transaction(tx_id, Utc::now(), "normal")
+            .await
+            .expect("begin_transaction should succeed");
+        manager
+            .append_event(tx_id, &event)
+            .await
+            .expect("append_event should succeed");
+        manager
+            .flush_all_buffers()
+            .await
+            .expect("flush_all_buffers should succeed");
+    }
+
+    #[tokio::test]
+    async fn test_commit_transaction_returns_inmemory_metadata() {
+        let (manager, _tmp) = test_manager_fs().await;
+        let tx_id = 42;
+        seed_simple_transaction(&manager, tx_id).await;
+
+        let (path, metadata) = manager
+            .commit_transaction(tx_id, Some(crate::types::Lsn(100)))
+            .await
+            .unwrap();
+
+        // Returned in-memory metadata must match what was persisted to disk.
+        let on_disk = manager.read_metadata(&path).await.unwrap();
+        assert_eq!(metadata.transaction_id, tx_id);
+        assert_eq!(metadata.transaction_id, on_disk.transaction_id);
+        assert_eq!(metadata.commit_lsn, on_disk.commit_lsn);
+        assert_eq!(metadata.segments.len(), on_disk.segments.len());
+    }
+
+    #[tokio::test]
+    async fn test_pending_counter_tracks_commit_and_finalize() {
+        let (manager, _tmp) = test_manager_fs().await;
+        assert_eq!(manager.pending_count(), 0);
+
+        seed_simple_transaction(&manager, 1).await;
+        manager
+            .commit_transaction(1, Some(crate::types::Lsn(10)))
+            .await
+            .unwrap();
+        assert_eq!(manager.pending_count(), 1, "commit should increment");
+
+        // Counter must equal the authoritative dir-scan count.
+        let scanned = manager.list_pending_transactions().await.unwrap().len();
+        assert_eq!(manager.pending_count(), scanned);
+    }
+
+    /// Regression: producer-tracked `statement_count` must equal what the
+    /// consumer's `SqlStreamParser` reads back. A multi-table TRUNCATE renders
+    /// ONE event-line containing N `;`-terminated statements, so a naive +1
+    /// per event would under-count and corrupt crash-resume skip arithmetic.
+    #[tokio::test]
+    async fn test_statement_count_matches_parser_for_multi_table_truncate() {
+        use crate::storage::SqlStreamParser;
+
+        let (manager, _tmp) = test_manager_fs().await;
+        let tx_id = 7;
+
+        manager
+            .begin_transaction(tx_id, Utc::now(), "normal")
+            .await
+            .unwrap();
+
+        // An ordinary INSERT (1 statement) ...
+        let data = RowData::from_pairs(vec![("id", ColumnValue::text("1"))]);
+        let insert = ChangeEvent::insert("public", "test", 12345, data, crate::types::Lsn(1));
+        manager.append_event(tx_id, &insert).await.unwrap();
+
+        // ... alongside a multi-table TRUNCATE that renders 3 statements in one
+        // event-line.
+        let truncate = ChangeEvent {
+            event_type: EventType::Truncate(vec![
+                std::sync::Arc::from("public.a"),
+                std::sync::Arc::from("public.b"),
+                std::sync::Arc::from("public.c"),
+            ]),
+            lsn: crate::types::Lsn(2),
+            metadata: None,
+        };
+        manager.append_event(tx_id, &truncate).await.unwrap();
+
+        manager.flush_all_buffers().await.unwrap();
+        let (_path, metadata) = manager
+            .commit_transaction(tx_id, Some(crate::types::Lsn(100)))
+            .await
+            .unwrap();
+
+        // Stored metadata count (producer-tracked, authoritative since Fix 1.1).
+        let stored: usize = metadata.segments.iter().map(|s| s.statement_count).sum();
+
+        // Read the data file(s) back exactly as the consumer does and count.
+        let mut parsed = 0usize;
+        for seg in &metadata.segments {
+            let mut p = SqlStreamParser::new();
+            let stmts = p.parse_file_from_index_collect(&seg.path, 0).await.unwrap();
+            parsed += stmts.len();
+        }
+
+        // 1 INSERT + 3 TRUNCATE statements = 4.
+        assert_eq!(parsed, 4, "consumer should read back 4 statements");
+        assert_eq!(
+            stored, parsed,
+            "stored statement_count must match what the consumer parser reads back"
+        );
     }
 
     // ── SQL injection prevention ──────────────────────────────────────

--- a/pg2any-lib/tests/graceful_shutdown_integration_tests.rs
+++ b/pg2any-lib/tests/graceful_shutdown_integration_tests.rs
@@ -109,13 +109,10 @@ async fn setup_pending_transaction_with_events(
 
     manager.flush_all_buffers().await.unwrap();
 
-    let pending_path = manager
+    let (pending_path, metadata) = manager
         .commit_transaction(tx_id, Some(Lsn(commit_lsn)))
         .await
         .unwrap();
-
-    let content = tokio::fs::read_to_string(&pending_path).await.unwrap();
-    let metadata = serde_json::from_str(&content).unwrap();
 
     let pending_tx = PendingTransactionFile {
         file_path: pending_path,
@@ -362,12 +359,10 @@ async fn test_mid_batch_cancellation_completes_drain() {
         let event = create_insert_event(*lsn);
         manager.append_event(*i, &event).await.unwrap();
         manager.flush_all_buffers().await.unwrap();
-        let pending_path = manager
+        let (pending_path, metadata) = manager
             .commit_transaction(*i, Some(Lsn(*lsn)))
             .await
             .unwrap();
-        let content = tokio::fs::read_to_string(&pending_path).await.unwrap();
-        let metadata = serde_json::from_str(&content).unwrap();
         pending_txs.push(PendingTransactionFile {
             file_path: pending_path,
             metadata,
@@ -433,7 +428,7 @@ async fn test_committed_but_undelivered_recovered_on_restart() {
     let event = create_insert_event(55000);
     manager.append_event(42, &event).await.unwrap();
     manager.flush_all_buffers().await.unwrap();
-    let _pending_path = manager
+    let _pending = manager
         .commit_transaction(42, Some(Lsn(55000)))
         .await
         .unwrap();
@@ -558,12 +553,10 @@ async fn test_drain_on_error_preserves_file_for_recovery() {
         let event = create_insert_event(*lsn);
         manager.append_event(*i, &event).await.unwrap();
         manager.flush_all_buffers().await.unwrap();
-        let pending_path = manager
+        let (pending_path, metadata) = manager
             .commit_transaction(*i, Some(Lsn(*lsn)))
             .await
             .unwrap();
-        let content = tokio::fs::read_to_string(&pending_path).await.unwrap();
-        let metadata = serde_json::from_str(&content).unwrap();
         pending_txs.push(PendingTransactionFile {
             file_path: pending_path,
             metadata,


### PR DESCRIPTION
drop redundant data-file re-read when finalizing uncompressed transactions Uncompressed finalize re-read+SQL-parsed the whole segment file only to recount statements the producer already tracked. Pass the known count through TransactionStorage so uncompressed finalize is zero-I/O.

perf: build commit notification from in-memory metadata commit_transaction now returns the metadata it just wrote, so the producer no longer re-reads and JSON-parses the .meta file per commit.

perf: track pending-transaction count in memory Replace the per-transaction pending-dir scan + JSON parse (used only for a monitoring count) with an AtomicUsize seeded at startup and kept in sync on commit/finalize.

perf: count rendered statements without allocating per-statement Strings

Add SqlStreamParser::count_line/finish_count — a count-only walk of the same state machine that tracks non-whitespace bytes instead of buffering. Used by count_rendered_statements (per SQL event), removing the Vec + per-stmt String allocation Phase 1 introduced. Count parity with the read path is tested.

perf: render SQL into a reused per-transaction buffer

Add render_into variants writing into a caller buffer; generate_sql now delegate. append_event reuses ActiveTransactionState.render_buf for SQL-mode events, removing a String allocation per event. Output is byte-identical.

perf: decode MySQL bytea hex literals straight into the TSV buffer

Replace per-cell Vec hex decode + escape with decode_hex_into, which escapes decoded bytes directly into the output buffer. Byte-identical TSV.