### PR TITLE
feat(slot): add slot LSN query + pure reconcile_resume

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ pg2any is a Rust CDC (Change Data Capture) library that streams PostgreSQL WAL c
 - Producer and consumer are separate Tokio tasks communicating via `mpsc` channel
 - Transaction files are the source of truth for crash recovery - never skip file persistence
 - LSN tracking: `flush_lsn` = last WAL position committed to destination. Updated by consumer only.
+- Recovery resume position (`slot.rs::reconcile_resume`, called from `CdcClient::new`): query `pg_replication_slots` first (server-side `confirmed_flush_lsn` is the source of truth for logical replication resume), fall back to the on-disk LSN when the slot is gone. De-dup boundary = `max(confirmed_flush_lsn, disk_flush_lsn)` — seeds `LsnTracker` so `commit_lsn <= boundary` transactions are skipped (preserves the no-replay guarantee). Slot-deleted logs a WARNING: the WAL gap up to the new slot's creation LSN may be unrecoverable. Slot query is a short-lived libpq connection (`pg_walstream::PgReplicationConnection`) in `spawn_blocking` + timeout; query failure falls back to disk.
 - Shutdown coordination: `CancellationToken` + `oneshot` channel (producer -> consumer)
 - Destinations behind `DestinationHandler` trait; Kafka uses event mode, SQL destinations use SQL batch mode
 - Destinations are constructed via the per-Config registry (`Config::create_destination`). Built-ins self-register in `Config::default()`; external users add their own via `ConfigBuilder::custom_destination` (factory closure) or `ConfigBuilder::use_destination::<H>()` (for `H: Default`).

--- a/pg2any-lib/src/client.rs
+++ b/pg2any-lib/src/client.rs
@@ -11,7 +11,7 @@ use pg_walstream::{LogicalReplicationStream, ReplicationStreamConfig};
 use std::sync::Arc;
 use tokio::sync::{mpsc, oneshot, Mutex};
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
 /// Main CDC client for coordinating replication and destination writes.
 ///
@@ -80,8 +80,64 @@ impl CdcClient {
         }
 
         info!("Initializing LSN tracker for position tracking");
-        let (lsn_tracker, start_lsn) =
+        let (lsn_tracker, disk_lsn) =
             crate::lsn_tracker::create_lsn_tracker_with_load(lsn_file_path).await;
+
+        // Slot-first recovery: query pg_replication_slots for the server-side resume position, falling back to the on-disk LSN if the slot is gone or the query fails.
+        let slot_result = crate::slot::query_replication_slot(
+            &config.source_connection_string,
+            &config.replication_slot_name,
+            config.connection_timeout,
+        )
+        .await;
+        let query_err = slot_result.as_ref().err().map(|e| e.to_string());
+
+        let decision = crate::slot::reconcile_resume(
+            disk_lsn.map(|l| l.0),
+            slot_result.as_ref().map(Option::as_ref).map_err(|_| ()),
+        );
+
+        match decision.source {
+            crate::slot::ResumeSource::Slot => info!(
+                "Resuming from replication slot '{}': confirmed_flush={}, dedup_boundary={} (disk={})",
+                config.replication_slot_name,
+                pg_walstream::format_lsn(decision.start_lsn.unwrap_or(0)),
+                pg_walstream::format_lsn(decision.dedup_boundary),
+                disk_lsn
+                    .map(|l| pg_walstream::format_lsn(l.0))
+                    .unwrap_or_else(|| "none".to_string()),
+            ),
+            crate::slot::ResumeSource::SlotDeletedFallback => warn!(
+                "Replication slot '{}' not found; resuming from on-disk LSN {}. If the slot was \
+                 deleted, WAL changes after this LSN up to now may be unrecoverable (a new slot \
+                 will be created at the current WAL position).",
+                config.replication_slot_name,
+                pg_walstream::format_lsn(decision.dedup_boundary),
+            ),
+            crate::slot::ResumeSource::QueryFailedFallback => warn!(
+                "Replication slot '{}' query failed ({}); resuming from on-disk LSN {}. The slot \
+                 likely still exists, so no WAL gap is expected.",
+                config.replication_slot_name,
+                query_err.as_deref().unwrap_or("unknown error"),
+                pg_walstream::format_lsn(decision.dedup_boundary),
+            ),
+            crate::slot::ResumeSource::Fresh => info!(
+                "No replication slot and no on-disk LSN; starting fresh from the current WAL position"
+            ),
+        }
+
+        if matches!(slot_result.as_ref(), Ok(Some(s)) if s.active) {
+            warn!(
+                "Replication slot '{}' is currently active (held by another connection); \
+                 starting replication may fail if a second consumer holds it",
+                config.replication_slot_name
+            );
+        }
+
+        // Seed the de-dup boundary (monotonic raise). shared_lsn_feedback is seeded from lsn_tracker.get() later in start_file_based_workflow.
+        lsn_tracker.commit_lsn(decision.dedup_boundary);
+
+        let start_lsn = decision.start_lsn.map(Lsn::new);
 
         info!("Creating replication stream");
         let stream_config = ReplicationStreamConfig::from(&config);

--- a/pg2any-lib/src/config.rs
+++ b/pg2any-lib/src/config.rs
@@ -632,9 +632,7 @@ impl ConfigBuilder {
             ));
         }
 
-        if self.config.replication_slot_name.is_empty() {
-            return Err(CdcError::config("Replication slot name is required"));
-        }
+        crate::slot::validate_slot_name(&self.config.replication_slot_name)?;
 
         if self.config.publication_name.is_empty() {
             return Err(CdcError::config("Publication name is required"));

--- a/pg2any-lib/src/lib.rs
+++ b/pg2any-lib/src/lib.rs
@@ -66,6 +66,9 @@ pub mod types;
 
 pub mod lsn_tracker;
 
+// Slot-first LSN recovery (queries pg_replication_slots, reconciles with disk)
+pub(crate) mod slot;
+
 // High-level client interface
 pub mod client;
 mod consumer;

--- a/pg2any-lib/src/slot.rs
+++ b/pg2any-lib/src/slot.rs
@@ -1,0 +1,493 @@
+//! Slot-first LSN recovery.
+//!
+//! On startup we query `pg_replication_slots` for the slot's server-side
+//! position (`confirmed_flush_lsn`) and reconcile it with the on-disk LSN.
+//! For logical replication PostgreSQL resumes from `confirmed_flush_lsn`
+//! regardless of the `start_lsn` hint, so the **de-dup boundary** — the LSN at
+//! or below which committed transactions are skipped — is the real correctness
+//! lever. We set it to `max(confirmed_flush_lsn, disk)`.
+
+use crate::error::{CdcError, Result};
+use pg_walstream::{parse_lsn, PgReplicationConnection};
+use std::time::Duration;
+use tracing::debug;
+
+/// LSN positions read from a row of `pg_replication_slots`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SlotStatus {
+    /// `confirmed_flush_lsn`: where logical decoding resumes. `None` if NULL.
+    pub(crate) confirmed_flush_lsn: Option<u64>,
+    /// `restart_lsn`: physical WAL retention floor. Diagnostic only. `None` if NULL.
+    pub(crate) restart_lsn: Option<u64>,
+    /// `active`: whether another connection currently holds the slot.
+    pub(crate) active: bool,
+}
+
+/// Where the resume position came from (for logging).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ResumeSource {
+    /// Slot found; resumed from its `confirmed_flush_lsn`.
+    Slot,
+    /// Slot not found but an on-disk LSN exists; resumed from disk (possible gap).
+    SlotDeletedFallback,
+    /// Slot query failed (transient) but an on-disk LSN exists; resumed from disk (safe: slot likely still exists).
+    QueryFailedFallback,
+    /// No slot and no on-disk LSN; fresh start from the current WAL position.
+    Fresh,
+}
+
+/// The reconciled resume decision.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ResumeDecision {
+    /// `START_REPLICATION` start hint. `Some` only when read from a live slot
+    /// (its `confirmed_flush_lsn`); `None` otherwise (→ `0/0`, let PG decide).
+    /// For logical replication PG resumes from `confirmed_flush_lsn` server-side
+    /// regardless, so this is a hint only — `dedup_boundary` is the real lever.
+    pub(crate) start_lsn: Option<u64>,
+    /// Skip committed transactions with `commit_lsn <= dedup_boundary`.
+    pub(crate) dedup_boundary: u64,
+    pub(crate) source: ResumeSource,
+}
+
+/// Reconcile the on-disk LSN with the slot's LSNs. Pure — no I/O.
+///
+/// `start_lsn` is only ever `Some` when read from a live slot; every fallback
+/// leaves it `None` (→ `0/0`) so PG picks the position itself. `dedup_boundary`
+/// is what actually guarantees no replay.
+///
+/// - Slot present: `start_lsn = confirmed_flush_lsn`; boundary = `max(disk, confirmed)`.
+/// - Slot absent (`Ok(None)`), disk present: boundary = disk (slot-deleted fallback, possible gap).
+/// - Query failed (`Err`), disk present: boundary = disk (safe fallback, slot likely still exists).
+/// - Both absent: fresh start.
+pub(crate) fn reconcile_resume(
+    disk: Option<u64>,
+    slot: std::result::Result<Option<&SlotStatus>, ()>,
+) -> ResumeDecision {
+    match slot {
+        Ok(Some(s)) => ResumeDecision {
+            start_lsn: s.confirmed_flush_lsn,
+            dedup_boundary: disk.unwrap_or(0).max(s.confirmed_flush_lsn.unwrap_or(0)),
+            source: ResumeSource::Slot,
+        },
+        Ok(None) => match disk {
+            Some(d) => ResumeDecision {
+                start_lsn: None,
+                dedup_boundary: d,
+                source: ResumeSource::SlotDeletedFallback,
+            },
+            None => ResumeDecision {
+                start_lsn: None,
+                dedup_boundary: 0,
+                source: ResumeSource::Fresh,
+            },
+        },
+        Err(()) => match disk {
+            Some(d) => ResumeDecision {
+                start_lsn: None,
+                dedup_boundary: d,
+                source: ResumeSource::QueryFailedFallback,
+            },
+            None => ResumeDecision {
+                start_lsn: None,
+                dedup_boundary: 0,
+                source: ResumeSource::Fresh,
+            },
+        },
+    }
+}
+
+/// Validate a PostgreSQL replication slot name.
+///
+/// PostgreSQL restricts slot names to lower-case letters, digits, and  underscores (`[a-z0-9_]`). Validating against that set is the reusable, injection-proof way to make a slot name safe for SQL interpolation stronger than escaping, which is fragile when `standard_conforming_strings` is off. Call this at every boundary where a slot name enters a query.
+pub(crate) fn validate_slot_name(slot_name: &str) -> Result<()> {
+    if slot_name.is_empty() {
+        return Err(CdcError::config("Replication slot name is required"));
+    }
+    if !slot_name
+        .bytes()
+        .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'_')
+    {
+        return Err(CdcError::config(format!(
+            "Invalid replication slot name {slot_name:?}: only lower-case letters, digits, and underscores are allowed"
+        )));
+    }
+    Ok(())
+}
+
+/// Build the `pg_replication_slots` lookup. The name is validated to `[a-z0-9_]`
+/// by [`validate_slot_name`] before we get here, so interpolation is safe; the
+/// single-quote escape stays as belt-and-suspenders.
+fn build_slot_query(slot_name: &str) -> String {
+    let escaped = slot_name.replace('\'', "''");
+    format!(
+        "SELECT restart_lsn, confirmed_flush_lsn, active \
+         FROM pg_replication_slots WHERE slot_name = '{escaped}'"
+    )
+}
+
+/// Parse an LSN text field from `pg_replication_slots` (e.g. `"16/B374D848"`).
+/// Trims surrounding whitespace; NULL / empty / unparsable ⇒ `None`.
+fn parse_lsn_field(value: Option<String>) -> Option<u64> {
+    let v = value?;
+    let t = v.trim();
+    if t.is_empty() {
+        return None;
+    }
+    parse_lsn(t).ok()
+}
+
+/// Parse the boolean `active` text field. PostgreSQL renders booleans as
+/// `t`/`f`; we also accept `true`/`1`. NULL / anything else ⇒ `false`.
+fn parse_active_field(value: Option<String>) -> bool {
+    value
+        .map(|s| matches!(s.trim(), "t" | "true" | "1"))
+        .unwrap_or(false)
+}
+
+/// Blocking query. Returns `Ok(None)` when the slot does not exist.
+/// The connection and result are dropped (RAII) before returning — no leak.
+fn query_slot_blocking(conninfo: &str, slot_name: &str) -> Result<Option<SlotStatus>> {
+    let mut conn = PgReplicationConnection::connect(conninfo)?;
+    let result = conn.exec(&build_slot_query(slot_name))?;
+
+    if result.ntuples() == 0 {
+        return Ok(None);
+    }
+
+    Ok(Some(SlotStatus {
+        restart_lsn: parse_lsn_field(result.get_value(0, 0)),
+        confirmed_flush_lsn: parse_lsn_field(result.get_value(0, 1)),
+        active: parse_active_field(result.get_value(0, 2)),
+    }))
+}
+
+/// Query `pg_replication_slots` for `slot_name` on a short-lived connection.
+///
+/// Runs the blocking libpq call on a blocking thread, bounded by `timeout`.
+/// `Ok(None)` = slot not found. `Err` = connect/query failed or timed out; the
+/// caller should fall back to the on-disk LSN.
+///
+/// On timeout the blocking thread is left to finish and drop on its own — the
+/// blocking `connect`/`exec` cannot be cancelled mid-call.
+// ponytail: timeout stops us waiting, not the blocking call; acceptable for a one-shot startup probe.
+pub(crate) async fn query_replication_slot(
+    conninfo: &str,
+    slot_name: &str,
+    timeout: Duration,
+) -> Result<Option<SlotStatus>> {
+    validate_slot_name(slot_name)?;
+    let conninfo = conninfo.to_string();
+    let slot_name = slot_name.to_string();
+    debug!("Querying pg_replication_slots for slot '{}'", slot_name);
+
+    let handle = tokio::task::spawn_blocking(move || query_slot_blocking(&conninfo, &slot_name));
+
+    match tokio::time::timeout(timeout, handle).await {
+        Ok(Ok(res)) => res,
+        Ok(Err(join_err)) => Err(CdcError::generic(format!(
+            "replication slot query task failed: {join_err}"
+        ))),
+        Err(_elapsed) => Err(CdcError::connection(format!(
+            "replication slot query timed out after {timeout:?}"
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn slot(confirmed: Option<u64>, restart: Option<u64>, active: bool) -> SlotStatus {
+        SlotStatus {
+            confirmed_flush_lsn: confirmed,
+            restart_lsn: restart,
+            active,
+        }
+    }
+
+    #[test]
+    fn slot_present_disk_behind_boundary_is_slot() {
+        // confirmed > disk (rare crash window): boundary aligns up to slot.
+        let d = reconcile_resume(Some(100), Ok(Some(&slot(Some(500), Some(400), false))));
+        assert_eq!(d.start_lsn, Some(500));
+        assert_eq!(d.dedup_boundary, 500);
+        assert_eq!(d.source, ResumeSource::Slot);
+    }
+
+    #[test]
+    fn slot_present_disk_ahead_boundary_is_disk() {
+        // confirmed < disk (normal steady state): boundary stays at disk.
+        let d = reconcile_resume(Some(900), Ok(Some(&slot(Some(500), Some(400), false))));
+        assert_eq!(d.start_lsn, Some(500));
+        assert_eq!(d.dedup_boundary, 900);
+        assert_eq!(d.source, ResumeSource::Slot);
+    }
+
+    #[test]
+    fn slot_present_disk_equal() {
+        let d = reconcile_resume(Some(500), Ok(Some(&slot(Some(500), Some(400), false))));
+        assert_eq!(d.dedup_boundary, 500);
+        assert_eq!(d.source, ResumeSource::Slot);
+    }
+
+    #[test]
+    fn slot_present_disk_missing() {
+        let d = reconcile_resume(None, Ok(Some(&slot(Some(500), Some(400), false))));
+        assert_eq!(d.start_lsn, Some(500));
+        assert_eq!(d.dedup_boundary, 500);
+        assert_eq!(d.source, ResumeSource::Slot);
+    }
+
+    #[test]
+    fn slot_present_confirmed_null() {
+        // confirmed_flush NULL -> start_lsn None; boundary falls back to disk.
+        let d = reconcile_resume(Some(700), Ok(Some(&slot(None, Some(400), false))));
+        assert_eq!(d.start_lsn, None);
+        assert_eq!(d.dedup_boundary, 700);
+        assert_eq!(d.source, ResumeSource::Slot);
+    }
+
+    #[test]
+    fn slot_present_confirmed_null_disk_missing() {
+        // confirmed NULL and no disk -> boundary 0, start hint None (PG picks position).
+        let d = reconcile_resume(None, Ok(Some(&slot(None, None, false))));
+        assert_eq!(d.start_lsn, None);
+        assert_eq!(d.dedup_boundary, 0);
+        assert_eq!(d.source, ResumeSource::Slot);
+    }
+
+    #[test]
+    fn slot_absent_disk_present_is_fallback() {
+        // start_lsn None: a recreated slot starts at the current WAL position,
+        // so we don't hand PG the stale on-disk LSN; boundary stays at disk.
+        let d = reconcile_resume(Some(700), Ok(None));
+        assert_eq!(d.start_lsn, None);
+        assert_eq!(d.dedup_boundary, 700);
+        assert_eq!(d.source, ResumeSource::SlotDeletedFallback);
+    }
+
+    #[test]
+    fn query_failed_disk_present_is_fallback() {
+        // Transient query failure with an on-disk LSN: safe fallback, NOT a slot-deleted gap.
+        let d = reconcile_resume(Some(700), Err(()));
+        assert_eq!(d.start_lsn, None);
+        assert_eq!(d.dedup_boundary, 700);
+        assert_eq!(d.source, ResumeSource::QueryFailedFallback);
+    }
+
+    #[test]
+    fn query_failed_disk_missing_is_fresh() {
+        // Query failure with nothing on disk: nowhere to resume from -> fresh.
+        let d = reconcile_resume(None, Err(()));
+        assert_eq!(d.start_lsn, None);
+        assert_eq!(d.dedup_boundary, 0);
+        assert_eq!(d.source, ResumeSource::Fresh);
+    }
+
+    #[test]
+    fn both_absent_is_fresh() {
+        let d = reconcile_resume(None, Ok(None));
+        assert_eq!(d.start_lsn, None);
+        assert_eq!(d.dedup_boundary, 0);
+        assert_eq!(d.source, ResumeSource::Fresh);
+    }
+
+    #[test]
+    fn lsn_text_parses_like_postgres() {
+        // Sanity: the pg_lsn text format we will read from the slot.
+        assert_eq!(pg_walstream::parse_lsn("0/0").unwrap(), 0);
+        assert_eq!(
+            pg_walstream::parse_lsn("16/B374D848").unwrap(),
+            0x16B374D848
+        );
+        assert!(pg_walstream::parse_lsn("not-an-lsn").is_err());
+    }
+
+    #[test]
+    fn validate_slot_name_accepts_legal_names() {
+        assert!(validate_slot_name("pg2any_slot").is_ok());
+        assert!(validate_slot_name("slot_123").is_ok());
+        assert!(validate_slot_name("a").is_ok());
+    }
+
+    #[test]
+    fn validate_slot_name_rejects_illegal_names() {
+        // Empty, injection payload, and every out-of-charset class must be rejected
+        // BEFORE the name ever reaches SQL interpolation.
+        assert!(validate_slot_name("").is_err()); // empty
+        assert!(validate_slot_name("a'b").is_err()); // single quote (injection)
+        assert!(validate_slot_name("slot; DROP TABLE t").is_err()); // classic payload
+        assert!(validate_slot_name("MySlot").is_err()); // uppercase
+        assert!(validate_slot_name("my-slot").is_err()); // hyphen
+        assert!(validate_slot_name("my slot").is_err()); // space
+        assert!(validate_slot_name("slot\\").is_err()); // backslash (SCS-off vector)
+    }
+
+    #[test]
+    fn build_query_contains_slot_and_columns() {
+        let sql = build_slot_query("pg2any_slot");
+        assert!(sql.contains("pg_replication_slots"));
+        assert!(sql.contains("restart_lsn"));
+        assert!(sql.contains("confirmed_flush_lsn"));
+        assert!(sql.contains("slot_name = 'pg2any_slot'"));
+    }
+
+    #[test]
+    fn build_query_escapes_single_quote() {
+        // Defensive: PG slot names are [a-z0-9_], but never interpolate raw.
+        let sql = build_slot_query("a'b");
+        assert!(sql.contains("slot_name = 'a''b'"));
+    }
+
+    #[test]
+    fn parse_lsn_field_valid_values() {
+        assert_eq!(parse_lsn_field(Some("0/0".to_string())), Some(0));
+        assert_eq!(
+            parse_lsn_field(Some("16/B374D848".to_string())),
+            Some(0x16B374D848)
+        );
+        // Surrounding whitespace is trimmed.
+        assert_eq!(
+            parse_lsn_field(Some("  16/B374D848  ".to_string())),
+            Some(0x16B374D848)
+        );
+    }
+
+    #[test]
+    fn parse_lsn_field_null_empty_invalid_are_none() {
+        assert_eq!(parse_lsn_field(None), None); // NULL column
+        assert_eq!(parse_lsn_field(Some(String::new())), None); // empty
+        assert_eq!(parse_lsn_field(Some("   ".to_string())), None); // whitespace only
+        assert_eq!(parse_lsn_field(Some("garbage".to_string())), None); // no slash
+        assert_eq!(parse_lsn_field(Some("16".to_string())), None); // missing '/'
+        assert_eq!(parse_lsn_field(Some("zz/zz".to_string())), None); // bad hex
+    }
+
+    #[test]
+    fn parse_active_field_true_values() {
+        assert!(parse_active_field(Some("t".to_string())));
+        assert!(parse_active_field(Some("true".to_string())));
+        assert!(parse_active_field(Some("1".to_string())));
+        assert!(parse_active_field(Some("  t  ".to_string()))); // trimmed
+    }
+
+    #[test]
+    fn parse_active_field_false_values() {
+        assert!(!parse_active_field(Some("f".to_string())));
+        assert!(!parse_active_field(Some("false".to_string())));
+        assert!(!parse_active_field(Some("0".to_string())));
+        assert!(!parse_active_field(Some("yes".to_string()))); // not a recognized truthy token
+        assert!(!parse_active_field(None)); // NULL column
+        assert!(!parse_active_field(Some(String::new())));
+    }
+
+    #[tokio::test]
+    async fn query_replication_slot_rejects_invalid_name() {
+        // An illegal slot name must be rejected up front — before any connection
+        // and before it can reach SQL interpolation. Uses an unroutable host to
+        // prove we never even attempt to connect.
+        let dsn = "host=192.0.2.1 port=5432 dbname=postgres user=postgres";
+        let res = query_replication_slot(dsn, "bad'; DROP", Duration::from_secs(5)).await;
+        assert!(
+            res.is_err(),
+            "invalid slot name must be rejected, got {res:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn query_replication_slot_connect_failure_is_err() {
+        // Nothing listening on port 1 ⇒ connect refused fast ⇒ Err.
+        // This is the path that makes the caller fall back to the on-disk LSN;
+        // it must return Err rather than panic or hang.
+        let dsn = "host=127.0.0.1 port=1 dbname=postgres user=postgres connect_timeout=1";
+        let res = query_replication_slot(dsn, "any_slot", Duration::from_secs(5)).await;
+        assert!(
+            res.is_err(),
+            "connect failure should map to Err (fallback trigger), got {res:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn query_replication_slot_unreachable_host_is_err() {
+        let dsn = "host=192.0.2.1 port=5432 dbname=postgres user=postgres";
+        let res = query_replication_slot(dsn, "any_slot", Duration::from_millis(200)).await;
+        assert!(
+            res.is_err(),
+            "unreachable host should map to Err (fallback trigger), got {res:?}"
+        );
+    }
+
+    // Live-Postgres roundtrip. Gated on `PG2ANY_TEST_SOURCE_DSN` (a
+    // `replication=database` DSN); returns early (passes) when unset so the
+    // suite stays green without a database. Kept in-crate so `slot` can remain
+    // `pub(crate)` rather than exposing internals as public API just for a test.
+    const IT_SLOT: &str = "pg2any_it_slot_lsn_recovery";
+
+    #[tokio::test]
+    async fn query_replication_slot_roundtrip_live() {
+        let Ok(dsn) = std::env::var("PG2ANY_TEST_SOURCE_DSN") else {
+            eprintln!("PG2ANY_TEST_SOURCE_DSN not set; skipping live slot roundtrip test");
+            return;
+        };
+
+        // Setup: drop any leftover, then create a fresh logical slot.
+        let d = dsn.clone();
+        tokio::task::spawn_blocking(move || {
+            if let Ok(mut c) = PgReplicationConnection::connect(&d) {
+                let _ = c.exec(&format!("SELECT pg_drop_replication_slot('{IT_SLOT}')"));
+            }
+            let mut c = PgReplicationConnection::connect(&d).expect("connect for setup");
+            c.exec(&format!(
+                "SELECT pg_create_logical_replication_slot('{IT_SLOT}', 'pgoutput')"
+            ))
+            .expect("create logical slot");
+        })
+        .await
+        .expect("setup task");
+
+        // Slot exists: query returns Some, and all three columns map correctly.
+        let status = query_replication_slot(&dsn, IT_SLOT, Duration::from_secs(10))
+            .await
+            .expect("query should succeed")
+            .expect("slot should be found");
+        assert!(
+            status.confirmed_flush_lsn.is_some(),
+            "confirmed_flush_lsn should be present for a fresh logical slot"
+        );
+        // Guard the column-index mapping of the other two columns: a fresh
+        // pgoutput slot has a non-null restart_lsn and, since no one is
+        // streaming it, is not active. (If restart_lsn/confirmed_flush_lsn were
+        // swapped, is_some() alone would not catch it.)
+        assert!(
+            status.restart_lsn.is_some(),
+            "restart_lsn should be present for a fresh logical slot"
+        );
+        assert!(
+            !status.active,
+            "a freshly created, unstreamed slot should not be active"
+        );
+
+        // reconcile: with the slot present, we resume from the slot.
+        let decision = reconcile_resume(Some(1), Ok(Some(&status)));
+        assert_eq!(decision.source, ResumeSource::Slot);
+        assert_eq!(
+            decision.dedup_boundary,
+            status.confirmed_flush_lsn.unwrap().max(1)
+        );
+
+        // Teardown, then assert the slot-not-found path returns Ok(None).
+        let d = dsn.clone();
+        tokio::task::spawn_blocking(move || {
+            let mut c = PgReplicationConnection::connect(&d).expect("connect for teardown");
+            c.exec(&format!("SELECT pg_drop_replication_slot('{IT_SLOT}')"))
+                .expect("drop slot");
+        })
+        .await
+        .expect("teardown task");
+
+        let gone = query_replication_slot(&dsn, IT_SLOT, Duration::from_secs(10))
+            .await
+            .expect("query should succeed");
+        assert!(gone.is_none(), "slot should be gone after drop");
+    }
+}

--- a/pg2any-lib/tests/graceful_shutdown_integration_tests.rs
+++ b/pg2any-lib/tests/graceful_shutdown_integration_tests.rs
@@ -599,3 +599,377 @@ async fn test_drain_on_error_preserves_file_for_recovery() {
     assert_eq!(loaded_lsn, Some(Lsn(40000)));
     assert!(50000 > tracker_restart.get());
 }
+
+/// Handler that records the exact SQL commands it executes and cancels a shared
+/// token after `cancel_after_batches` batches — simulating SIGTERM arriving
+/// mid-transaction. Runs the pre-commit hook (like a real destination) so the
+/// resume checkpoint (`last_executed_command_index`) is staged and flushed.
+struct CancellingRecorder {
+    executed: Arc<std::sync::Mutex<Vec<String>>>,
+    token: CancellationToken,
+    cancel_after_batches: usize,
+    batch_counter: usize,
+}
+
+#[async_trait]
+impl DestinationHandler for CancellingRecorder {
+    async fn connect(&mut self, _connection_string: &str) -> Result<()> {
+        Ok(())
+    }
+
+    fn set_schema_mappings(&mut self, _mappings: HashMap<String, String>) {}
+
+    async fn execute_sql_batch_with_hook(
+        &mut self,
+        commands: &[String],
+        pre_commit_hook: Option<PreCommitHook>,
+    ) -> Result<()> {
+        // Record what actually got applied, in order.
+        {
+            let mut log = self.executed.lock().unwrap();
+            log.extend(commands.iter().cloned());
+        }
+
+        // Stage + (via the manager) flush the resume checkpoint, exactly as a
+        // real destination does. Must happen for THIS batch before we cancel,
+        // so the next-batch cancellation check resumes from the right index.
+        if let Some(hook) = pre_commit_hook {
+            hook().await?;
+        }
+
+        self.batch_counter += 1;
+        if self.batch_counter == self.cancel_after_batches {
+            self.token.cancel();
+        }
+        Ok(())
+    }
+
+    async fn close(&mut self) -> Result<()> {
+        Ok(())
+    }
+}
+
+fn create_distinct_insert_event(id: usize, lsn: u64) -> ChangeEvent {
+    let data = RowData::from_pairs(vec![
+        ("id", ColumnValue::text(&id.to_string())),
+        ("name", ColumnValue::text(&format!("row-{id}"))),
+    ]);
+    ChangeEvent::insert("public", "test", 12345, data, Lsn::from(lsn))
+}
+
+/// Finding 1 verification: a large transaction that is cancelled mid-processing
+/// (SIGTERM) and then resumed (drain/restart) must apply every statement
+/// EXACTLY ONCE — no replay (duplicate key) and no loss.
+///
+/// This exercises the full producer-count -> consumer-skip path end to end with
+/// DISTINCT statements, so a mismatch between the producer's tracked
+/// `segment_statement_count` and the consumer's `SqlStreamParser` read count
+/// (the crash-resume skip arithmetic) surfaces as a duplicated or missing
+/// statement. The pre-existing resume tests use identical events and only count
+/// batches, so they cannot catch this class of position-tracking bug.
+#[tokio::test]
+async fn test_cancel_and_resume_applies_each_statement_exactly_once() {
+    const N: usize = 12;
+    const COMMIT_LSN: u64 = 123_000;
+
+    let temp_dir = TempDir::new().unwrap();
+    let lsn_file = temp_dir.path().join("test_lsn_exactly_once");
+    let lsn_path = lsn_file.to_str().unwrap();
+
+    // Small segment size forces the producer to rotate across MULTIPLE segments,
+    // exercising both whole-segment skip and within-segment index skip on resume.
+    let manager = Arc::new(
+        TransactionManager::new(temp_dir.path(), DestinationType::MySQL, None, 160)
+            .await
+            .unwrap(),
+    );
+
+    manager
+        .begin_transaction(700, Utc::now(), "normal")
+        .await
+        .unwrap();
+    for id in 0..N {
+        manager
+            .append_event(700, &create_distinct_insert_event(id, COMMIT_LSN))
+            .await
+            .unwrap();
+    }
+    manager.flush_all_buffers().await.unwrap();
+    let (pending_path, metadata) = manager
+        .commit_transaction(700, Some(Lsn(COMMIT_LSN)))
+        .await
+        .unwrap();
+    // Sanity: the transaction really did span more than one segment.
+    assert!(
+        metadata.segments.len() > 1,
+        "test needs a multi-segment transaction, got {} segment(s)",
+        metadata.segments.len()
+    );
+    let pending_tx = PendingTransactionFile {
+        file_path: pending_path,
+        metadata,
+    };
+
+    let executed: Arc<std::sync::Mutex<Vec<String>>> = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let metrics = Arc::new(pg2any_lib::MetricsCollector::new());
+    let shared_feedback = SharedLsnFeedback::new_shared();
+    let lsn_tracker = LsnTracker::new(Some(lsn_path)).await;
+    let batch_size = 3;
+
+    // --- Run 1: process, but cancel after 2 batches (SIGTERM mid-transaction) ---
+    let token = CancellationToken::new();
+    let mut dest: Box<dyn DestinationHandler> = Box::new(CancellingRecorder {
+        executed: executed.clone(),
+        token: token.clone(),
+        cancel_after_batches: 2,
+        batch_counter: 0,
+    });
+
+    let result = manager
+        .clone()
+        .process_transaction_file(
+            &pending_tx,
+            &mut dest,
+            &token,
+            &lsn_tracker,
+            &metrics,
+            batch_size,
+            &shared_feedback,
+        )
+        .await;
+    assert!(
+        result.is_err() && result.unwrap_err().is_cancelled(),
+        "run 1 must stop with a cancellation error"
+    );
+    // LSN must NOT advance for a partially-applied transaction.
+    assert_eq!(lsn_tracker.get(), 0, "flush_lsn must not advance mid-tx");
+
+    // --- Run 2: drain/restart with a fresh, uncancelled token ---
+    let drain_token = CancellationToken::new();
+    let mut dest2: Box<dyn DestinationHandler> = Box::new(CancellingRecorder {
+        executed: executed.clone(),
+        token: drain_token.clone(),
+        cancel_after_batches: usize::MAX, // never cancel
+        batch_counter: 0,
+    });
+    manager
+        .clone()
+        .process_transaction_file(
+            &pending_tx,
+            &mut dest2,
+            &drain_token,
+            &lsn_tracker,
+            &metrics,
+            batch_size,
+            &shared_feedback,
+        )
+        .await
+        .expect("run 2 (drain) must complete");
+
+    // Transaction fully applied -> flush_lsn advances, file removed.
+    assert_eq!(lsn_tracker.get(), COMMIT_LSN);
+    assert!(manager
+        .list_pending_transactions()
+        .await
+        .unwrap()
+        .is_empty());
+
+    // The core assertion: every distinct statement applied EXACTLY ONCE, in order.
+    let applied = executed.lock().unwrap().clone();
+    assert_eq!(
+        applied.len(),
+        N,
+        "expected {N} statements applied exactly once, got {} (replay or loss): {applied:#?}",
+        applied.len()
+    );
+    for (id, stmt) in applied.iter().enumerate() {
+        assert!(
+            stmt.contains(&format!("row-{id}")),
+            "statement {id} out of order / replayed / lost: {stmt:?}"
+        );
+    }
+}
+
+/// Build a transaction whose events include a multi-table TRUNCATE (one event
+/// that renders to MULTIPLE `;`-statements). Returns the committed pending file.
+async fn build_mixed_tx(
+    temp_dir: &TempDir,
+    tx_id: u32,
+    commit_lsn: u64,
+) -> (Arc<TransactionManager>, PendingTransactionFile) {
+    let manager = Arc::new(
+        TransactionManager::new(temp_dir.path(), DestinationType::MySQL, None, 160)
+            .await
+            .unwrap(),
+    );
+    manager
+        .begin_transaction(tx_id, Utc::now(), "normal")
+        .await
+        .unwrap();
+
+    // 5 distinct inserts, then a 3-table TRUNCATE (renders to 3 statements in a
+    // single appended event), then 6 more distinct inserts.
+    for id in 0..5 {
+        manager
+            .append_event(tx_id, &create_distinct_insert_event(id, commit_lsn))
+            .await
+            .unwrap();
+    }
+    let tables: Vec<std::sync::Arc<str>> = vec![
+        std::sync::Arc::from("public.ta"),
+        std::sync::Arc::from("public.tb"),
+        std::sync::Arc::from("public.tc"),
+    ];
+    manager
+        .append_event(tx_id, &ChangeEvent::truncate(tables, Lsn::from(commit_lsn)))
+        .await
+        .unwrap();
+    for id in 5..11 {
+        manager
+            .append_event(tx_id, &create_distinct_insert_event(id, commit_lsn))
+            .await
+            .unwrap();
+    }
+
+    manager.flush_all_buffers().await.unwrap();
+    let (pending_path, metadata) = manager
+        .commit_transaction(tx_id, Some(Lsn(commit_lsn)))
+        .await
+        .unwrap();
+    (
+        manager,
+        PendingTransactionFile {
+            file_path: pending_path,
+            metadata,
+        },
+    )
+}
+
+async fn process_recording(
+    manager: &Arc<TransactionManager>,
+    pending_tx: &PendingTransactionFile,
+    lsn_path: &str,
+    cancel_after_batches: usize,
+    batch_size: usize,
+) -> (Vec<String>, u64) {
+    let executed: Arc<std::sync::Mutex<Vec<String>>> = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let metrics = Arc::new(pg2any_lib::MetricsCollector::new());
+    let shared_feedback = SharedLsnFeedback::new_shared();
+    let lsn_tracker = LsnTracker::new(Some(lsn_path)).await;
+    let token = CancellationToken::new();
+    let mut dest: Box<dyn DestinationHandler> = Box::new(CancellingRecorder {
+        executed: executed.clone(),
+        token: token.clone(),
+        cancel_after_batches,
+        batch_counter: 0,
+    });
+
+    // Loop process -> resume, mirroring drain: a cancellation re-runs with a
+    // fresh uncancelled token until the transaction is fully applied.
+    let mut cancelled = true;
+    let mut first = true;
+    while cancelled {
+        let tok = if first {
+            token.clone()
+        } else {
+            CancellationToken::new()
+        };
+        first = false;
+        match manager
+            .clone()
+            .process_transaction_file(
+                pending_tx,
+                &mut dest,
+                &tok,
+                &lsn_tracker,
+                &metrics,
+                batch_size,
+                &shared_feedback,
+            )
+            .await
+        {
+            Ok(()) => cancelled = false,
+            Err(e) if e.is_cancelled() => {
+                // swap in a non-cancelling recorder for the drain pass
+                dest = Box::new(CancellingRecorder {
+                    executed: executed.clone(),
+                    token: CancellationToken::new(),
+                    cancel_after_batches: usize::MAX,
+                    batch_counter: 0,
+                });
+            }
+            Err(e) => panic!("unexpected error: {e}"),
+        }
+    }
+
+    let applied = executed.lock().unwrap().clone();
+    (applied, lsn_tracker.get())
+}
+
+/// Finding 1 (multi-statement event): a transaction containing a multi-table
+/// TRUNCATE — one event that renders to several `;`-statements — must, after a
+/// mid-transaction cancel + resume, apply the EXACT same statements as a clean
+/// uninterrupted pass. If the producer's `count_rendered_statements` (which must
+/// count the TRUNCATE as 3, not 1) disagrees with the consumer's parser, the
+/// resume-skip lands on the wrong statement and this oracle comparison fails.
+#[tokio::test]
+async fn test_cancel_resume_with_multi_statement_truncate_matches_clean_pass() {
+    const COMMIT_LSN: u64 = 456_000;
+    let batch_size = 3;
+
+    // Oracle: one clean, uninterrupted pass.
+    let baseline_dir = TempDir::new().unwrap();
+    let (mgr_a, tx_a) = build_mixed_tx(&baseline_dir, 800, COMMIT_LSN).await;
+    assert!(
+        tx_a.metadata.segments.len() > 1,
+        "need a multi-segment tx to exercise segment skip"
+    );
+    let baseline_lsn = baseline_dir.path().join("lsn_a");
+    let (baseline, lsn_a) = process_recording(
+        &mgr_a,
+        &tx_a,
+        baseline_lsn.to_str().unwrap(),
+        usize::MAX, // never cancel
+        batch_size,
+    )
+    .await;
+    assert_eq!(lsn_a, COMMIT_LSN);
+    // Producer-tracked statement count must equal what a clean pass executes.
+    let producer_total: usize = tx_a
+        .metadata
+        .segments
+        .iter()
+        .map(|s| s.statement_count)
+        .sum();
+    assert_eq!(
+        baseline.len(),
+        producer_total,
+        "producer segment_statement_count sum ({producer_total}) != statements a clean pass executes ({})",
+        baseline.len()
+    );
+    // The TRUNCATE contributed 3 statements (not 1).
+    assert_eq!(baseline.len(), 5 + 3 + 6);
+
+    // Actual: cancel mid-transaction, then resume to completion.
+    for cancel_after in [1usize, 2, 3] {
+        let dir = TempDir::new().unwrap();
+        let (mgr_b, tx_b) = build_mixed_tx(&dir, 801, COMMIT_LSN).await;
+        let lsn_b = dir.path().join("lsn_b");
+        let (actual, lsn) = process_recording(
+            &mgr_b,
+            &tx_b,
+            lsn_b.to_str().unwrap(),
+            cancel_after,
+            batch_size,
+        )
+        .await;
+        assert_eq!(
+            lsn, COMMIT_LSN,
+            "flush_lsn must reach commit_lsn after drain"
+        );
+        assert_eq!(
+            actual, baseline,
+            "cancel_after={cancel_after}: resume applied a different statement sequence than a clean pass (replay/loss/misorder)"
+        );
+    }
+}

--- a/tests/chaos/scripts/run_pgbench_chaos_test.sh
+++ b/tests/chaos/scripts/run_pgbench_chaos_test.sh
@@ -367,7 +367,9 @@ main() {
                 if [ $stall_count -ge 3 ]; then
                     log_error "Replication stalled at $current_count rows for 3 consecutive retries — CDC likely dead or stuck"
                     log_error "Attempting container restart to recover..."
-                    docker restart "$CONTAINER_NAME" 2>/dev/null || true
+                    # Graceful stop (matches chaos_script.sh): `docker restart` ses its own default 10s timeout and IGNORES the compose  stop_grace_period, which would SIGKILL a large-transaction drain mid-flight and cause replay on restart.
+                    docker stop --time 120 "$CONTAINER_NAME" 2>/dev/null || true
+                    docker start "$CONTAINER_NAME" 2>/dev/null || true
                     sleep 30
                     stall_count=0
                 fi


### PR DESCRIPTION
New slot.rs module: reconcile_resume (pure, exhaustively unit-tested truth table) and query_replication_slot (short-lived libpq connection via pg_walstream, spawn_blocking + timeout, leak-safe). De-dup boundary = max(confirmed_flush_lsn, disk).

CdcClient::new now queries pg_replication_slots first and reconciles with the on-disk LSN; seeds the de-dup boundary to max(confirmed_flush_lsn, disk). Slot-deleted logs a WARNING about the potential unrecoverable WAL gap.